### PR TITLE
Remove use of profiles - now that we have moved to main branch and camel-4.14.x branch, they are no longer needed

### DIFF
--- a/library/ai/pom.xml
+++ b/library/ai/pom.xml
@@ -18,20 +18,7 @@
         <module>agents</module>
         <module>chat-memory</module>
         <module>models</module>
+        <module>vector-dbs</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>camel-next</id>
-            <activation>
-                <property>
-                    <name>!camel-lts</name>
-                </property>
-            </activation>
-            <modules>
-                <module>vector-dbs</module>
-            </modules>
-        </profile>
-    </profiles>
 
 </project>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -17,22 +17,9 @@
     <modules>
         <module>ai</module>
         <module>common</module>
+        <module>jdbc</module>
+        <module>jms</module>
         <module>vertx</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>camel-next</id>
-            <activation>
-                <property>
-                    <name>!camel-lts</name>
-                </property>
-            </activation>
-            <modules>
-                <module>jdbc</module>
-                <module>jms</module>
-            </modules>
-        </profile>
-    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,11 @@
     <name>Camel Forage</name>
 
     <properties>
+        <camel.version>4.16.0</camel.version>
+        <langchain4j-version>1.7.1</langchain4j-version>
+        <langchain4j-beta-version>1.6.0-beta12</langchain4j-beta-version>
+        <langchain4j-community-version>1.6.0-beta12</langchain4j-community-version>
+
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -160,50 +165,19 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>camel-current</id>
-            <activation>
-                <property>
-                    <name>camel-current</name>
-                </property>
-            </activation>
-            <properties>
-                <camel.version>4.15.0</camel.version>
-                <langchain4j-version>1.6.0</langchain4j-version>
-                <langchain4j-beta-version>1.6.0-beta12</langchain4j-beta-version>
-                <langchain4j-community-version>1.6.0-beta12</langchain4j-community-version>
-            </properties>
-        </profile>
-        <profile>
-            <id>camel-next</id>
-            <activation>
-                <property>
-                    <name>!camel-current</name>
-                </property>
-            </activation>
-            <properties>
-                <camel.version>4.16.0-SNAPSHOT</camel.version>
-                <langchain4j-version>1.7.1</langchain4j-version>
-                <langchain4j-beta-version>1.6.0-beta12</langchain4j-beta-version>
-                <langchain4j-community-version>1.6.0-beta12</langchain4j-community-version>
-            </properties>
 
-            <repositories>
-                <repository>
-                    <id>apache.snapshots</id>
-                    <name>Apache Snapshot Repository</name>
-                    <url>https://repository.apache.org/snapshots</url>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
-
-    </profiles>
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://repository.apache.org/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
 </project>


### PR DESCRIPTION
Remove use of profiles - now that we have moved to main branch and camel-4.14.x branch, they are no longer needed - we were using them to separate modules that supporting components that were not present in the camel-4.14 LTS release.