### PR TITLE
Unified container images

### DIFF
--- a/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/AggregationTest.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/AggregationTest.java
@@ -8,6 +8,7 @@ import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resources;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -20,9 +21,11 @@ import org.testcontainers.utility.DockerImageName;
 @ExtendWith(IntegrationTestSetupExtension.class)
 public class AggregationTest implements TestActionSupport {
 
+    static final String IMAGE_NAME = ConfigProvider.getConfig().getValue("postgres.container.image", String.class);
+
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-                    DockerImageName.parse("mirror.gcr.io/postgres:15.0").asCompatibleSubstituteFor("postgres"))
+                    DockerImageName.parse(IMAGE_NAME).asCompatibleSubstituteFor("postgres"))
             .withExposedPorts(5432)
             .withUsername("test")
             .withPassword("test")

--- a/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/IdempotentTest.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/IdempotentTest.java
@@ -15,6 +15,7 @@ import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,11 +30,12 @@ import org.testcontainers.utility.DockerImageName;
 @ExtendWith(IntegrationTestSetupExtension.class)
 public class IdempotentTest implements TestActionSupport {
 
+    static final String IMAGE_NAME = ConfigProvider.getConfig().getValue("postgres.container.image", String.class);
     static final Path INPUT_FOLDER = Paths.get("target", "data", "in");
 
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-                    DockerImageName.parse("mirror.gcr.io/postgres:15.0").asCompatibleSubstituteFor("postgres"))
+                    DockerImageName.parse(IMAGE_NAME).asCompatibleSubstituteFor("postgres"))
             .withExposedPorts(5432)
             .withUsername("test")
             .withPassword("test")

--- a/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/MultiTest.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/MultiTest.java
@@ -29,6 +29,7 @@ import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resources;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.MySQLContainer;
@@ -45,9 +46,13 @@ import org.testcontainers.utility.DockerImageName;
 @ExtendWith(IntegrationTestSetupExtension.class)
 public class MultiTest implements TestActionSupport, ForageIntegrationTest {
 
+    static final String POSTGRES_IMAGE_NAME =
+            ConfigProvider.getConfig().getValue("postgres.container.image", String.class);
+    static final String MYSQL_IMAGE_NAME = ConfigProvider.getConfig().getValue("mysql.container.image", String.class);
+
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-                    DockerImageName.parse("mirror.gcr.io/postgres:15.0").asCompatibleSubstituteFor("postgres"))
+                    DockerImageName.parse(POSTGRES_IMAGE_NAME).asCompatibleSubstituteFor("postgres"))
             .withExposedPorts(5432)
             .withUsername("test")
             .withPassword("test")
@@ -56,7 +61,7 @@ public class MultiTest implements TestActionSupport, ForageIntegrationTest {
 
     @Container
     static MySQLContainer<?> mysql = new MySQLContainer<>(
-                    DockerImageName.parse("mirror.gcr.io/mysql:8.4").asCompatibleSubstituteFor("mysql"))
+                    DockerImageName.parse(MYSQL_IMAGE_NAME).asCompatibleSubstituteFor("mysql"))
             .withExposedPorts(3306)
             .withInitScript("multiITmysqlInitScript.sql");
 

--- a/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/SingleTest.java
+++ b/integration-tests/jdbc/src/test/java/org/apache/camel/forage/jdbc/SingleTest.java
@@ -24,6 +24,7 @@ import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resources;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -36,9 +37,11 @@ import org.testcontainers.utility.DockerImageName;
 @ExtendWith(IntegrationTestSetupExtension.class)
 public class SingleTest implements TestActionSupport {
 
+    static final String IMAGE_NAME = ConfigProvider.getConfig().getValue("postgres.container.image", String.class);
+
     @Container
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-                    DockerImageName.parse("mirror.gcr.io/postgres:15.0").asCompatibleSubstituteFor("postgres"))
+                    DockerImageName.parse(IMAGE_NAME).asCompatibleSubstituteFor("postgres"))
             .withExposedPorts(5432)
             .withUsername("test")
             .withPassword("test")

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -74,9 +74,52 @@
                     </execution>
                 </executions>
             </plugin>
-
-
+            <plugin>
+                <groupId>org.citrusframework.mvn</groupId>
+                <artifactId>citrus-maven-plugin</artifactId>
+                <version>${citrus.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                        <version>${groovy.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>generate-test-container-config</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <skipScriptExecution>${skip-test-containers-config-generation}</skipScriptExecution>
+                            <scripts>
+                                <script>file:${project.basedir}/../../tooling/scripts/generate-test-containers-config-properties.groovy</script>
+                            </scripts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>skip-test-container-config-generation</id>
+            <activation>
+                <file>
+                    <missing>../../tooling/scripts/generate-test-containers-config-properties.groovy</missing>
+                </file>
+            </activation>
+            <properties>
+                <skip-test-containers-config-generation>true</skip-test-containers-config-generation>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <azure.messaging.eventhubs.version>5.21.2</azure.messaging.eventhubs.version>
         <camel-quarkus.version>3.29.0</camel-quarkus.version>
         <citrus.version>4.8.2</citrus.version>
+        <groovy.version>4.0.28</groovy.version>
         <jackson.version>2.15.2</jackson.version>
         <javaparser.version>3.27.1</javaparser.version>
         <junit-jupiter-suite.version>1.13.4</junit-jupiter-suite.version>
@@ -49,6 +50,10 @@
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <vertx.version>4.5.20</vertx.version>
+
+        <!-- Test container image properties -->
+        <postgres.container.image>mirror.gcr.io/postgres:17.5-alpine</postgres.container.image>
+        <mysql.container.image>mirror.gcr.io/mysql:8.4</mysql.container.image>
     </properties>
 
     <dependencyManagement>

--- a/tooling/scripts/generate-test-containers-config-properties.groovy
+++ b/tooling/scripts/generate-test-containers-config-properties.groovy
@@ -1,0 +1,14 @@
+def fileContent = project.properties.findAll { key, value ->
+    key.endsWith('container.image')
+}.collect { key, value ->
+    "${key}=${value}"
+}.join('\n')
+
+File testClasses = new File("${project.build.testOutputDirectory}")
+if (testClasses.exists()) {
+    File metaInfDir = new File("${testClasses.absolutePath}/META-INF")
+    metaInfDir.mkdir()
+
+    File file = new File("${metaInfDir.absolutePath}/microprofile-config.properties")
+    file.write(fileContent)
+}


### PR DESCRIPTION
All properties in root/pom.xml  (where key is ending with `container.image`) are available to integration tests.
Therefore all images (with versions) are defined in one place and there are no version duplications.