### PR TITLE
JDBC Integration test using Citrus

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,4 +31,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' package --file pom.xml
+      run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' package failsafe:integration-test failsafe:verify --file pom.xml

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -33,7 +33,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
         camel-profile: [camel-current, camel-next]
         experimental: [false]
         include:
@@ -55,3 +55,24 @@ jobs:
           cache: maven
       - name: Build with Maven (${{ matrix.camel-profile }})
         run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' package --file pom.xml -P ${{ matrix.camel-profile }}
+
+  build-with-integration-tests:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        camel-profile: [ camel-current, camel-next ]
+        experimental: [ false ]
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven (${{ matrix.camel-profile }}) and run integration tests
+        run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml -P ${{ matrix.camel-profile }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 
 .ObjectStore
 .PutObjectStoreDirHeres
+.citrus-jbang

--- a/integration-tests/common/pom.xml
+++ b/integration-tests/common/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>integration-tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>integration-tests-common</artifactId>
+    <name>Camel Forage :: Integration Tests :: Common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-api</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-base</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-camel</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-junit5</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <version>${junit-jupiter-suite.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>camel-jbang-plugin-forage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+
+    <profiles>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!--  The following dependencies guarantee that this module is built after them.
+                      Integration tests require a lot of dependencies for forage plugin. Forage-catalog requires almost
+                      everything, which moves integration test to the end of the build. -->
+                <dependency>
+                    <groupId>org.apache.camel.forage</groupId>
+                    <artifactId>forage-catalog</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/ForageIntegrationTest.java
+++ b/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/ForageIntegrationTest.java
@@ -1,0 +1,23 @@
+package org.apache.camel.forage.integration.tests;
+
+import java.util.function.Consumer;
+import org.citrusframework.TestCaseRunner;
+
+/**
+ * Interface required for special test cases:
+ * <p/>
+ * <ul>
+ *     <li>Start routes once per class - implement {@link #runBeforeAll}</li>. See example {@link org.apache.camel.forage.jdbc.MultiTest}.
+ * </ul>
+ * <p/>
+ * The test class has to register extension like <pre>@ExtendWith(IntegrationTestSetupExtension.class)</pre>
+ *
+ */
+public interface ForageIntegrationTest {
+
+    /**
+     * Start routes once for the class lifetime.
+     * Don't forget to register a cleanup method via @{link java.lang.AutoCloseable}
+     */
+    void runBeforeAll(TestCaseRunner runner, Consumer<AutoCloseable> afterAll);
+}

--- a/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -1,0 +1,107 @@
+package org.apache.camel.forage.integration.tests;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.apache.camel.forage.plugin.DataSourceExportHelper;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestCaseRunner;
+import org.citrusframework.camel.actions.CamelActionBuilder;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.junit.jupiter.CitrusExtensionHelper;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JUni5 extension, responsible for:
+ * <p/>
+ * <ul>
+ * <li>Copying the test resource files into working directory.</li>
+ * </ul>
+ * <li>Starting tests for all runtimes. This is implemented by {@link org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider}.
+ * Each run puts value into system properties with key {@link IntegrationTestSetupExtension#RUNTIME_PROPERTY}.
+ * There are 3 values: null, "--runtime=spring-boot" and "--runtime=quarkus".</li>
+ * <p/>
+ * Test class should be annotated with
+ * <ul>
+ *     <li>@CitrusSupport</li>
+ *     <li>@Testcontainers</li>
+ *     <li>@ExtendWith(IntegrationTestSetupExtension.class)</li>
+ * </ul>
+ * and should add args to the citrus runner similar to <pre>.withArg(System.getProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY))</pre>
+ */
+public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterAllCallback {
+
+    private final Logger LOG = LoggerFactory.getLogger(IntegrationTestSetupExtension.class);
+
+    public static final String RUNTIME_PROPERTY = "integration_test_runtime+property";
+
+    private boolean runBeforeAll = false;
+    private Map<String, Object> variables;
+    private final ArrayList<AutoCloseable> closeables = new ArrayList<>();
+    private TestContext previousTestContext;
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        if (!runBeforeAll) {
+            runBeforeAll = true;
+            internalBeforeAll(context);
+            runBeforeAll(context);
+        }
+        // save test context variables
+        TestContext testContext = CitrusExtensionHelper.getTestContext(context);
+        if (previousTestContext != null) {
+            testContext.getVariables().putAll(previousTestContext.getVariables());
+        } else {
+            previousTestContext = testContext;
+            ;
+        }
+    }
+
+    private void runBeforeAll(ExtensionContext context) {
+
+        if (context.getRequiredTestInstance() instanceof ForageIntegrationTest) {
+
+            TestCaseRunner runner = CitrusExtensionHelper.getTestRunner(context);
+
+            LOG.info("Running 'runBeforeAll' setup for class: %s"
+                    .formatted(context.getRequiredTestClass().getName()));
+            ((ForageIntegrationTest) context.getRequiredTestInstance()).runBeforeAll(runner, closeables::add);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        previousTestContext = null;
+        LOG.info("Running 'afterAll' setup for class: %s"
+                .formatted(context.getRequiredTestClass().getName()));
+        closeables.forEach(c -> {
+            try {
+                c.close();
+            } catch (Exception e) {
+                LOG.warn("Error closing test case", e);
+            }
+        });
+        closeables.clear();
+    }
+
+    private void internalBeforeAll(ExtensionContext context) throws Exception {
+        String projectVersion = DataSourceExportHelper.getProjectVersion();
+        TestCaseRunner runner = CitrusExtensionHelper.getTestRunner(context);
+        CamelActionBuilder camel =
+                (CamelActionBuilder) TestActionBuilder.lookup("camel").get();
+        // ensure, that forage plugin is installed
+        CitrusExtensionHelper.getTestRunner(context)
+                .when(camel.jbang()
+                        .plugin()
+                        .add()
+                        .pluginName("forage")
+                        .withArg("--artifactId", "camel-jbang-plugin-forage")
+                        .withArg("--groupId", "org.apache.camel.forage")
+                        .withArg("--version", projectVersion)
+                        .withArg("--gav", "org.apache.camel.forage:camel-jbang-plugin-forage:" + projectVersion));
+    }
+}

--- a/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/PlainSuite.java
+++ b/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/PlainSuite.java
@@ -1,0 +1,27 @@
+package org.apache.camel.forage.integration.tests.suites;
+
+import org.junit.platform.suite.api.AfterSuite;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Suite
+@SuiteDisplayName("<plain>")
+@SelectPackages("org.apache.camel.forage")
+public class PlainSuite {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlainSuite.class);
+
+    @AfterSuite
+    public static void afterSuite() {
+        TestSuiteHelper.afterSuite();
+    }
+
+    @BeforeSuite
+    public static void beforeSuite() {
+        TestSuiteHelper.beforeSuite("<plain>", LOG);
+    }
+}

--- a/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/QuarkusSuite.java
+++ b/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/QuarkusSuite.java
@@ -1,0 +1,27 @@
+package org.apache.camel.forage.integration.tests.suites;
+
+import org.junit.platform.suite.api.AfterSuite;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Suite
+@SuiteDisplayName("Quarkus")
+@SelectPackages("org.apache.camel.forage")
+public class QuarkusSuite {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QuarkusSuite.class);
+
+    @AfterSuite
+    public static void afterSuite() {
+        TestSuiteHelper.afterSuite();
+    }
+
+    @BeforeSuite
+    public static void beforeSuite() {
+        TestSuiteHelper.beforeSuite("quarkus", LOG);
+    }
+}

