### PR TITLE
Align Agent structure and usage to JDBC and JMS

### DIFF
--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/util/config/ConfigStore.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/util/config/ConfigStore.java
@@ -368,6 +368,35 @@ public final class ConfigStore {
         properties.put(module, value);
     }
 
+    /**
+     * Sets a configuration value directly by string key.
+     *
+     * <p>This method bypasses the ConfigModule lookup and stores the value directly
+     * in the internal properties using the provided key. This is useful when mapping
+     * configuration values between different namespaces.
+     *
+     * @param key the configuration key (e.g., "google.api.key")
+     * @param value the configuration value to store
+     * @since 1.0
+     */
+    public void setDirect(String key, String value) {
+        properties.put(key, value);
+    }
+
+    /**
+     * Gets a configuration value directly by string key.
+     *
+     * <p>This method bypasses the ConfigModule lookup and retrieves the value directly
+     * from the internal properties using the provided key.
+     *
+     * @param key the configuration key (e.g., "google.api.key")
+     * @return an Optional containing the value if present, or empty if not found
+     * @since 1.0
+     */
+    public Optional<String> getDirect(String key) {
+        return Optional.ofNullable((String) properties.get(key));
+    }
+
     public ClassLoader getClassLoader() {
         return classLoader;
     }

--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>forage-agent-factories</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-agent</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Vector Database Modules -->
         <dependency>

--- a/library/ai/agents/forage-agent-factories/src/main/java/org/apache/camel/forage/agent/factory/DefaultAgentFactory.java
+++ b/library/ai/agents/forage-agent-factories/src/main/java/org/apache/camel/forage/agent/factory/DefaultAgentFactory.java
@@ -9,7 +9,6 @@ import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
 import org.apache.camel.component.langchain4j.agent.api.AgentFactory;
 import org.apache.camel.forage.core.ai.ChatMemoryBeanProvider;
 import org.apache.camel.forage.core.ai.ModelProvider;
-import org.apache.camel.forage.core.annotations.ForageFactory;
 import org.apache.camel.forage.core.util.config.ConfigStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,11 +16,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Default implementation of AgentFactory that uses ServiceLoader to discover and create agents
  */
-@ForageFactory(
-        value = "default-agent",
-        components = {"camel-langchain4j-agent"},
-        description = "Default agent factory with ServiceLoader discovery",
-        factoryType = "Agent")
 public class DefaultAgentFactory implements AgentFactory {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultAgentFactory.class);
 

--- a/library/ai/agents/forage-agent-factories/src/main/java/org/apache/camel/forage/agent/factory/MultiAgentFactory.java
+++ b/library/ai/agents/forage-agent-factories/src/main/java/org/apache/camel/forage/agent/factory/MultiAgentFactory.java
@@ -13,7 +13,6 @@ import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
 import org.apache.camel.component.langchain4j.agent.api.AgentFactory;
 import org.apache.camel.forage.core.ai.ChatMemoryBeanProvider;
 import org.apache.camel.forage.core.ai.ModelProvider;
-import org.apache.camel.forage.core.annotations.ForageFactory;
 import org.apache.camel.forage.core.common.ServiceLoaderHelper;
 import org.apache.camel.forage.core.util.config.ConfigStore;
 import org.slf4j.Logger;
@@ -22,11 +21,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation of AgentFactory that uses ServiceLoader to discover and create multiple agents
  */
