### PR TITLE
github actions - use the same java version for CI jobs (21)

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
Java 21  should be used for `main` CI (It is already in PR CI