--- a/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/SpringBootSuite.java
+++ b/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/SpringBootSuite.java
@@ -1,0 +1,27 @@
+package org.apache.camel.forage.integration.tests.suites;
+
+import org.junit.platform.suite.api.AfterSuite;
+import org.junit.platform.suite.api.BeforeSuite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Suite
+@SuiteDisplayName("springboot")
+@SelectPackages("org.apache.camel.forage")
+public class SpringBootSuite {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringBootSuite.class);
+
+    @AfterSuite
+    public static void afterSuite() {
+        TestSuiteHelper.afterSuite();
+    }
+
+    @BeforeSuite
+    public static void beforeSuite() {
+        TestSuiteHelper.beforeSuite("spring-boot", LOG);
+    }
+}

--- a/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/TestSuiteHelper.java
+++ b/integration-tests/common/src/main/java/org/apache/camel/forage/integration/tests/suites/TestSuiteHelper.java
@@ -1,0 +1,49 @@
+package org.apache.camel.forage.integration.tests.suites;
+
+import org.apache.camel.forage.integration.tests.IntegrationTestSetupExtension;
+import org.apache.camel.forage.plugin.DataSourceExportHelper;
+import org.slf4j.Logger;
+
+/**
+ * Helper class for Suites.
+ */
+class TestSuiteHelper {
+
+    public static void afterSuite() {
+        System.clearProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY);
+        System.clearProperty("citrus.camel.jbang.version");
+    }
+
+    public static void beforeSuite(String runtimeValue, Logger log) {
+        if (!runtimeValue.startsWith("<")) {
+            System.setProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY, "--runtime=" + runtimeValue);
+        } else {
+            System.clearProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY);
+        }
+        System.setProperty("citrus.camel.jbang.version", DataSourceExportHelper.getCamelVersion());
+        logText(runtimeValue, log);
+    }
+
+    private static void logText(String text, Logger log) {
+
+        int totalLength = 80;
+
+        if (log != null) {
+            String paddedText = " " + text + " ";
+            int textLength = paddedText.length();
+
+            int dashLength = totalLength - textLength;
+            int leftDashes = dashLength / 2;
+            int rightDashes = dashLength - leftDashes;
+
+            StringBuilder line = new StringBuilder();
+            line.append("-".repeat(leftDashes));
+            line.append(paddedText);
+            line.append("-".repeat(rightDashes));
+
+            log.info("-".repeat(totalLength));
+            log.info(line.toString());
+            log.info("-".repeat(totalLength));
+        }
+    }
+}

