### PR TITLE
Use 4.15.0 release for camel-next profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                 </property>
             </activation>
             <properties>
-                <camel.version>4.15.0-SNAPSHOT</camel.version>
+                <camel.version>4.15.0</camel.version>
                 <langchain4j-version>1.6.0</langchain4j-version>
                 <langchain4j-beta-version>1.6.0-beta12</langchain4j-beta-version>
                 <langchain4j-community-version>1.6.0-beta12</langchain4j-community-version>


### PR DESCRIPTION
At some point it might be necessary to use 4.16.0-SNAPSHOT, but 4.15.0 is now released and would be good to use for now as the camel-next version.