-@ForageFactory(
-        value = "multi-agent",
-        components = {"camel-langchain4j-agent"},
-        description = "Multi-agent factory with ServiceLoader discovery and configuration-based selection",
-        factoryType = "Agent")
 public class MultiAgentFactory implements AgentFactory {
     private static final Logger LOG = LoggerFactory.getLogger(MultiAgentFactory.class);
 

--- a/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentBeanFactory.java
+++ b/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentBeanFactory.java
@@ -1,28 +1,51 @@
 package org.apache.camel.forage.agent;
 
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
 import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.langchain4j.agent.api.Agent;
-import org.apache.camel.forage.agent.factory.DefaultAgentFactory;
-import org.apache.camel.forage.agent.factory.MultiAgentConfig;
-import org.apache.camel.forage.agent.factory.MultiAgentFactory;
+import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
+import org.apache.camel.forage.agent.factory.ConfigurationAware;
+import org.apache.camel.forage.core.ai.ChatMemoryBeanProvider;
+import org.apache.camel.forage.core.ai.ModelProvider;
+import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.core.annotations.ForageFactory;
 import org.apache.camel.forage.core.common.BeanFactory;
+import org.apache.camel.forage.core.util.config.ConfigStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * BeanFactory that registers Agent beans into the CamelContext registry.
- * Delegates to either DefaultAgentFactory or MultiAgentFactory based on
- * configuration to create and register agents for use in Camel routes.
  *
- * <p>If multi.agent.names is configured, uses MultiAgentFactory for multi-agent
- * scenarios. Otherwise, uses DefaultAgentFactory for single-agent setups.
+ * <p>Uses prefix auto-detection like JDBC and JMS factories. Agent prefixes are
+ * detected from properties matching pattern {@code {prefix}.agent.*}.
+ *
+ * <p>Example configurations:
+ * <pre>
+ * # Single agent (no prefix needed)
+ * agent.model.kind=ollama
+ * agent.base.url=http://localhost:11434
+ * agent.model.name=llama3
+ *
+ * # Multiple agents (prefixes auto-detected)
+ * google.agent.model.kind=google-gemini
+ * google.agent.api.key=your-key
+ * google.agent.model.name=gemini-2.0-flash
+ *
+ * ollama.agent.model.kind=ollama
+ * ollama.agent.base.url=http://localhost:11434
+ * ollama.agent.model.name=llama3
+ * </pre>
  */
 @ForageFactory(
         value = "CamelAgentFactory",
         components = {"camel-langchain4j-agent"},
-        description = "Agent bean factory delegating to DefaultAgentFactory or MultiAgentFactory",
+        description = "Agent bean factory with prefix auto-detection like JDBC/JMS",
         factoryType = "Agent",
         autowired = true)
 public class AgentBeanFactory implements BeanFactory {
@@ -30,52 +53,48 @@ public class AgentBeanFactory implements BeanFactory {
 
     private CamelContext camelContext;
     private static final String DEFAULT_AGENT = "agent";
+    private static final String FEATURE_MEMORY = "memory";
 
     @Override
     public void configure() {
-        MultiAgentConfig multiAgentConfig = new MultiAgentConfig();
-        List<String> multiAgentNames = multiAgentConfig.multiAgentNames();
+        AgentConfig defaultConfig = new AgentConfig();
 
-        if (multiAgentNames != null && !multiAgentNames.isEmpty()) {
-            try {
-                configureMultiAgent(multiAgentNames);
-            } catch (Exception e) {
-                throw new IllegalArgumentException(e);
-            }
+        // Auto-detect prefixes from properties like "google.agent.*", "ollama.agent.*"
+        Set<String> prefixes = ConfigStore.getInstance().readPrefixes(defaultConfig, "(.+)\\.agent\\..*");
+
+        if (!prefixes.isEmpty()) {
+            LOG.info("Detected agent prefixes: {}", prefixes);
+            configureMultiAgent(prefixes);
+        } else if (defaultConfig.modelKind() != null) {
+            LOG.info("Configuring single agent with model kind: {}", defaultConfig.modelKind());
+            configureSingleAgent(defaultConfig);
         } else {
-            configureSingleAgent();
+            LOG.debug("No agent configuration found, skipping agent registration");
         }
     }
 
-    private void configureMultiAgent(List<String> agentNames) throws Exception {
-        LOG.info("Configuring multi-agent mode with agents: {}", agentNames);
-
-        MultiAgentFactory multiAgentFactory = new MultiAgentFactory();
-        multiAgentFactory.setCamelContext(camelContext);
-
-        // Pre-create and register individual agents for each configured name
-        for (String agentName : agentNames) {
+    private void configureMultiAgent(Set<String> prefixes) {
+        for (String agentName : prefixes) {
             if (camelContext.getRegistry().lookupByNameAndType(agentName, Agent.class) == null) {
-
-                Agent agent = multiAgentFactory.createAgent(null, agentName);
-                if (agent != null) {
-                    camelContext.getRegistry().bind(agentName, agent);
-                    LOG.info("Registered Agent bean with name: {}", agentName);
+                try {
+                    AgentConfig agentConfig = new AgentConfig(agentName);
+                    Agent agent = createAgent(agentConfig, agentName);
+                    if (agent != null) {
+                        camelContext.getRegistry().bind(agentName, agent);
+                        LOG.info("Registered Agent bean with name: {}", agentName);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to create agent '{}': {}", agentName, e.getMessage());
+                    LOG.debug("Agent creation exception details", e);
                 }
             }
         }
     }
 
-    private void configureSingleAgent() {
-        LOG.info("Configuring single-agent mode");
-
-        DefaultAgentFactory defaultAgentFactory = new DefaultAgentFactory();
-        defaultAgentFactory.setCamelContext(camelContext);
-
-        // Create and register a default agent
+    private void configureSingleAgent(AgentConfig config) {
         if (camelContext.getRegistry().lookupByNameAndType(DEFAULT_AGENT, Agent.class) == null) {
             try {
-                Agent agent = defaultAgentFactory.createAgent();
+                Agent agent = createAgent(config, DEFAULT_AGENT);
                 if (agent != null) {
                     camelContext.getRegistry().bind(DEFAULT_AGENT, agent);
                     LOG.info("Registered default Agent bean with name: {}", DEFAULT_AGENT);
@@ -87,9 +106,176 @@ public class AgentBeanFactory implements BeanFactory {
         }
     }
 
+    private Agent createAgent(AgentConfig config, String name) {
+        String modelKind = config.modelKind();
+        if (modelKind == null) {
+            LOG.warn("No model kind configured for agent '{}'", name);
+            return null;
+        }
+
+        LOG.info("Creating agent '{}' with model kind: {}", name, modelKind);
+
+        // Create chat model
+        ChatModel chatModel = createChatModel(config, modelKind, name);
+        if (chatModel == null) {
+            LOG.warn("Failed to create chat model for agent '{}'", name);
+            return null;
+        }
+
+        // Create memory provider if enabled
+        ChatMemoryProvider chatMemoryProvider = null;
+        if (config.hasFeature(FEATURE_MEMORY)) {
+            String memoryKind = config.memoryKind();
+            if (memoryKind != null) {
+                chatMemoryProvider = createMemoryProvider(config, memoryKind);
+            } else {
+                // Default to message-window memory
+                chatMemoryProvider = createDefaultMemoryProvider(config);
+            }
+        }
+
+        // Find and create agent using ServiceLoader
+        Agent agent = findAndCreateAgent();
+        if (agent == null) {
+            LOG.warn("No Agent implementation found in classpath");
+            return null;
+        }
+
+        // Configure the agent
+        if (agent instanceof ConfigurationAware configurationAware) {
+            AgentConfiguration agentConfiguration = new AgentConfiguration();
+            agentConfiguration.withChatModel(chatModel).withChatMemoryProvider(chatMemoryProvider);
+            configurationAware.configure(agentConfiguration);
+        }
+
+        return agent;
+    }
+
+    private ChatModel createChatModel(AgentConfig config, String modelKind, String agentName) {
+        // Find model provider by kind using ServiceLoader
+        List<ServiceLoader.Provider<ModelProvider>> providers = findModelProviders();
+
+        for (ServiceLoader.Provider<ModelProvider> provider : providers) {
+            Class<? extends ModelProvider> providerClass = provider.type();
+            ForageBean annotation = providerClass.getAnnotation(ForageBean.class);
+            if (annotation != null && annotation.value().equals(modelKind)) {
+                LOG.debug("Found model provider for kind '{}': {}", modelKind, providerClass.getName());
+                ModelProvider modelProvider = provider.get();
+
+                // Create model using unified config
+                return createChatModelFromConfig(config, modelKind, modelProvider, agentName);
+            }
+        }
+
+        LOG.warn("No model provider found for kind: {}", modelKind);
+        return null;
+    }
+
+    private ChatModel createChatModelFromConfig(
+            AgentConfig config, String modelKind, ModelProvider modelProvider, String agentName) {
+        // Map unified agent config values to provider-specific config keys
+        // Provider configs expect keys like: {prefix}.{provider}.api.key
+        // We have values in: {prefix}.agent.api.key
+        // So we need to set system properties that the provider's loadOverrides will pick up
+
+        String providerPrefix = getProviderConfigPrefix(modelKind);
+        String prefix = DEFAULT_AGENT.equals(agentName) ? null : agentName;
+
+        // Set provider config values as system properties (provider's loadOverrides will pick these up)
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "api.key", config.apiKey());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "model.name", config.modelName());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "base.url", config.baseUrl());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "temperature", config.temperature());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "max.tokens", config.maxTokens());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "top.p", config.topP());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "top.k", config.topK());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "endpoint", config.endpoint());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "deployment.name", config.deploymentName());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "log.requests", config.logRequests());
+        setSystemPropertyIfNotNull(prefix, providerPrefix, "log.responses", config.logResponses());
+
+        return modelProvider.create(prefix);
+    }
+
+    private void setSystemPropertyIfNotNull(String prefix, String providerPrefix, String key, Object value) {
+        if (value != null) {
+            String fullKey = prefix != null ? prefix + "." + providerPrefix + "." + key : providerPrefix + "." + key;
+            System.setProperty(fullKey, String.valueOf(value));
+            LOG.trace("Set system property: {}={}", fullKey, value);
+        }
+    }
+
+    private String getProviderConfigPrefix(String modelKind) {
+        // Map model kind to provider config prefix
+        return switch (modelKind) {
+            case "google-gemini" -> "google";
+            case "azure-openai" -> "azure.openai";
+            case "openai" -> "openai";
+            case "ollama" -> "ollama";
+            case "anthropic" -> "anthropic";
+            case "mistral-ai" -> "mistral";
+            case "hugging-face" -> "huggingface";
+            case "watsonx-ai" -> "watsonx";
+            case "local-ai" -> "localai";
+            case "dashscope" -> "dashscope";
+            default -> modelKind.replace("-", ".");
+        };
+    }
+
+    private ChatMemoryProvider createMemoryProvider(AgentConfig config, String memoryKind) {
+        List<ServiceLoader.Provider<ChatMemoryBeanProvider>> providers = findMemoryProviders();
+
+        for (ServiceLoader.Provider<ChatMemoryBeanProvider> provider : providers) {
+            Class<? extends ChatMemoryBeanProvider> providerClass = provider.type();
+            ForageBean annotation = providerClass.getAnnotation(ForageBean.class);
+            if (annotation != null && annotation.value().equals(memoryKind)) {
+                LOG.debug("Found memory provider for kind '{}': {}", memoryKind, providerClass.getName());
+                ChatMemoryBeanProvider memoryProvider = provider.get();
+                return memoryProvider.create();
+            }
+        }
+
+        LOG.warn("No memory provider found for kind '{}', using default", memoryKind);
+        return createDefaultMemoryProvider(config);
+    }
+
+    private ChatMemoryProvider createDefaultMemoryProvider(AgentConfig config) {
+        int maxMessages = config.memoryMaxMessages();
+        return memoryId -> MessageWindowChatMemory.builder()
+                .id(memoryId)
+                .maxMessages(maxMessages)
+                .build();
+    }
+
+    private Agent findAndCreateAgent() {
+        List<ServiceLoader.Provider<Agent>> providers = findAgents();
+        if (!providers.isEmpty()) {
+            return providers.get(0).get();
+        }
+        return null;
+    }
+
+    private List<ServiceLoader.Provider<ModelProvider>> findModelProviders() {
+        ServiceLoader<ModelProvider> loader =
+                ServiceLoader.load(ModelProvider.class, camelContext.getApplicationContextClassLoader());
+        return loader.stream().toList();
+    }
+
+    private List<ServiceLoader.Provider<ChatMemoryBeanProvider>> findMemoryProviders() {
+        ServiceLoader<ChatMemoryBeanProvider> loader =
+                ServiceLoader.load(ChatMemoryBeanProvider.class, camelContext.getApplicationContextClassLoader());
+        return loader.stream().toList();
+    }
+
+    private List<ServiceLoader.Provider<Agent>> findAgents() {
+        ServiceLoader<Agent> loader = ServiceLoader.load(Agent.class, camelContext.getApplicationContextClassLoader());
+        return loader.stream().toList();
+    }
+
     @Override
     public void setCamelContext(CamelContext camelContext) {
         this.camelContext = camelContext;
+        ConfigStore.getInstance().setClassLoader(camelContext.getApplicationContextClassLoader());
     }
 
     @Override

--- a/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentConfig.java
+++ b/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentConfig.java
@@ -1,0 +1,179 @@
+package org.apache.camel.forage.agent;
+
+import static org.apache.camel.forage.agent.AgentConfigEntries.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+
+/**
+ * Unified configuration class for agent factory.
+ *
+ * <p>This configuration class manages all agent settings under the unified {@code agent.*}
+ * namespace, following the same pattern as JDBC and JMS configurations.
+ *
+ * <p>Supports both default configurations and prefixed configurations for multi-agent scenarios.
+ * Prefixes are auto-detected from properties like {@code myagent.agent.model.kind}.
+ */
+public class AgentConfig implements Config {
+
+    private final String prefix;
+
+    public AgentConfig() {
+        this(null);
+    }
+
+    public AgentConfig(String prefix) {
+        this.prefix = prefix;
+
+        AgentConfigEntries.register(prefix);
+        ConfigStore.getInstance().load(AgentConfig.class, this, this::register);
+        AgentConfigEntries.loadOverrides(prefix);
+    }
+
+    @Override
+    public void register(String name, String value) {
+        Optional<ConfigModule> config = AgentConfigEntries.find(prefix, name);
+        config.ifPresent(module -> ConfigStore.getInstance().set(module, value));
+    }
+
+    @Override
+    public String name() {
+        return "forage-agent-factory";
+    }
+
+    // Core configuration
+
+    public String modelKind() {
+        return ConfigStore.getInstance().get(MODEL_KIND.asNamed(prefix)).orElse(null);
+    }
+
+    public List<String> features() {
+        return ConfigStore.getInstance()
+                .get(FEATURES.asNamed(prefix))
+                .map(s -> Arrays.asList(s.split(",")))
+                .orElse(Collections.emptyList());
+    }
+
+    public boolean hasFeature(String feature) {
+        return features().contains(feature);
+    }
+
+    public String memoryKind() {
+        return ConfigStore.getInstance().get(MEMORY_KIND.asNamed(prefix)).orElse(null);
+    }
+
+    // Common model configuration
+
+    public String apiKey() {
+        return ConfigStore.getInstance().get(API_KEY.asNamed(prefix)).orElse(null);
+    }
+
+    public String baseUrl() {
+        return ConfigStore.getInstance().get(BASE_URL.asNamed(prefix)).orElse(null);
+    }
+
+    public String modelName() {
+        return ConfigStore.getInstance().get(MODEL_NAME.asNamed(prefix)).orElse(null);
+    }
+
+    public Double temperature() {
+        return ConfigStore.getInstance()
+                .get(TEMPERATURE.asNamed(prefix))
+                .map(Double::parseDouble)
+                .orElse(null);
+    }
+
+    public Integer maxTokens() {
+        return ConfigStore.getInstance()
+                .get(MAX_TOKENS.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(null);
+    }
+
+    public Double topP() {
+        return ConfigStore.getInstance()
+                .get(TOP_P.asNamed(prefix))
+                .map(Double::parseDouble)
+                .orElse(null);
+    }
+
+    public Integer topK() {
+        return ConfigStore.getInstance()
+                .get(TOP_K.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(null);
+    }
+
+    // Azure OpenAI specific
+
+    public String endpoint() {
+        return ConfigStore.getInstance().get(ENDPOINT.asNamed(prefix)).orElse(null);
+    }
+
+    public String deploymentName() {
+        return ConfigStore.getInstance().get(DEPLOYMENT_NAME.asNamed(prefix)).orElse(null);
+    }
+
+    // Logging
+
+    public Boolean logRequests() {
+        return ConfigStore.getInstance()
+                .get(LOG_REQUESTS.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(null);
+    }
+
+    public Boolean logResponses() {
+        return ConfigStore.getInstance()
+                .get(LOG_RESPONSES.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(null);
+    }
+
+    // Memory configuration
+
+    public Integer memoryMaxMessages() {
+        return ConfigStore.getInstance()
+                .get(MEMORY_MAX_MESSAGES.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(20);
+    }
+
+    // Redis memory
+
+    public String memoryRedisHost() {
+        return ConfigStore.getInstance().get(MEMORY_REDIS_HOST.asNamed(prefix)).orElse("localhost");
+    }
+
+    public Integer memoryRedisPort() {
+        return ConfigStore.getInstance()
+                .get(MEMORY_REDIS_PORT.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(6379);
+    }
+
+    public String memoryRedisPassword() {
+        return ConfigStore.getInstance()
+                .get(MEMORY_REDIS_PASSWORD.asNamed(prefix))
+                .orElse(null);
+    }
+
+    // Infinispan memory
+
+    public String memoryInfinispanServerList() {
+        return ConfigStore.getInstance()
+                .get(MEMORY_INFINISPAN_SERVER_LIST.asNamed(prefix))
+                .orElse("localhost:11222");
+    }
+
+    public String memoryInfinispanCacheName() {
+        return ConfigStore.getInstance()
+                .get(MEMORY_INFINISPAN_CACHE_NAME.asNamed(prefix))
+                .orElse("chat-memory");
+    }
+}

--- a/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentConfigEntries.java
+++ b/library/ai/agents/forage-agent/src/main/java/org/apache/camel/forage/agent/AgentConfigEntries.java
@@ -1,0 +1,304 @@
+package org.apache.camel.forage.agent;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.camel.forage.core.util.config.ConfigEntries;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigTag;
+
+/**
+ * Unified configuration entries for agent factory.
+ *
+ * <p>This class defines all configuration modules under the unified {@code agent.*} namespace,
+ * following the same pattern as JDBC ({@code jdbc.*}) and JMS ({@code jms.*}).
+ *
+ * <p>Example configuration:
+ * <pre>
+ * # Single agent (no prefix)
+ * agent.model.kind=ollama
+ * agent.base.url=http://localhost:11434
+ * agent.model.name=llama3
+ *
+ * # Multiple agents (with prefix, auto-detected)
+ * google.agent.model.kind=google-gemini
+ * google.agent.features=memory
+ * google.agent.memory.kind=message-window
+ * google.agent.api.key=your-api-key
+ * google.agent.model.name=gemini-2.0-flash
+ *
+ * ollama.agent.model.kind=ollama
+ * ollama.agent.base.url=http://localhost:11434
+ * ollama.agent.model.name=llama3
+ * </pre>
+ */
+public final class AgentConfigEntries extends ConfigEntries {
+
+    // Core agent configuration
+    public static final ConfigModule MODEL_KIND = ConfigModule.of(
+            AgentConfig.class,
+            "agent.model.kind",
+            "The model provider kind (e.g., ollama, openai, google-gemini, azure-openai, anthropic)",
+            "Model Kind",
+            null,
+            "bean-name",
+            true,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule FEATURES = ConfigModule.of(
+            AgentConfig.class,
+            "agent.features",
+            "Comma-separated list of enabled features (e.g., memory)",
+            "Features",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule MEMORY_KIND = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.kind",
+            "The memory provider kind (e.g., message-window, redis, infinispan)",
+            "Memory Kind",
+            null,
+            "bean-name",
+            false,
+            ConfigTag.COMMON);
+
+    // Common model configuration (shared across providers)
+    public static final ConfigModule API_KEY = ConfigModule.of(
+            AgentConfig.class,
+            "agent.api.key",
+            "API key for authentication with the model provider",
+            "API Key",
+            null,
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule BASE_URL = ConfigModule.of(
+            AgentConfig.class,
+            "agent.base.url",
+            "Base URL for the model provider API",
+            "Base URL",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule MODEL_NAME = ConfigModule.of(
+            AgentConfig.class,
+            "agent.model.name",
+            "The specific model name to use",
+            "Model Name",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule TEMPERATURE = ConfigModule.of(
+            AgentConfig.class,
+            "agent.temperature",
+            "Temperature for response randomness (0.0-2.0)",
+            "Temperature",
+            null,
+            "double",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule MAX_TOKENS = ConfigModule.of(
+            AgentConfig.class,
+            "agent.max.tokens",
+            "Maximum number of tokens in the response",
+            "Max Tokens",
+            null,
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule TOP_P = ConfigModule.of(
+            AgentConfig.class,
+            "agent.top.p",
+            "Top-P (nucleus) sampling parameter (0.0-1.0)",
+            "Top P",
+            null,
+            "double",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule TOP_K = ConfigModule.of(
+            AgentConfig.class,
+            "agent.top.k",
+            "Top-K sampling parameter",
+            "Top K",
+            null,
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    // Azure OpenAI specific
+    public static final ConfigModule ENDPOINT = ConfigModule.of(
+            AgentConfig.class,
+            "agent.endpoint",
+            "Azure OpenAI resource endpoint URL",
+            "Endpoint",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule DEPLOYMENT_NAME = ConfigModule.of(
+            AgentConfig.class,
+            "agent.deployment.name",
+            "Azure OpenAI deployment name",
+            "Deployment Name",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    // Logging
+    public static final ConfigModule LOG_REQUESTS = ConfigModule.of(
+            AgentConfig.class,
+            "agent.log.requests",
+            "Enable request logging",
+            "Log Requests",
+            null,
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule LOG_RESPONSES = ConfigModule.of(
+            AgentConfig.class,
+            "agent.log.responses",
+            "Enable response logging",
+            "Log Responses",
+            null,
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    // Memory configuration
+    public static final ConfigModule MEMORY_MAX_MESSAGES = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.max.messages",
+            "Maximum number of messages to retain in memory",
+            "Max Messages",
+            "20",
+            "integer",
+            false,
+            ConfigTag.COMMON);
+
+    // Redis memory
+    public static final ConfigModule MEMORY_REDIS_HOST = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.redis.host",
+            "Redis server hostname",
+            "Redis Host",
+            "localhost",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule MEMORY_REDIS_PORT = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.redis.port",
+            "Redis server port",
+            "Redis Port",
+            "6379",
+            "integer",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule MEMORY_REDIS_PASSWORD = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.redis.password",
+            "Redis authentication password",
+            "Redis Password",
+            null,
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    // Infinispan memory
+    public static final ConfigModule MEMORY_INFINISPAN_SERVER_LIST = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.infinispan.server-list",
+            "Comma-separated list of Infinispan servers",
+            "Server List",
+            "localhost:11222",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule MEMORY_INFINISPAN_CACHE_NAME = ConfigModule.of(
+            AgentConfig.class,
+            "agent.memory.infinispan.cache-name",
+            "Infinispan cache name for storing messages",
+            "Cache Name",
+            "chat-memory",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new ConcurrentHashMap<>();
+
+    static {
+        init();
+    }
+
+    static void init() {
+        // Core
+        CONFIG_MODULES.put(MODEL_KIND, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(FEATURES, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MEMORY_KIND, ConfigEntry.fromModule());
+
+        // Common model config
+        CONFIG_MODULES.put(API_KEY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(BASE_URL, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MODEL_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TEMPERATURE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MAX_TOKENS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TOP_P, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TOP_K, ConfigEntry.fromModule());
+
+        // Azure specific
+        CONFIG_MODULES.put(ENDPOINT, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(DEPLOYMENT_NAME, ConfigEntry.fromModule());
+
+        // Logging
+        CONFIG_MODULES.put(LOG_REQUESTS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(LOG_RESPONSES, ConfigEntry.fromModule());
+
+        // Memory
+        CONFIG_MODULES.put(MEMORY_MAX_MESSAGES, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MEMORY_REDIS_HOST, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MEMORY_REDIS_PORT, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MEMORY_REDIS_PASSWORD, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MEMORY_INFINISPAN_SERVER_LIST, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MEMORY_INFINISPAN_CACHE_NAME, ConfigEntry.fromModule());
+    }
+
+    public static Map<ConfigModule, ConfigEntry> entries() {
+        return Collections.unmodifiableMap(CONFIG_MODULES);
+    }
+
+    public static Optional<ConfigModule> find(String prefix, String name) {
+        return find(CONFIG_MODULES, prefix, name);
+    }
+
+    public static void register(String prefix) {
+        if (prefix != null) {
+            for (Map.Entry<ConfigModule, ConfigEntry> entry : entries().entrySet()) {
+                ConfigModule configModule = entry.getKey().asNamed(prefix);
+                CONFIG_MODULES.put(configModule, ConfigEntry.fromModule());
+            }
+        }
+    }
+
+    public static void loadOverrides(String prefix) {
+        load(CONFIG_MODULES, prefix);
+    }
+}


### PR DESCRIPTION
the beans are created and bind to the context, moreover, I've aligned the structure of the properties file, similar to the jdbc/jms, the base structure is the following now
`<id>.agent.*=..`
This way, only one file is needed forage-agent-factory.properties for example with content
```
# Google Gemini agent with message-window memory
foo.agent.model.kind=google-gemini
foo.agent.model.name=gemini-2.5-flash-lite
# Alternatively, you can also export it via env vars on the shell: GOOGLE_API_KEY=<value>
foo.agent.api.key=<my-api-key>
foo.agent.features=memory
foo.agent.memory.kind=message-window
foo.agent.memory.max.messages=20

# Ollama agent without memory
bar.agent.model.kind=ollama
bar.agent.model.name=granite4:3b
bar.agent.base.url=http://localhost:11434/
```