--- a/integration-tests/jdbc/pom.xml
+++ b/integration-tests/jdbc/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>integration-tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>integration-tests-jdbc</artifactId>
+    <name>Camel Forage :: Integration Tests :: JDBC</name>
+
+    <dependencies>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- db drivers -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>integration-tests-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- test containers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.citrusframework.mvn</groupId>
+                <artifactId>citrus-maven-plugin</artifactId>
+                <version>${citrus.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. -->
+                <dependency>
+                    <groupId>org.apache.camel.forage</groupId>
+                    <artifactId>forage-quarkus-jdbc-configurer</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/MultiTest.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/MultiTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.forage.jdbc;
+
+import static org.citrusframework.camel.dsl.CamelSupport.camel;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.camel.forage.integration.tests.ForageIntegrationTest;
+import org.apache.camel.forage.integration.tests.IntegrationTestSetupExtension;
+import org.citrusframework.GherkinTestActionRunner;
+import org.citrusframework.TestActionSupport;
+import org.citrusframework.TestCaseRunner;
+import org.citrusframework.annotations.CitrusResource;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.spi.Resources;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Test class starts route only once, before all tests are executed.
+ */
+@CitrusSupport
+@Testcontainers
+@ExtendWith(IntegrationTestSetupExtension.class)
+public class MultiTest implements TestActionSupport, ForageIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+                    DockerImageName.parse("mirror.gcr.io/postgres:15.0").asCompatibleSubstituteFor("postgres"))
+            .withExposedPorts(5432)
+            .withUsername("test")
+            .withPassword("test")
+            .withDatabaseName("postgresql")
+            .withInitScript("singleITInitScript.sql");
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>(
+                    DockerImageName.parse("mirror.gcr.io/mysql:8.4").asCompatibleSubstituteFor("mysql"))
+            .withExposedPorts(3306)
+            .withInitScript("multiITmysqlInitScript.sql");
+
+    @Override
+    public void runBeforeAll(TestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
+        runner.when((camel())
+                .jbang()
+                .custom("forage", "run")
+                .processName("route")
+                .addResource(Resources.fromClasspath(getClass().getSimpleName() + "/route.camel.yaml", getClass()))
+                .addResource(Resources.fromClasspath(
+                        getClass().getSimpleName() + "/forage-datasource-factory.properties", getClass()))
+                .withArg(System.getProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY))
+                .dumpIntegrationOutput(true)
+                .autoRemove(false)
+                .withEnvs(Map.of("DS1_JDBC_URL", postgres.getJdbcUrl(), "DS2_JDBC_URL", mysql.getJdbcUrl())));
+
+        afterAll.accept(() -> runner.then(camel().jbang().stop().integration("route")));
+    }
+
+    @Test
+    @CitrusTest()
+    public void postgresql(@CitrusResource GherkinTestActionRunner runner) {
+        // validation of logged message
+        runner.then(camel().jbang()
+                .verify()
+                .integration("route")
+                .waitForLogMessage("from jdbc postgresql - [{id=1, content=postgres 1}, {id=2, content=postgres 2}]"));
+    }
+
+    @Test
+    @CitrusTest()
+    public void mysql(@CitrusResource GherkinTestActionRunner runner) {
+        // validation of logged message
+        runner.then(camel().jbang()
+                .verify()
+                .integration("route")
+                .waitForLogMessage("from sql mysql - [{id=1, content=mysql 1}, {id=2, content=mysql 2}]"));
+    }
+}

