### PR TITLE
Idempotent Repository bean factory

### DIFF
--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
@@ -5,6 +5,7 @@ import org.apache.camel.forage.core.util.config.Config;
 import org.apache.camel.forage.core.util.config.ConfigModule;
 import org.apache.camel.forage.core.util.config.ConfigStore;
 import org.apache.camel.forage.core.util.config.MissingConfigException;
+import org.apache.camel.forage.jdbc.common.idempotent.ForageJdbcMessageIdRepository;
 
 /**
  * Configuration for data source factory with JDBC connection settings and pool parameters.
@@ -261,5 +262,31 @@ public class DataSourceFactoryConfig implements Config {
         return ConfigStore.getInstance()
                 .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME.asNamed(prefix))
                 .orElse(null);
+    }
+
+    public boolean enableIdempotentRepository() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.ENABLE_IDEMPOTENT_REPOSITORY.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public String idempotentRepositoryTableName() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.IDEMPOTENT_REPOSITORY_TABLE_NAME.asNamed(prefix))
+                .orElse(ForageJdbcMessageIdRepository.DEFAULT_TABLENAME);
+    }
+
+    public boolean enableIdempotentRepositoryTableCreate() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.IDEMPOTENT_REPOSITORY_TABLE_IF_NOT_EXISTS.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(true);
+    }
+
+    public String idempotentRepositoryProcessorName() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.IDEMPOTENT_REPOSITORY_TABLE_IF_NOT_EXISTS.asNamed(prefix))
+                .orElse("FORAGE_PROCESSOR_" + idempotentRepositoryTableName());
     }
 }

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
@@ -81,6 +81,14 @@ public class DataSourceFactoryConfigEntries extends ConfigEntries {
             ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.use.recovery");
     public static final ConfigModule AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME =
             ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.propagation.behaviour.name");
+    public static final ConfigModule ENABLE_IDEMPOTENT_REPOSITORY =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.idempotent.repository.enabled");
+    public static final ConfigModule IDEMPOTENT_REPOSITORY_TABLE_NAME =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.idempotent.repository.table.name");
+    public static final ConfigModule IDEMPOTENT_REPOSITORY_TABLE_IF_NOT_EXISTS =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.idempotent.repository.table.create");
+    public static final ConfigModule IDEMPOTENT_REPOSITORY_PROCESSOR_NAME =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.idempotent.repository.processor.name");
 
     private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new ConcurrentHashMap<>();
 
@@ -124,6 +132,10 @@ public class DataSourceFactoryConfigEntries extends ConfigEntries {
         CONFIG_MODULES.put(AGGREGATION_REPOSITORY_MAXIMUM_REDELIVERIES, ConfigEntry.fromModule());
         CONFIG_MODULES.put(AGGREGATION_REPOSITORY_USE_RECOVERY, ConfigEntry.fromModule());
         CONFIG_MODULES.put(AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(ENABLE_IDEMPOTENT_REPOSITORY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(IDEMPOTENT_REPOSITORY_TABLE_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(IDEMPOTENT_REPOSITORY_TABLE_IF_NOT_EXISTS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(IDEMPOTENT_REPOSITORY_PROCESSOR_NAME, ConfigEntry.fromModule());
     }
 
     public static Map<ConfigModule, ConfigEntry> entries() {

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/ForageDataSource.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/ForageDataSource.java
@@ -1,0 +1,6 @@
+package org.apache.camel.forage.jdbc.common;
+
+import javax.sql.DataSource;
+import org.apache.camel.forage.jdbc.common.idempotent.ForageIdRepository;
+
+public record ForageDataSource(DataSource dataSource, ForageIdRepository forageIdRepository) {}

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/PooledDataSource.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/PooledDataSource.java
@@ -12,6 +12,7 @@ import io.agroal.narayana.NarayanaTransactionIntegration;
 import java.time.Duration;
 import javax.sql.DataSource;
 import org.apache.camel.forage.core.jdbc.DataSourceProvider;
+import org.apache.camel.forage.jdbc.common.idempotent.ForageIdRepository;
 import org.apache.camel.forage.jdbc.common.transactions.TransactionConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * Abstract base class for pooled JDBC implementations using Agroal connection pooling.
  * Provides database-agnostic DataSource configuration with optimized pool settings.
  */
