### PR TITLE
IBM MQ quarkus + tests

### DIFF
--- a/integration-tests/jms/README.md
+++ b/integration-tests/jms/README.md
@@ -1,0 +1,7 @@
+# Running the tests
+
+To run the test using IBM MQ, you need to accept the license from the official docker image for IBM MQ.
+
+You can run `docker run -e LICENSE=view icr.io/ibm-messaging/mq:9.3.2.1-r1` to view the license.
+
+If you accept the license and want to run the tests, use `-Dibm.mq.container.license=accept` property.

--- a/integration-tests/jms/pom.xml
+++ b/integration-tests/jms/pom.xml
@@ -41,6 +41,14 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- The JMS client library to test with -->
+        <dependency>
+            <groupId>com.ibm.mq</groupId>
+            <artifactId>com.ibm.mq.jakarta.client</artifactId>
+            <version>${ibmmq-client.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/integration-tests/jms/src/test/java/org/apache/camel/forage/jms/IBMMQDestinations.java
+++ b/integration-tests/jms/src/test/java/org/apache/camel/forage/jms/IBMMQDestinations.java
@@ -1,0 +1,80 @@
+package org.apache.camel.forage.jms;
+
+import com.ibm.mq.MQException;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.constants.MQConstants;
+import com.ibm.mq.headers.MQDataException;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.ibm.mq.headers.pcf.PCFMessageAgent;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Set;
+
+/**
+ * IBM MQ queries have to be created before starting the routes.
+ */
+public class IBMMQDestinations {
+    private static final String ADMIN_USER = "admin";
+    private static final String ADMIN_PASSWORD = "passw0rd";
+    private static final String ADMIN_CHANNEL = "DEV.ADMIN.SVRCONN";
+
+    private final String host;
+    private final int port;
+    private final String queueManagerName;
+
+    private final PCFMessageAgent agent;
+    // The destination can be created only once, otherwise the request will fail
+    private final Set<String> createdQueues = new HashSet<>();
+
+    public IBMMQDestinations(String host, int port, String queueManagerName) {
+        this.host = host;
+        this.port = port;
+        this.queueManagerName = queueManagerName;
+
+        // Disable creating log files for client
+        System.setProperty("com.ibm.msg.client.commonservices.log.status", "OFF");
+
+        agent = createPCFAgent();
+    }
+
+    private MQQueueManager createQueueManager() {
+        Hashtable<String, Object> properties = new Hashtable<>();
+        properties.put(MQConstants.HOST_NAME_PROPERTY, host);
+        properties.put(MQConstants.PORT_PROPERTY, port);
+        properties.put(MQConstants.CHANNEL_PROPERTY, ADMIN_CHANNEL);
+        properties.put(MQConstants.USE_MQCSP_AUTHENTICATION_PROPERTY, true);
+        properties.put(MQConstants.USER_ID_PROPERTY, ADMIN_USER);
+        properties.put(MQConstants.PASSWORD_PROPERTY, ADMIN_PASSWORD);
+        try {
+            return new MQQueueManager(queueManagerName, properties);
+        } catch (MQException e) {
+            throw new RuntimeException("Unable to create MQQueueManager:", e);
+        }
+    }
+
+    private PCFMessageAgent createPCFAgent() {
+        try {
+            return new PCFMessageAgent(createQueueManager());
+        } catch (MQDataException e) {
+            throw new RuntimeException("Unable to create PCFMessageAgent:", e);
+        }
+    }
+
+    private void sendRequest(PCFMessage request) {
+        try {
+            agent.send(request);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to send PCFMessage:", e);
+        }
+    }
+
+    public void createQueue(String queueName) {
+        if (!createdQueues.contains(queueName)) {
+            PCFMessage request = new PCFMessage(MQConstants.MQCMD_CREATE_Q);
+            request.addParameter(MQConstants.MQCA_Q_NAME, queueName);
+            request.addParameter(MQConstants.MQIA_Q_TYPE, MQConstants.MQQT_LOCAL);
+            sendRequest(request);
+            createdQueues.add(queueName);
+        }
+    }
+}

--- a/integration-tests/jms/src/test/java/org/apache/camel/forage/jms/JmsArtemisTest.java
+++ b/integration-tests/jms/src/test/java/org/apache/camel/forage/jms/JmsArtemisTest.java
@@ -20,8 +20,8 @@ import org.testcontainers.utility.DockerImageName;
 @CitrusSupport
 @Testcontainers
 @ExtendWith(IntegrationTestSetupExtension.class)
-public class JmsTest implements ForageIntegrationTest {
-    private static final Logger LOG = LoggerFactory.getLogger(JmsTest.class);
+public class JmsArtemisTest implements ForageIntegrationTest {
+    private static final Logger LOG = LoggerFactory.getLogger(JmsArtemisTest.class);
 
     static final String ARTEMIS_IMAGE_NAME =
             ConfigProvider.getConfig().getValue("activemq.artemis.container.image", String.class);
@@ -37,7 +37,7 @@ public class JmsTest implements ForageIntegrationTest {
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
         // running jbang forage run with required resources and required runtime
-        runner.when(forageRun(INTEGRATION_NAME, "forage-connectionfactory.properties", "route.camel.yaml")
+        runner.when(forageRun(INTEGRATION_NAME, "forage-connectionfactory.properties", "route-artemis.camel.yaml")
                 .dumpIntegrationOutput(true)
                 .withEnvs(Collections.singletonMap(
                         "JMS_BROKER_URL", "tcp://" + artemis.getHost() + ":" + artemis.getMappedPort(61616))));
@@ -51,6 +51,7 @@ public class JmsTest implements ForageIntegrationTest {
     @Test
     @CitrusTest()
     public void artemisTransactional(ForageTestCaseRunner runner) {
+
         // validation of logged message
         runner.then(camel().jbang()
                 .verify()

--- a/integration-tests/jms/src/test/java/org/apache/camel/forage/jms/JmsIbmMqTest.java
+++ b/integration-tests/jms/src/test/java/org/apache/camel/forage/jms/JmsIbmMqTest.java
@@ -1,0 +1,109 @@
+package org.apache.camel.forage.jms;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.apache.camel.forage.integration.tests.ForageIntegrationTest;
+import org.apache.camel.forage.integration.tests.ForageTestCaseRunner;
+import org.apache.camel.forage.integration.tests.IntegrationTestSetupExtension;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@EnabledIfSystemProperty(named = "ibm.mq.container.license", matches = "accept")
+@CitrusSupport
+@Testcontainers
+@ExtendWith(IntegrationTestSetupExtension.class)
+public class JmsIbmMqTest implements ForageIntegrationTest {
+    private static final Logger LOG = LoggerFactory.getLogger(JmsIbmMqTest.class);
+
+    private static final String IBMMQ_IMAGE_NAME =
+            ConfigProvider.getConfig().getValue("ibmmq.container.image", String.class);
+    public static final String INTEGRATION_NAME = "jms-routes";
+    private static final int IBMMQ_PORT = 1414;
+    private static final String QUEUE_MANAGER_NAME = "QM1";
+    private static final String USER = "app";
+    private static final String PASSWORD = "passw0rd";
+    private static final String MESSAGING_CHANNEL = "DEV.APP.SVRCONN";
+    private static final String MQSC_COMMAND_FILE_NAME = "99-auth.mqsc";
+    private static final String MQSC_FILE_CONTAINER_PATH = "/etc/mqm/" + MQSC_COMMAND_FILE_NAME;
+
+    @Container
+    static GenericContainer ibmmq = new GenericContainer<>(DockerImageName.parse(IBMMQ_IMAGE_NAME))
+            .withExposedPorts(IBMMQ_PORT)
+            .withEnv(Map.of(
+                    "LICENSE",
+                    Optional.ofNullable(System.getProperty("ibm.mq.container.license"))
+                            .orElse(""),
+                    "MQ_QMGR_NAME",
+                    QUEUE_MANAGER_NAME))
+            .withCopyToContainer(Transferable.of(PASSWORD), "/run/secrets/mqAdminPassword")
+            .withCopyToContainer(Transferable.of(PASSWORD), "/run/secrets/mqAppPassword")
+            .withCopyToContainer(Transferable.of(mqscConfig()), MQSC_FILE_CONTAINER_PATH)
+            // AMQ5806I is a message code for queue manager start
+            .waitingFor(Wait.forLogMessage(".*AMQ5806I.*", 1));
+
+    /**
+     * By default, the user does have access just to predefined queues, this will add permissions to access
+     * all standard queues + topics and a special system queue.
+     *
+     * @return mqsc config string
+     */
+    private static String mqscConfig() {
+        return "SET AUTHREC PROFILE('*') PRINCIPAL('" + USER + "') OBJTYPE(TOPIC) AUTHADD(ALL)\n"
+                + "SET AUTHREC PROFILE('*') PRINCIPAL('" + USER + "') OBJTYPE(QUEUE) AUTHADD(ALL)\n"
+                + "SET AUTHREC PROFILE('SYSTEM.DEFAULT.MODEL.QUEUE') OBJTYPE(QUEUE) PRINCIPAL('" + USER
+                + "') AUTHADD(ALL)\n"
+                + "SET AUTHREC PROFILE('input.queue') PRINCIPAL('app') OBJTYPE(QMGR) AUTHADD(CONNECT,INQ)\n"
+                + "SET AUTHREC PROFILE('input.queue') PRINCIPAL('app') OBJTYPE(QUEUE) AUTHADD(PUT,GET,INQ,BROWSE)\n"
+                + "SET AUTHREC PROFILE('output.queue') PRINCIPAL('app') OBJTYPE(QUEUE) AUTHADD(PUT,GET,INQ,BROWSE)";
+    }
+
+    @Override
+    public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
+        // create queueu
+        IBMMQDestinations destinations =
+                new IBMMQDestinations(ibmmq.getHost(), ibmmq.getMappedPort(IBMMQ_PORT), QUEUE_MANAGER_NAME);
+        destinations.createQueue("input.queue");
+        destinations.createQueue("output.queue");
+        destinations.createQueue("DLQ");
+        destinations.createQueue("DLQ2");
+
+        // running jbang forage run with required resources and required runtime
+        runner.when(forageRun(INTEGRATION_NAME, "forage-connectionfactory.properties", "route-ibm.camel.yaml")
+                .dumpIntegrationOutput(true)
+                //                .withArg("--jvm-debug", "5005")
+                .withEnvs(Collections.singletonMap(
+                        "JMS_BROKER_URL",
+                        "mq://%s:%d/%s/%s"
+                                .formatted(
+                                        ibmmq.getHost(),
+                                        ibmmq.getMappedPort(1414),
+                                        MESSAGING_CHANNEL,
+                                        QUEUE_MANAGER_NAME))));
+
+        return INTEGRATION_NAME;
+    }
+
+    @Test
+    @CitrusTest()
+    public void ibmMqTransactional(ForageTestCaseRunner runner) {
+        // validation of logged message
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .waitForLogMessage("Successfully processed message: Transactional message"));
+    }
+}

--- a/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsArtemisTest/forage-connectionfactory.properties
+++ b/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsArtemisTest/forage-connectionfactory.properties
@@ -1,7 +1,6 @@
 # ActiveMQ Artemis JMS Configuration with XA Transactions
-# JMS connection settings
 jms.kind=artemis
-#jms.broker.url=tcp://localhost:61616
+jms.broker.url=tcp://localhost:61616
 jms.username=artemis
 jms.password=artemis
 

--- a/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
+++ b/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
@@ -1,22 +1,26 @@
-- errorHandler:
-    deadLetterChannel:
-      deadLetterUri: jms:DLQ
-      redeliveryPolicy:
-        maximumRedeliveries: 2
-      useOriginalBody: true
 - route:
     id: producer-route
     from:
       id: timer-producer
       uri: timer
       parameters:
+        includeMetadata: true
         period: "5000"
+        repeatCount: 3
         timerName: producer
       steps:
         - setBody:
             id: set-message
             simple:
-              expression: Transactional message
+              expression: Transactional message ${exchangeProperty.CamelTimerCounter}
+        - setHeader:
+            id: setHeader-5933
+            name: counter
+            simple:
+              expression: ${exchangeProperty.CamelTimerCounter}
+        - log:
+            id: log-1795
+            message: "Message sent: ${body}"
         - to:
             id: send-to-input
             uri: jms
@@ -63,12 +67,13 @@
               - steps:
                   - log:
                       id: log-error
-                      message: Simulating error - message will be rolled back
+                      message: "Simulating error - message will be rolled back "
                   - throwException:
                       id: throw-error
                       exceptionType: java.lang.RuntimeException
                       message: Simulated processing error
-                simple: ${random(0,10)} > 7
+                simple:
+                  expression: ${header.counter} < 3
 - route:
     id: output-consumer-route
     from:
@@ -93,3 +98,9 @@
         - log:
             id: log-dlq
             message: "Message sent to DLQ after max redeliveries: ${body}"
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:DLQ
+      redeliveryPolicy:
+        maximumRedeliveries: 2
+      useOriginalBody: true

--- a/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsIbmMqTest/forage-connectionfactory.properties
+++ b/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsIbmMqTest/forage-connectionfactory.properties
@@ -1,0 +1,19 @@
+# IbmMQ JMS Configuration with XA Transactions
+jms.kind=ibmmq
+jms.broker.url=mq://localhost:1414/DEV.APP.SVRCONN/QM1
+jms.username=app
+jms.password=passw0rd
+
+# Connection pool settings
+jms.pool.enabled=true
+jms.pool.max.connections=10
+jms.pool.max.sessions.per.connection=500
+jms.pool.idle.timeout.millis=30000
+jms.pool.connection.timeout.millis=30000
+jms.pool.block.if.full=true
+
+# XA Transaction settings
+jms.transaction.enabled=true
+jms.transaction.timeout.seconds=30
+jms.transaction.node.id=node1
+jms.transaction.enable.recovery=true

--- a/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
+++ b/integration-tests/jms/src/test/resources/org/apache/camel/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
@@ -1,0 +1,106 @@
+- route:
+    id: producer-route
+    from:
+      id: timer-producer
+      uri: timer
+      parameters:
+        includeMetadata: true
+        period: "5000"
+        repeatCount: 3
+        timerName: producer
+      steps:
+        - setBody:
+            id: set-message
+            simple:
+              expression: Transactional message ${exchangeProperty.CamelTimerCounter}
+        - setHeader:
+            id: setHeader-5933
+            name: counter
+            simple:
+              expression: ${exchangeProperty.CamelTimerCounter}
+        - log:
+            id: log-1795
+            message: "Message sent: ${body}"
+        - to:
+            id: send-to-input
+            uri: jms
+            parameters:
+              destinationName: input.queue
+              destinationType: queue
+        - log:
+            id: log-sent
+            message: Sent message to input queue
+- route:
+    id: transactional-consumer-route
+    from:
+      id: jms-consumer
+      uri: jms
+      parameters:
+        destinationName: input.queue
+        destinationType: queue
+        transacted: "true"
+      steps:
+        - transacted:
+            id: xa-transaction
+            ref: PROPAGATION_REQUIRED
+        - log:
+            id: log-processing
+            message: "Processing message: ${body}"
+        - choice:
+            id: error-simulation
+            otherwise:
+              id: success-path
+              steps:
+                - log:
+                    id: log-success
+                    message: Processing successful - committing transaction
+                - to:
+                    id: send-to-output
+                    uri: jms
+                    parameters:
+                      destinationName: output.queue
+                      destinationType: queue
+                - log:
+                    id: log-forwarded
+                    message: Message forwarded to output queue
+            when:
+              - steps:
+                  - log:
+                      id: log-error
+                      message: "Simulating error - message will be rolled back "
+                  - throwException:
+                      id: throw-error
+                      exceptionType: java.lang.RuntimeException
+                      message: Simulated processing error
+                simple:
+                  expression: ${header.counter} < 3
+- route:
+    id: output-consumer-route
+    from:
+      id: output-consumer
+      uri: jms
+      parameters:
+        destinationName: output.queue
+        destinationType: queue
+      steps:
+        - log:
+            id: log-processed
+            message: "Successfully processed message: ${body}"
+- route:
+    id: dlq-consumer-route
+    from:
+      id: dlq-consumer
+      uri: jms
+      parameters:
+        destinationName: DLQ2
+        destinationType: queue
+      steps:
+        - log:
+            id: log-dlq
+            message: "Message sent to DLQ after max redeliveries: ${body}"
+- errorHandler:
+    deadLetterChannel:
+      deadLetterUri: jms:DLQ
+      redeliveryPolicy:
+        maximumRedeliveries: 2
+      useOriginalBody: true

--- a/library/jms/camel-quarkus/runtime/pom.xml
+++ b/library/jms/camel-quarkus/runtime/pom.xml
@@ -34,6 +34,12 @@
 
         <dependency>
             <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-jms-ibmmq</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
             <artifactId>forage-jms-artemis</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/library/jms/camel-quarkus/runtime/src/main/java/org/apache/camel/forage/quarkus/jms/ForageJmsConfigSource.java
+++ b/library/jms/camel-quarkus/runtime/src/main/java/org/apache/camel/forage/quarkus/jms/ForageJmsConfigSource.java
@@ -92,6 +92,8 @@ public class ForageJmsConfigSource extends AbstractConfigSource {
                 builder.add(
                         "quarkus.transaction-manager.object-store.directory", config::transactionObjectStoreDirectory);
             }
+        } else if ("ibmmq".equals(config.jmsKind())) {
+            // configuration is created via recorder, na property is required
         } else {
             throw new IllegalArgumentException(
                     "`%s` Jms kind is not supported by Quarkus runtime.".formatted(config.jmsKind()));

--- a/library/jms/camel-quarkus/runtime/src/main/java/org/apache/camel/forage/quarkus/jms/ForageJmsRecorder.java
+++ b/library/jms/camel-quarkus/runtime/src/main/java/org/apache/camel/forage/quarkus/jms/ForageJmsRecorder.java
@@ -1,0 +1,24 @@
+package org.apache.camel.forage.quarkus.jms;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import jakarta.jms.ConnectionFactory;
+import org.apache.camel.forage.jms.ibmmq.IbmMqJms;
+import org.jboss.logging.Logger;
+
+/**
+ * Aggregation repository is created via Recorder
+ */
+@Recorder
+public class ForageJmsRecorder {
+    private static final Logger LOG = Logger.getLogger(ForageJmsRecorder.class);
+
+    public RuntimeValue<ConnectionFactory> createIbmMQConnectionFactory(String id) {
+
+        ConnectionFactory cf = new IbmMqJms().create(id);
+        if (cf != null) {
+            return new RuntimeValue<>(cf);
+        }
+        return null;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <camel-quarkus.version>3.29.0</camel-quarkus.version>
         <citrus.version>4.8.2</citrus.version>
         <groovy.version>4.0.28</groovy.version>
+        <ibmmq-client.version>9.4.3.0</ibmmq-client.version>
         <jackson.version>2.15.2</jackson.version>
         <javaparser.version>3.27.1</javaparser.version>
         <junit-jupiter-suite.version>1.13.4</junit-jupiter-suite.version>
@@ -57,6 +58,7 @@
         <postgres.container.image>mirror.gcr.io/postgres:17.5-alpine</postgres.container.image>
         <mysql.container.image>mirror.gcr.io/mysql:8.4</mysql.container.image>
         <activemq.artemis.container.image>mirror.gcr.io/apache/activemq-artemis:2.44.0</activemq.artemis.container.image>
+        <ibmmq.container.image>icr.io/ibm-messaging/mq:9.4.3.0-r1</ibmmq.container.image>
     </properties>
 
     <dependencyManagement>

--- a/tooling/camel-jbang-plugin-forage/src/main/resources/jms-command.properties
+++ b/tooling/camel-jbang-plugin-forage/src/main/resources/jms-command.properties
@@ -1,5 +1,6 @@
 quarkus=mvn:org.apache.camel.forage:forage-quarkus-jms:@project.version@,mvn:org.apache.camel.forage:forage-quarkus-jms-deployment:@project.version@,mvn:org.apache.camel.quarkus:camel-quarkus-jms:@camel-quarkus.version@
-quarkus.jmsKind=mvn:io.quarkiverse.${jmsKind}:quarkus-${jmsKind}-jms:@quarkus-artemis-jms.version@
+quarkus.artemis=mvn:io.quarkiverse.artemis:quarkus-artemis-jms:@quarkus-artemis-jms.version@
+quarkus.ibmmq=mvn:org.apache.camel.quarkus:camel-quarkus-jta:@camel-quarkus.version@,mvn:io.quarkiverse.messaginghub:quarkus-pooled-jms:@quarkus.version@
 quarkus.pooled-jms=mvn:io.quarkiverse.messaginghub:quarkus-pooled-jms:@quarkus-pooled-jms.version@
 quarkus.narayana-jta=mvn:io.quarkus:quarkus-narayana-jta:@quarkus.version@
 main=mvn:org.apache.camel.forage:forage-jms:@project.version@


### PR DESCRIPTION
Adds quarkus support of ibm mq.
(Ibm mq test is not started by default on CI - because of licence agreement, but could be started with property `-Dibm.mq.container.license=accept` (see README.MD)