--- a/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/SingleTest.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/SingleTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.forage.jdbc;
+
+import java.util.Collections;
+import org.apache.camel.forage.integration.tests.IntegrationTestSetupExtension;
+import org.citrusframework.GherkinTestActionRunner;
+import org.citrusframework.TestActionSupport;
+import org.citrusframework.annotations.CitrusResource;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.spi.Resources;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@CitrusSupport
+@Testcontainers
+@ExtendWith(IntegrationTestSetupExtension.class)
+public class SingleTest implements TestActionSupport {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+                    DockerImageName.parse("mirror.gcr.io/postgres:15.0").asCompatibleSubstituteFor("postgres"))
+            .withExposedPorts(5432)
+            .withUsername("test")
+            .withPassword("test")
+            .withDatabaseName("postgresql")
+            .withInitScript("singleITInitScript.sql");
+
+    @Test
+    @CitrusTest()
+    public void singleIT(@CitrusResource GherkinTestActionRunner runner) {
+        // running jbang forage run with required resources and required runtime
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName("route")
+                .addResource(Resources.fromClasspath(getClass().getSimpleName() + "/route.camel.yaml", getClass()))
+                .addResource(Resources.fromClasspath(
+                        getClass().getSimpleName() + "/forage-datasource-factory.properties", getClass()))
+                .dumpIntegrationOutput(true)
+                .withArg(System.getProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY))
+                .withEnvs(Collections.singletonMap("JDBC_URL", postgres.getJdbcUrl())));
+
+        // validation of logged message
+        runner.then(camel().jbang()
+                .verify()
+                .integration("route")
+                .waitForLogMessage("from jdbc default ds - [{id=1, content=postgres 1}, {id=2, content=postgres 2}]"));
+    }
+}

--- a/integration-tests/jdbc/src/test/resources/log4j2-test.xml
+++ b/integration-tests/jdbc/src/test/resources/log4j2-test.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout pattern="%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{Dim} %highlight{%5p} %style{%pid}{Magenta} %style{---}{Dim} %style{[%15.15t]}{Dim} %style{%-35.35c}{Cyan} %style{:}{Dim} %m%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+
+    <!-- Our own classes-->
+    <Logger name="org.citrusframework" additivity="false" level="INFO">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="Logger.Message_IN" additivity="false" level="DEBUG">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="Logger.Message_OUT" additivity="false" level="DEBUG">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.springframework" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.eclipse" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.apache" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+  </Loggers>
+
+</Configuration>