-public abstract class PooledDataSource implements DataSourceProvider {
+public abstract class PooledDataSource implements DataSourceProvider, ForageIdRepository {
     private static final Logger LOG = LoggerFactory.getLogger(PooledDataSource.class);
 
     private DataSourceFactoryConfig config;

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/aggregation/ForageAggregationRepository.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/aggregation/ForageAggregationRepository.java
@@ -4,7 +4,7 @@ import jakarta.transaction.TransactionManager;
 import javax.sql.DataSource;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
 import org.apache.camel.processor.aggregate.jdbc.JdbcAggregationRepository;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.jta.JtaTransactionManager;
 
 public class ForageAggregationRepository extends JdbcAggregationRepository {
 
@@ -14,8 +14,10 @@ public class ForageAggregationRepository extends JdbcAggregationRepository {
             DataSourceFactoryConfig dataSourceFactoryConfig) {
         setRepositoryName(dataSourceFactoryConfig.aggregationRepositoryName());
         setDataSource(dataSource);
-        DataSourceTransactionManager dataSourceTransactionManager = new DataSourceTransactionManager(dataSource);
-        setTransactionManager(dataSourceTransactionManager);
+
+        JtaTransactionManager jtaTransactionManager =
+                new JtaTransactionManager(com.arjuna.ats.jta.TransactionManager.transactionManager());
+        setTransactionManager(jtaTransactionManager);
 
         setHeadersToStoreAsText(dataSourceFactoryConfig.aggregationRepositoryHeadersToStore()); // comma separated list
         setStoreBodyAsText(dataSourceFactoryConfig.aggregationRepositoryStoreBody());

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/idempotent/ForageIdRepository.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/idempotent/ForageIdRepository.java
@@ -1,0 +1,28 @@
+package org.apache.camel.forage.jdbc.common.idempotent;
+
+public interface ForageIdRepository {
+
+    default String tableExistsString() {
+        return ForageJdbcMessageIdRepository.DEFAULT_TABLE_EXISTS_STRING;
+    }
+
+    default String createString() {
+        return ForageJdbcMessageIdRepository.DEFAULT_CREATE_STRING;
+    }
+
+    default String queryString() {
+        return ForageJdbcMessageIdRepository.DEFAULT_QUERY_STRING;
+    }
+
+    default String insertString() {
+        return ForageJdbcMessageIdRepository.DEFAULT_INSERT_STRING;
+    }
+
+    default String deleteString() {
+        return ForageJdbcMessageIdRepository.DEFAULT_DELETE_STRING;
+    }
+
+    default String clearString() {
+        return ForageJdbcMessageIdRepository.DEFAULT_CLEAR_STRING;
+    }
+}

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepository.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepository.java
@@ -1,0 +1,44 @@
+package org.apache.camel.forage.jdbc.common.idempotent;
+
+import javax.sql.DataSource;
+import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
+import org.apache.camel.processor.idempotent.jdbc.JdbcMessageIdRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.jta.JtaTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public class ForageJdbcMessageIdRepository extends JdbcMessageIdRepository {
+
+    public static final String DEFAULT_TABLENAME = JdbcMessageIdRepository.DEFAULT_TABLENAME;
+    public static final String DEFAULT_TABLE_EXISTS_STRING = JdbcMessageIdRepository.DEFAULT_TABLE_EXISTS_STRING;
+    public static final String DEFAULT_CREATE_STRING = JdbcMessageIdRepository.DEFAULT_CREATE_STRING;
+    public static final String DEFAULT_QUERY_STRING = JdbcMessageIdRepository.DEFAULT_QUERY_STRING;
+    public static final String DEFAULT_INSERT_STRING = JdbcMessageIdRepository.DEFAULT_INSERT_STRING;
+    public static final String DEFAULT_DELETE_STRING = JdbcMessageIdRepository.DEFAULT_DELETE_STRING;
+    public static final String DEFAULT_CLEAR_STRING = JdbcMessageIdRepository.DEFAULT_CLEAR_STRING;
+
+    public ForageJdbcMessageIdRepository(
+            DataSourceFactoryConfig config, DataSource dataSource, ForageIdRepository forageIdRepository) {
+        setTableName(config.idempotentRepositoryTableName());
+
+        setJdbcTemplate(new JdbcTemplate(dataSource));
+        setDataSource(dataSource);
+        setCreateString(forageIdRepository.createString());
+        setClearString(forageIdRepository.clearString());
+        setDeleteString(forageIdRepository.deleteString());
+        setInsertString(forageIdRepository.insertString());
+        setQueryString(forageIdRepository.queryString());
+        setTableExistsString(forageIdRepository.tableExistsString());
+
+        setProcessorName(config.idempotentRepositoryProcessorName());
+
+        setCreateTableIfNotExists(config.enableIdempotentRepositoryTableCreate());
+
+        if (config.transactionEnabled()) {
+            JtaTransactionManager jtaTransactionManager =
+                    new JtaTransactionManager(com.arjuna.ats.jta.TransactionManager.transactionManager());
+            TransactionTemplate transactionTemplate = new TransactionTemplate(jtaTransactionManager);
+            setTransactionTemplate(transactionTemplate);
+        }
+    }
+}

--- a/library/jdbc/forage-jdbc-mssql/src/main/java/org/apache/camel/forage/jdbc/mssql/MssqlJdbc.java
+++ b/library/jdbc/forage-jdbc-mssql/src/main/java/org/apache/camel/forage/jdbc/mssql/MssqlJdbc.java
@@ -28,4 +28,9 @@ public class MssqlJdbc extends PooledDataSource {
     public String getTestQuery() {
         return "SELECT @@VERSION, DB_NAME(), SUSER_SNAME()";
     }
+
+    @Override
+    public String createString() {
+        return "CREATE TABLE CAMEL_MESSAGEPROCESSED (processorName VARCHAR(255), messageId VARCHAR(100), createdAt DATETIME, PRIMARY KEY (processorName, messageId))";
+    }
 }

--- a/library/jdbc/forage-jdbc-oracle/src/main/java/org/apache/camel/forage/jdbc/oracle/OracleJdbc.java
+++ b/library/jdbc/forage-jdbc-oracle/src/main/java/org/apache/camel/forage/jdbc/oracle/OracleJdbc.java
@@ -28,4 +28,9 @@ public class OracleJdbc extends PooledDataSource {
     public String getTestQuery() {
         return "SELECT banner FROM v$version WHERE ROWNUM = 1";
     }
+
+    @Override
+    public String createString() {
+        return "CREATE TABLE CAMEL_MESSAGEPROCESSED (processorName VARCHAR2(255), messageId VARCHAR2(100), createdAt TIMESTAMP, PRIMARY KEY (processorName, messageId))";
+    }
 }


### PR DESCRIPTION
@JiriOndrusek the idea is the same as aggregate, but this is for the idempotent repository.

With this PR we cover all the camel-sql usecases.

Both Idempotent and Aggregate Repositories need to be reviewed, right now the beans are created as part of the Jdbc DataSource bean (since it is used under the hood), but we may split the Idempotent and Aggregate repository in their own structure if needed (with configs and service loaders)