### PR TITLE
Add AgentBeanFactory for automatic agent registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,6 @@ build/
 ### Mac OS ###
 .DS_Store
 
-.ObjectStore
-.PutObjectStoreDirHeres
+ObjectStore/
+PutObjectStore/
 .citrus-jbang

--- a/library/ai/agents/forage-agent-factories/src/main/java/org/apache/camel/forage/agent/factory/MultiAgentFactory.java
+++ b/library/ai/agents/forage-agent-factories/src/main/java/org/apache/camel/forage/agent/factory/MultiAgentFactory.java
@@ -74,10 +74,7 @@ public class MultiAgentFactory implements AgentFactory {
         return serviceLoader.stream().toList();
     }
 
-    //    @Override
-    public synchronized Agent createAgent(Exchange exchange) throws Exception {
-        final String agentId = AgentIdSelectorHelper.select(config, exchange);
-
+    public synchronized Agent createAgent(Exchange exchange, String agentId) throws Exception {
         if (LOG.isTraceEnabled()) {
             LOG.debug("Available agents: {}", agents);
         }
@@ -105,6 +102,12 @@ public class MultiAgentFactory implements AgentFactory {
         }
 
         throw AgentIdSelectorHelper.newUndefinedAgentException(config, exchange);
+    }
+
+    public synchronized Agent createAgent(Exchange exchange) throws Exception {
+        final String agentId = AgentIdSelectorHelper.select(config, exchange);
+
+        return createAgent(exchange, agentId);
     }
 
     private synchronized Agent newAgent(AgentFactoryConfig agentFactoryConfig, String name) {

--- a/library/ai/agents/forage-agent/pom.xml
+++ b/library/ai/agents/forage-agent/pom.xml
@@ -15,6 +15,27 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-support</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.camel.forage</groupId>
             <artifactId>forage-agent-factories</artifactId>
             <version>${project.version}</version>

--- a/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentBeanFactory.java
+++ b/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentBeanFactory.java
@@ -1,0 +1,99 @@
+package org.apache.camel.forage.agent;
+
+import java.util.List;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.langchain4j.agent.api.Agent;
+import org.apache.camel.forage.agent.factory.DefaultAgentFactory;
+import org.apache.camel.forage.agent.factory.MultiAgentConfig;
+import org.apache.camel.forage.agent.factory.MultiAgentFactory;
+import org.apache.camel.forage.core.annotations.ForageFactory;
+import org.apache.camel.forage.core.common.BeanFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * BeanFactory that registers Agent beans into the CamelContext registry.
+ * Delegates to either DefaultAgentFactory or MultiAgentFactory based on
+ * configuration to create and register agents for use in Camel routes.
+ *
+ * <p>If multi.agent.names is configured, uses MultiAgentFactory for multi-agent
+ * scenarios. Otherwise, uses DefaultAgentFactory for single-agent setups.
+ */
+@ForageFactory(
+        value = "CamelAgentFactory",
+        components = {"camel-langchain4j-agent"},
+        description = "Agent bean factory delegating to DefaultAgentFactory or MultiAgentFactory",
+        factoryType = "Agent",
+        autowired = true)
+public class AgentBeanFactory implements BeanFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(AgentBeanFactory.class);
+
+    private CamelContext camelContext;
+    private static final String DEFAULT_AGENT = "agent";
+
+    @Override
+    public void configure() {
+        MultiAgentConfig multiAgentConfig = new MultiAgentConfig();
+        List<String> multiAgentNames = multiAgentConfig.multiAgentNames();
+
+        if (multiAgentNames != null && !multiAgentNames.isEmpty()) {
+            try {
+                configureMultiAgent(multiAgentNames);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(e);
+            }
+        } else {
+            configureSingleAgent();
+        }
+    }
+
+    private void configureMultiAgent(List<String> agentNames) throws Exception {
+        LOG.info("Configuring multi-agent mode with agents: {}", agentNames);
+
+        MultiAgentFactory multiAgentFactory = new MultiAgentFactory();
+        multiAgentFactory.setCamelContext(camelContext);
+
+        // Pre-create and register individual agents for each configured name
+        for (String agentName : agentNames) {
+            if (camelContext.getRegistry().lookupByNameAndType(agentName, Agent.class) == null) {
+
+                Agent agent = multiAgentFactory.createAgent(null, agentName);
+                if (agent != null) {
+                    camelContext.getRegistry().bind(agentName, agent);
+                    LOG.info("Registered Agent bean with name: {}", agentName);
+                }
+            }
+        }
+    }
+
+    private void configureSingleAgent() {
+        LOG.info("Configuring single-agent mode");
+
+        DefaultAgentFactory defaultAgentFactory = new DefaultAgentFactory();
+        defaultAgentFactory.setCamelContext(camelContext);
+
+        // Create and register a default agent
+        if (camelContext.getRegistry().lookupByNameAndType(DEFAULT_AGENT, Agent.class) == null) {
+            try {
+                Agent agent = defaultAgentFactory.createAgent();
+                if (agent != null) {
+                    camelContext.getRegistry().bind(DEFAULT_AGENT, agent);
+                    LOG.info("Registered default Agent bean with name: {}", DEFAULT_AGENT);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to create default agent: {}", e.getMessage());
+                LOG.debug("Agent creation exception details", e);
+            }
+        }
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+}

--- a/library/ai/agents/forage-agent/src/main/resources/META-INF/services/org.apache.camel.forage.core.common.BeanFactory
+++ b/library/ai/agents/forage-agent/src/main/resources/META-INF/services/org.apache.camel.forage.core.common.BeanFactory
@@ -1,0 +1,1 @@
+org.apache.camel.forage.agent.AgentBeanFactory

--- a/library/jdbc/forage-jdbc-test/src/test/java/org/apache/camel/forage/jdbc/OracleDataSourceTest.java
+++ b/library/jdbc/forage-jdbc-test/src/test/java/org/apache/camel/forage/jdbc/OracleDataSourceTest.java
@@ -44,7 +44,7 @@ public class OracleDataSourceTest extends DataSourceTest {
     protected void validateTestQueryResult(ResultSet rs) throws SQLException {
         rs.next();
 
-        Assertions.assertThat(rs.getString(1)).contains("Oracle Database");
+        Assertions.assertThat(rs.getString(1)).contains("Oracle");
     }
 
     @Test


### PR DESCRIPTION
Introduces AgentBeanFactory that registers Agent beans into the CamelContext registry at startup. Delegates to DefaultAgentFactory or MultiAgentFactory based on configuration.

Fixes #92