--- a/integration-tests/jdbc/src/test/resources/multiITmysqlInitScript.sql
+++ b/integration-tests/jdbc/src/test/resources/multiITmysqlInitScript.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test.foo(id INTEGER PRIMARY KEY, content VARCHAR(255));
+INSERT INTO test.foo VALUES (1, 'mysql 1');
+INSERT INTO test.foo VALUES (2, 'mysql 2');

--- a/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/MultiTest/forage-datasource-factory.properties
+++ b/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/MultiTest/forage-datasource-factory.properties
@@ -1,0 +1,37 @@
+# PostgreSQL JDBC Configuration
+# Database connection settings
+ds1.jdbc.db.kind=postgresql
+#ds1.jdbc.url=jdbc:postgresql://localhost:5432/postgres
+ds1.jdbc.username=test
+ds1.jdbc.password=test
+
+# Connection pool settings
+ds1.jdbc.pool.initial.size=5
+ds1.jdbc.pool.min.size=2
+ds1.jdbc.pool.max.size=20
+ds1.jdbc.pool.acquisition.timeout.seconds=5
+ds1.jdbc.pool.validation.timeout.seconds=3
+ds1.jdbc.pool.leak.timeout.minutes=10
+ds1.jdbc.pool.idle.validation.timeout.minutes=3
+
+# Transaction settings
+ds1.jdbc.transaction.timeout.seconds=30
+
+# MySQL JDBC Configuration
+# Database connection settings
+ds2.jdbc.db.kind=mysql
+#ds2.jdbc.url=jdbc:mysql://localhost:3306/test
+ds2.jdbc.username=test
+ds2.jdbc.password=test
+
+# Connection pool settings
+ds2.jdbc.pool.initial.size=5
+ds2.jdbc.pool.min.size=2
+ds2.jdbc.pool.max.size=20
+ds2.jdbc.pool.acquisition.timeout.seconds=5
+ds2.jdbc.pool.validation.timeout.seconds=3
+ds2.jdbc.pool.leak.timeout.minutes=10
+ds2.jdbc.pool.idle.validation.timeout.minutes=3
+
+# Transaction settings
+ds2.jdbc.transaction.timeout.seconds=30

--- a/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/MultiTest/route.camel.yaml
+++ b/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/MultiTest/route.camel.yaml
@@ -1,0 +1,93 @@
+- route:
+    id: route-2362
+    from:
+      id: from-4124
+      uri: timer
+      parameters:
+        period: "1000"
+        timerName: template
+      steps:
+        - to:
+            id: to-3877
+            uri: sql
+            parameters:
+              dataSource: "#ds1"
+              query: select * from bar
+        - log:
+            id: log-2176
+            message: from sql postgresql ds - ${body}
+        - to:
+            id: to-1832
+            uri: sql
+            parameters:
+              dataSource: "#ds2"
+              query: select * from test.foo
+        - log:
+            id: log-1980
+            message: from sql mysql - ${body}
+- route:
+    id: route-2362-3853
+    from:
+      id: from-4124-3053
+      uri: timer
+      parameters:
+        period: "1000"
+        timerName: template
+      steps:
+        - setBody:
+            id: setBody-4165
+            simple:
+              expression: select * from bar
+        - to:
+            id: to-2601
+            uri: jdbc
+            parameters:
+              dataSourceName: ds1
+        - log:
+            id: log-2176-3777
+            message: from jdbc postgresql - ${body}
+        - setBody:
+            id: setBody-2643
+            simple:
+              expression: select * from test.foo
+        - to:
+            id: to-1729
+            uri: jdbc
+            parameters:
+              dataSourceName: ds2
+        - log:
+            id: log-8472
+            message: from jdbc mysql - ${body}
+- route:
+    id: route-2362-3853-3892
+    from:
+      id: from-4124-3053-2241
+      uri: timer
+      parameters:
+        period: "1000"
+        timerName: template
+      steps:
+        - setBody:
+            id: setBody-4165-2569
+            simple:
+              expression: select * from bar
+        - to:
+            id: to-3702
+            uri: spring-jdbc
+            parameters:
+              dataSourceName: ds1
+        - log:
+            id: log-2176-3777-4035
+            message: from jdbc postgresql - ${body}
+        - setBody:
+            id: setBody-2643-3720
+            simple:
+              expression: select * from test.foo
+        - to:
+            id: to-3070
+            uri: spring-jdbc
+            parameters:
+              dataSourceName: ds2
+        - log:
+            id: log-8472-1184
+            message: from jdbc mysql - ${body}

