### PR TITLE
Fixes #126 - use of proper class loader (to work also in Quarkus)

### DIFF
--- a/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/org/apache/camel/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
+++ b/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/org/apache/camel/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
@@ -59,7 +59,7 @@ class ForageJdbcProcessor {
     void registerAggregation(
             CamelContextBuildItem context, ForageJdbcRecorder recorder, BuildProducer<CamelRuntimeBeanBuildItem> beans)
             throws Exception {
-
+        ConfigStore.getInstance().setClassLoader(Thread.currentThread().getContextClassLoader());
         DataSourceFactoryConfig config = new DataSourceFactoryConfig();
         Set<String> prefixes = ConfigStore.getInstance().readPrefixes(config, "(.+).jdbc\\..*");
 

--- a/library/jdbc/camel-quarkus/jdbc/runtime/src/main/java/org/apache/camel/forage/quarkus/jdbc/ForageJdbcConfigSource.java
+++ b/library/jdbc/camel-quarkus/jdbc/runtime/src/main/java/org/apache/camel/forage/quarkus/jdbc/ForageJdbcConfigSource.java
@@ -18,6 +18,7 @@ public class ForageJdbcConfigSource implements ConfigSource {
         // there is no need to check. whether property already exists, because the priority solves it
 
         // try loading multiDatasource properties
+        ConfigStore.getInstance().setClassLoader(Thread.currentThread().getContextClassLoader());
         DataSourceFactoryConfig config = new DataSourceFactoryConfig();
         Set<String> prefixes =
                 ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jdbc"));

--- a/library/jms/camel-quarkus/runtime/src/main/java/org/apache/camel/forage/quarkus/jms/ForageJmsConfigSource.java
+++ b/library/jms/camel-quarkus/runtime/src/main/java/org/apache/camel/forage/quarkus/jms/ForageJmsConfigSource.java
@@ -15,6 +15,7 @@ public class ForageJmsConfigSource extends AbstractConfigSource {
 
     static {
         // try load named JMS properties
+        ConfigStore.getInstance().setClassLoader(Thread.currentThread().getContextClassLoader());
         ConnectionFactoryConfig config = new ConnectionFactoryConfig();
         Set<String> named = ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jms"));
 

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/AbstractExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/AbstractExportCustomizer.java
@@ -52,7 +52,7 @@ public abstract class AbstractExportCustomizer<T extends Config> implements Expo
                     .readPrefixes(getConfig(), ConfigHelper.getNamedPropertyRegexp(getPrefix()));
 
             if (defaultProperties.isEmpty() && namedProperties.isEmpty()) {
-                Log.warn("No property required for %s (%s) is present. Configuration is not exported!"
+                Log.trace("No property for %s (%s) is present."
                         .formatted(getPrefix(), getConfig().name()));
                 return enabled = false;
             }


### PR DESCRIPTION
fixes https://github.com/megacamelus/camel-forage/issues/126


Call `ConfigStore.class.getResourceAsStream("/" + instance.name() + ".properties");` is replaced with 
```
Thread.currentThread()
                    .getContextClassLoader()
                    .getResourceAsStream("/" + instance.name() + ".properties");`
```
so it works as expected in Quarkus runtime.

I also merged a duplicated method into a single, reusable function.