--- a/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/SingleTest/forage-datasource-factory.properties
+++ b/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/SingleTest/forage-datasource-factory.properties
@@ -1,0 +1,18 @@
+# PostgreSQL JDBC Configuration
+# Database connection settings
+jdbc.db.kind=postgresql
+#jdbc.url is configured dynamically in the test
+jdbc.username=test
+jdbc.password=test
+
+# Connection pool settings
+jdbc.pool.initial.size=5
+jdbc.pool.min.size=2
+jdbc.pool.max.size=20
+jdbc.pool.acquisition.timeout.seconds=5
+jdbc.pool.validation.timeout.seconds=3
+jdbc.pool.leak.timeout.minutes=10
+jdbc.pool.idle.validation.timeout.minutes=3
+
+# Transaction settings
+jdbc.transaction.timeout.seconds=30

--- a/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/SingleTest/route.camel.yaml
+++ b/integration-tests/jdbc/src/test/resources/org/apache/camel/forage/jdbc/SingleTest/route.camel.yaml
@@ -1,0 +1,21 @@
+- route:
+    id: route
+    from:
+      id: from-4124-3053
+      uri: timer
+      parameters:
+        period: "1000"
+        timerName: template
+      steps:
+        - setBody:
+            id: setBody-4165
+            simple:
+              expression: select * from bar
+        - to:
+            id: to-2601
+            uri: jdbc
+            parameters:
+              dataSourceName: dataSource
+        - log:
+            id: log-2176-3777
+            message: from jdbc default ds - ${body}

--- a/integration-tests/jdbc/src/test/resources/singleITInitScript.sql
+++ b/integration-tests/jdbc/src/test/resources/singleITInitScript.sql
@@ -1,0 +1,7 @@
+CREATE TABLE bar (
+                     id INTEGER PRIMARY KEY,
+                     content VARCHAR(255)
+);
+
+INSERT INTO bar VALUES (1, 'postgres 1');
+INSERT INTO bar VALUES (2, 'postgres 2');

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>camel-forage</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>integration-tests</artifactId>
+    <packaging>pom</packaging>
+    <name>Camel Forage :: Integration Tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-base</artifactId>
+            <version>${citrus.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-jbang-connector</artifactId>
+            <version>${citrus.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-junit5</artifactId>
+            <version>${citrus.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <modules>
+        <module>common</module>
+        <module>jdbc</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>org.apache.camel.forage:integration-tests-common</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>**/*Suite</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <citrus.camel.jbang.work.dir>${project.build.directory}/.run</citrus.camel.jbang.work.dir>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+        </plugins>
+    </build>
+
+</project>

--- a/library/jdbc/forage-jdbc-mysql/pom.xml
+++ b/library/jdbc/forage-jdbc-mysql/pom.xml
@@ -12,10 +12,6 @@
     <artifactId>forage-jdbc-mysql</artifactId>
     <name>Camel Forage :: Library :: JDBC :: MySQL</name>
 
-    <properties>
-        <mysql.version>9.1.0</mysql.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.forage</groupId>

--- a/library/jdbc/forage-jdbc-postgresql/pom.xml
+++ b/library/jdbc/forage-jdbc-postgresql/pom.xml
@@ -12,10 +12,6 @@
     <artifactId>forage-jdbc-postgresql</artifactId>
     <name>Camel Forage :: Library :: JDBC :: Postgresql</name>
 
-    <properties>
-        <postgresql.version>42.7.7</postgresql.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.camel.forage</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <spotless.version>2.46.1</spotless.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
+        <junit-jupiter-suite.version>1.13.4</junit-jupiter-suite.version>
         <assertj-core.version>3.27.4</assertj-core.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <agroal.version>2.8</agroal.version>
@@ -37,6 +38,11 @@
         <narayana.version>7.2.2.Final</narayana.version>
         <pooled-jms.version>3.1.7</pooled-jms.version>
         <vertx.version>4.5.20</vertx.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
+        <postgresql.version>42.7.7</postgresql.version>
+        <mysql.version>9.1.0</mysql.version>
+        <citrus.version>4.8.2</citrus.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -112,6 +118,7 @@
 
     <modules>
         <module>core</module>
+        <module>integration-tests</module>
         <module>library</module>
         <module>tooling</module>
         <module>forage-catalog</module>

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/DataSourceExportHelper.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/DataSourceExportHelper.java
@@ -31,11 +31,20 @@ public final class DataSourceExportHelper {
     }
 
     /**
+     * Gets the camel version from the versions.properties file. (which is populated during buildtime)
+     *
+     * @return the project version
+     */
+    public static String getCamelVersion() {
+        return getString("camel.version", "Could not determine quarkus version from properties file.");
+    }
+
+    /**
      * Gets the quarkus version from the versions.properties file. (which is populated during buildtime)
      *
      * @return the project version
      */
-    public static String geProjectVersion() {
+    public static String getProjectVersion() {
         return getString("jdbc.dependency.version", "Could not determine project version from properties file.");
     }
 

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
@@ -31,7 +31,7 @@ public class DatasourceExportCustomizer implements ExportCustomizer {
                 listDependencies(
                         dependencies,
                         Arrays.asList("mvn:org.apache.camel.forage:forage-quarkus-jdbc-configurer:"
-                                + DataSourceExportHelper.geProjectVersion()),
+                                + DataSourceExportHelper.getProjectVersion()),
                         "mvn:io.quarkus:quarkus-jdbc-",
                         ":" + DataSourceExportHelper.getQuarkusVersion(),
                         runtime);
@@ -41,19 +41,19 @@ public class DatasourceExportCustomizer implements ExportCustomizer {
                         dependencies,
                         Arrays.asList(
                                 "mvn:org.apache.camel.forage:forage-jdbc-starter:"
-                                        + DataSourceExportHelper.geProjectVersion(),
-                                "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.geProjectVersion()),
+                                        + DataSourceExportHelper.getProjectVersion(),
+                                "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.getProjectVersion()),
                         "mvn:org.apache.camel.forage:forage-jdbc-",
-                        ":" + DataSourceExportHelper.geProjectVersion(),
+                        ":" + DataSourceExportHelper.getProjectVersion(),
                         runtime);
             }
             case main -> {
                 listDependencies(
                         dependencies,
                         Collections.singletonList(
-                                "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.geProjectVersion()),
+                                "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.getProjectVersion()),
                         "mvn:org.apache.camel.forage:forage-jdbc-",
-                        ":" + DataSourceExportHelper.geProjectVersion(),
+                        ":" + DataSourceExportHelper.getProjectVersion(),
                         runtime);
             }
         }

--- a/tooling/camel-jbang-plugin-forage/src/main/resources/datasource-command.properties
+++ b/tooling/camel-jbang-plugin-forage/src/main/resources/datasource-command.properties
@@ -1,2 +1,3 @@
 jdbc.dependency.version=@project.version@
 quarkus.version=@quarkus.version@
+camel.version=@camel.version@


### PR DESCRIPTION
POC of integration tests for `forage run` covers all runtimes (plainCamel, CSB and CQ) and uses a POC of Citrus (which is not merged yet, so this PR has to fail).

The idea is to have the test definition as simple as possible. In ideal case, the configuratin files from forage-examples might be used.

There is a helper module `integrationTests/common` with main class `IntegrationTestSetupExtension` (see the javadoc for more onformation) - JUnit5 extension is responsible for handling resources + running tests for each runtime. 
(unfortunately ParametruzedTest could not be used , because conflict with Citrus)

The test class `SingleIT`
* handles test container (postgres in this case)
* defines resources (taken from forage examples)
* runs citrus test and verification

Integration test should be run by `mvn clean verify`

This is just a POC (draft) to gather responses from others.