### PR TITLE
A BeanFactory may bind multiple beans. Add this behaviour in the Fora…

### DIFF
--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/annotations/ConditionalBean.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/annotations/ConditionalBean.java
@@ -1,0 +1,51 @@
+package org.apache.camel.forage.core.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a bean that is conditionally registered based on configuration.
+ *
+ * This annotation is used within {@link ConditionalBeans} to declare individual beans
+ * that are automatically created when certain configuration options are enabled.
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface ConditionalBean {
+
+    /**
+     * The fixed bean name that will be registered in the Camel context.
+     * Mutually exclusive with {@link #nameFromConfig()}.
+     *
+     * @return the bean name
+     */
+    String name() default "";
+
+    /**
+     * The config entry that provides the bean name dynamically.
+     * Mutually exclusive with {@link #name()}.
+     *
+     * @return the config entry name that holds the bean name
+     */
+    String nameFromConfig() default "";
+
+    /**
+     * The Java type of the bean as a fully qualified class name.
+     * This should be the interface or API type that users would reference,
+     * not the internal implementation class.
+     *
+     * @return the fully qualified Java type name
+     */
+    String javaType();
+
+    /**
+     * Human-readable description of what this bean provides.
+     *
+     * @return the description
+     */
+    String description() default "";
+}

--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/annotations/ConditionalBeanGroup.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/annotations/ConditionalBeanGroup.java
@@ -1,0 +1,48 @@
+package org.apache.camel.forage.core.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a group of beans that are conditionally registered when a boolean config entry is enabled.
+ *
+ * This annotation is used within {@link ForageFactory#conditionalBeans()} to declare beans
+ * that are automatically created when certain configuration options are enabled.
+ * The catalog generator uses this to inform UI wizards (read-only, informational).
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface ConditionalBeanGroup {
+
+    /**
+     * Unique identifier for this conditional bean group.
+     *
+     * @return the group identifier
+     */
+    String id();
+
+    /**
+     * Human-readable description of what these beans provide.
+     *
+     * @return the description
+     */
+    String description() default "";
+
+    /**
+     * The boolean config entry that triggers bean creation when set to true.
+     * For example: "jdbc.transaction.enabled"
+     *
+     * @return the config entry name
+     */
+    String configEntry();
+
+    /**
+     * The beans that are created when the condition is met.
+     *
+     * @return array of conditional bean definitions
+     */
+    ConditionalBean[] beans();
+}

--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/annotations/ForageFactory.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/annotations/ForageFactory.java
@@ -52,4 +52,12 @@ public @interface ForageFactory {
      * @return
      */
     boolean autowired() default false;
+
+    /**
+     * Conditional beans that are automatically registered when certain config entries are enabled.
+     * Used by the catalog generator to inform UI wizards about beans created based on configuration.
+     *
+     * @return array of conditional bean groups
+     */
+    ConditionalBeanGroup[] conditionalBeans() default {};
 }

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
@@ -3,6 +3,7 @@ package org.apache.camel.forage.jdbc.common;
 import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.ACQUISITION_TIMEOUT_SECONDS;
 import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_ALLOW_SERIALIZED_HEADERS;
 import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_DEAD_LETTER_URI;
+import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_ENABLED;
 import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_HEADERS_TO_STORE;
 import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_MAXIMUM_REDELIVERIES;
 import static org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_NAME;
@@ -296,6 +297,13 @@ public class DataSourceFactoryConfig implements Config {
         return ConfigStore.getInstance()
                 .get(AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME.asNamed(prefix))
                 .orElse(null);
+    }
+
+    public boolean aggregationRepositoryEnabled() {
+        return ConfigStore.getInstance()
+                .get(AGGREGATION_REPOSITORY_ENABLED.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(Boolean.parseBoolean(AGGREGATION_REPOSITORY_ENABLED.defaultValue()));
     }
 
     public boolean enableIdempotentRepository() {

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
@@ -357,6 +357,16 @@ public final class DataSourceFactoryConfigEntries extends ConfigEntries {
             false,
             ConfigTag.ADVANCED);
 
+    public static final ConfigModule AGGREGATION_REPOSITORY_ENABLED = ConfigModule.of(
+            DataSourceFactoryConfig.class,
+            "jdbc.aggregation.repository.enabled",
+            "Enable aggregation repository (requires transactions to be enabled)",
+            "Aggregation Repository Enabled",
+            "false",
+            "boolean",
+            false,
+            ConfigTag.COMMON);
+
     public static final ConfigModule ENABLE_IDEMPOTENT_REPOSITORY = ConfigModule.of(
             DataSourceFactoryConfig.class,
             "jdbc.idempotent.repository.enabled",
@@ -438,6 +448,7 @@ public final class DataSourceFactoryConfigEntries extends ConfigEntries {
         CONFIG_MODULES.put(AGGREGATION_REPOSITORY_MAXIMUM_REDELIVERIES, ConfigEntry.fromModule());
         CONFIG_MODULES.put(AGGREGATION_REPOSITORY_USE_RECOVERY, ConfigEntry.fromModule());
         CONFIG_MODULES.put(AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_ENABLED, ConfigEntry.fromModule());
         CONFIG_MODULES.put(ENABLE_IDEMPOTENT_REPOSITORY, ConfigEntry.fromModule());
         CONFIG_MODULES.put(IDEMPOTENT_REPOSITORY_TABLE_NAME, ConfigEntry.fromModule());
         CONFIG_MODULES.put(IDEMPOTENT_REPOSITORY_TABLE_IF_NOT_EXISTS, ConfigEntry.fromModule());

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/DataSourceBeanFactory.java
@@ -5,6 +5,8 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.apache.camel.CamelContext;
+import org.apache.camel.forage.core.annotations.ConditionalBean;
+import org.apache.camel.forage.core.annotations.ConditionalBeanGroup;
 import org.apache.camel.forage.core.annotations.ForageFactory;
 import org.apache.camel.forage.core.common.BeanFactory;
 import org.apache.camel.forage.core.common.ServiceLoaderHelper;
@@ -30,7 +32,60 @@ import org.slf4j.LoggerFactory;
         components = {"camel-sql", "camel-jdbc", "camel-spring-jdbc"},
         description = "Default DataSource factory with ServiceLoader discovery",
         factoryType = "DataSource",
-        autowired = true)
+        autowired = true,
+        conditionalBeans = {
+            @ConditionalBeanGroup(
+                    id = "jta-transaction-policies",
+                    description = "JTA Transaction Policy beans for Camel transacted routes",
+                    configEntry = "jdbc.transaction.enabled",
+                    beans = {
+                        @ConditionalBean(
+                                name = "PROPAGATION_REQUIRED",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description =
+                                        "Starts a new transaction if none exists, otherwise joins the existing one"),
+                        @ConditionalBean(
+                                name = "MANDATORY",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Requires an existing transaction, throws exception if none exists"),
+                        @ConditionalBean(
+                                name = "NEVER",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Must execute without a transaction, throws exception if one exists"),
+                        @ConditionalBean(
+                                name = "NOT_SUPPORTED",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Suspends any existing transaction and executes without one"),
+                        @ConditionalBean(
+                                name = "REQUIRES_NEW",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Always starts a new transaction, suspending any existing one"),
+                        @ConditionalBean(
+                                name = "SUPPORTS",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Joins existing transaction if present, otherwise runs without one")
+                    }),
+            @ConditionalBeanGroup(
+                    id = "aggregation-repository",
+                    description = "JDBC-backed aggregation repository for Camel aggregator EIP",
+                    configEntry = "jdbc.aggregation.repository.enabled",
+                    beans = {
+                        @ConditionalBean(
+                                nameFromConfig = "jdbc.aggregation.repository.name",
+                                javaType = "org.apache.camel.processor.aggregate.jdbc.JdbcAggregationRepository",
+                                description = "Transactional JDBC aggregation repository")
+                    }),
+            @ConditionalBeanGroup(
+                    id = "idempotent-repository",
+                    description = "JDBC-backed idempotent repository for message deduplication",
+                    configEntry = "jdbc.idempotent.repository.enabled",
+                    beans = {
+                        @ConditionalBean(
+                                nameFromConfig = "jdbc.idempotent.repository.table.name",
+                                javaType = "org.apache.camel.processor.idempotent.jdbc.JdbcMessageIdRepository",
+                                description = "JDBC message ID repository for idempotent consumer")
+                    })
+        })
 public class DataSourceBeanFactory implements BeanFactory {
     private final Logger LOG = LoggerFactory.getLogger(DataSourceBeanFactory.class);
 

--- a/library/jms/forage-jms/src/main/java/org/apache/camel/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/org/apache/camel/forage/jms/ConnectionFactoryBeanFactory.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 import org.apache.camel.CamelContext;
+import org.apache.camel.forage.core.annotations.ConditionalBean;
+import org.apache.camel.forage.core.annotations.ConditionalBeanGroup;
 import org.apache.camel.forage.core.annotations.ForageFactory;
 import org.apache.camel.forage.core.common.BeanFactory;
 import org.apache.camel.forage.core.common.ServiceLoaderHelper;
@@ -27,7 +29,40 @@ import org.slf4j.LoggerFactory;
         components = {"camel-jms"},
         description = "Default ConnectionFactory factory with ServiceLoader discovery",
         factoryType = "ConnectionFactory",
-        autowired = true)
+        autowired = true,
+        conditionalBeans = {
+            @ConditionalBeanGroup(
+                    id = "jta-transaction-policies",
+                    description = "JTA Transaction Policy beans for Camel transacted routes",
+                    configEntry = "jms.transaction.enabled",
+                    beans = {
+                        @ConditionalBean(
+                                name = "PROPAGATION_REQUIRED",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description =
+                                        "Starts a new transaction if none exists, otherwise joins the existing one"),
+                        @ConditionalBean(
+                                name = "MANDATORY",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Requires an existing transaction, throws exception if none exists"),
+                        @ConditionalBean(
+                                name = "NEVER",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Must execute without a transaction, throws exception if one exists"),
+                        @ConditionalBean(
+                                name = "NOT_SUPPORTED",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Suspends any existing transaction and executes without one"),
+                        @ConditionalBean(
+                                name = "REQUIRES_NEW",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Always starts a new transaction, suspending any existing one"),
+                        @ConditionalBean(
+                                name = "SUPPORTS",
+                                javaType = "org.apache.camel.spi.TransactedPolicy",
+                                description = "Joins existing transaction if present, otherwise runs without one")
+                    })
+        })
 public class ConnectionFactoryBeanFactory implements BeanFactory {
     private final Logger LOG = LoggerFactory.getLogger(ConnectionFactoryBeanFactory.class);
 

--- a/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/CatalogGenerator.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/CatalogGenerator.java
@@ -130,6 +130,12 @@ public class CatalogGenerator {
                     // Add this platform variant
                     FactoryVariant variant = new FactoryVariant(factoryInfo.getClassName(), gav);
                     factory.getVariants().put(platform, variant);
+
+                    // Copy conditional beans if present
+                    if (factoryInfo.getConditionalBeans() != null
+                            && !factoryInfo.getConditionalBeans().isEmpty()) {
+                        factory.setConditionalBeans(factoryInfo.getConditionalBeans());
+                    }
                 }
             }
 
@@ -329,7 +335,7 @@ public class CatalogGenerator {
         List<ForgeBeanInfo> beans = codeScanner.scanForForageBeans(artifact, rootProject);
         component.setBeans(beans);
 
-        // Scan for ForageFactory annotations
+        // Scan for ForageFactory annotations (conditionalBeans are now extracted directly from @ForageFactory)
         List<FactoryInfo> factories = codeScanner.scanForForageFactories(artifact, rootProject);
         component.setFactories(factories);
 

--- a/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/ConditionalBeanGroup.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/ConditionalBeanGroup.java
@@ -1,0 +1,66 @@
+package org.apache.camel.forage.maven.catalog;
+
+import java.util.List;
+
+/**
+ * Represents a group of beans that are conditionally registered when a boolean config entry is enabled.
+ *
+ * This class is used in the catalog JSON to inform UI wizards about beans that are automatically
+ * created when certain configuration options are enabled.
+ */
+public class ConditionalBeanGroup {
+    private String id;
+    private String description;
+    private String configEntry;
+    private List<ConditionalBeanInfo> beans;
+
+    public ConditionalBeanGroup() {}
+
+    public ConditionalBeanGroup(String id, String description, String configEntry, List<ConditionalBeanInfo> beans) {
+        this.id = id;
+        this.description = description;
+        this.configEntry = configEntry;
+        this.beans = beans;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getConfigEntry() {
+        return configEntry;
+    }
+
+    public void setConfigEntry(String configEntry) {
+        this.configEntry = configEntry;
+    }
+
+    public List<ConditionalBeanInfo> getBeans() {
+        return beans;
+    }
+
+    public void setBeans(List<ConditionalBeanInfo> beans) {
+        this.beans = beans;
+    }
+
+    @Override
+    public String toString() {
+        return "ConditionalBeanGroup{" + "id='"
+                + id + '\'' + ", description='"
+                + description + '\'' + ", configEntry='"
+                + configEntry + '\'' + ", beans="
+                + beans + '}';
+    }
+}

--- a/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/ConditionalBeanInfo.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/ConditionalBeanInfo.java
@@ -1,0 +1,84 @@
+package org.apache.camel.forage.maven.catalog;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Represents information about a bean that is conditionally registered.
+ *
+ * Bean names can be either fixed or dynamic:
+ * <ul>
+ *   <li>Fixed: {@link #name} contains the exact bean name</li>
+ *   <li>Dynamic: {@link #nameFromConfig} references a config entry that provides the name</li>
+ * </ul>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConditionalBeanInfo {
+    private String name;
+    private String nameFromConfig;
+    private String javaType;
+    private String description;
+
+    public ConditionalBeanInfo() {}
+
+    public ConditionalBeanInfo(String name, String nameFromConfig, String javaType, String description) {
+        this.name = name;
+        this.nameFromConfig = nameFromConfig;
+        this.javaType = javaType;
+        this.description = description;
+    }
+
+    /**
+     * Creates a ConditionalBeanInfo with a fixed name.
+     */
+    public static ConditionalBeanInfo withName(String name, String javaType, String description) {
+        return new ConditionalBeanInfo(name, null, javaType, description);
+    }
+
+    /**
+     * Creates a ConditionalBeanInfo with a dynamic name from config.
+     */
+    public static ConditionalBeanInfo withNameFromConfig(String nameFromConfig, String javaType, String description) {
+        return new ConditionalBeanInfo(null, nameFromConfig, javaType, description);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNameFromConfig() {
+        return nameFromConfig;
+    }
+
+    public void setNameFromConfig(String nameFromConfig) {
+        this.nameFromConfig = nameFromConfig;
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+
+    public void setJavaType(String javaType) {
+        this.javaType = javaType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return "ConditionalBeanInfo{" + "name='"
+                + name + '\'' + ", nameFromConfig='"
+                + nameFromConfig + '\'' + ", javaType='"
+                + javaType + '\'' + ", description='"
+                + description + '\'' + '}';
+    }
+}

--- a/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/FactoryInfo.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/FactoryInfo.java
@@ -1,11 +1,13 @@
 package org.apache.camel.forage.maven.catalog;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Arrays;
 import java.util.List;
 
 /**
  * Represents information about a ForageFactory annotation found in the codebase.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FactoryInfo {
     private String name;
     private List<String> components;
@@ -13,6 +15,7 @@ public class FactoryInfo {
     private String factoryType;
     private String className;
     private boolean autowired;
+    private List<ConditionalBeanGroup> conditionalBeans;
 
     public FactoryInfo() {}
 
@@ -86,6 +89,14 @@ public class FactoryInfo {
 
     public void setAutowired(boolean autowired) {
         this.autowired = autowired;
+    }
+
+    public List<ConditionalBeanGroup> getConditionalBeans() {
+        return conditionalBeans;
+    }
+
+    public void setConditionalBeans(List<ConditionalBeanGroup> conditionalBeans) {
+        this.conditionalBeans = conditionalBeans;
     }
 
     @Override

--- a/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/ForageFactory.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/org/apache/camel/forage/maven/catalog/ForageFactory.java
@@ -39,6 +39,9 @@ public class ForageFactory {
     @JsonProperty("beansByFeature")
     private Map<String, List<ForageBean>> beansByFeature;
 
+    @JsonProperty("conditionalBeans")
+    private List<ConditionalBeanGroup> conditionalBeans;
+
     public ForageFactory() {}
 
     public ForageFactory(String name, String factoryType, String description) {
@@ -117,6 +120,14 @@ public class ForageFactory {
 
     public void setBeansByFeature(Map<String, List<ForageBean>> beansByFeature) {
         this.beansByFeature = beansByFeature;
+    }
+
+    public List<ConditionalBeanGroup> getConditionalBeans() {
+        return conditionalBeans;
+    }
+
+    public void setConditionalBeans(List<ConditionalBeanGroup> conditionalBeans) {
+        this.conditionalBeans = conditionalBeans;
     }
 
     @Override


### PR DESCRIPTION
…ge Catalog

For example:

```
@ForageFactory(
        value = "CamelDataSourceFactory",
        components = {"camel-sql", "camel-jdbc", "camel-spring-jdbc"},
        description = "Default DataSource factory with ServiceLoader discovery",
        factoryType = "DataSource",
        autowired = true,
        conditionalBeans = {
            @ConditionalBeanGroup(
                    id = "jta-transaction-policies",
                    description = "JTA Transaction Policy beans for Camel transacted routes",
                    configEntry = "jdbc.transaction.enabled",
                    beans = {
                        @ConditionalBean(
                                name = "PROPAGATION_REQUIRED",
                                javaType = "org.apache.camel.spi.TransactedPolicy",
                                description =
                                        "Starts a new transaction if none exists, otherwise joins the existing one"),
                        @ConditionalBean(
                                name = "MANDATORY",
                                javaType = "org.apache.camel.spi.TransactedPolicy",
                                description = "Requires an existing transaction, throws exception if none exists"),
                        @ConditionalBean(
                                name = "NEVER",
                                javaType = "org.apache.camel.spi.TransactedPolicy",
                                description = "Must execute without a transaction, throws exception if one exists"),
                        @ConditionalBean(
                                name = "NOT_SUPPORTED",
                                javaType = "org.apache.camel.spi.TransactedPolicy",
                                description = "Suspends any existing transaction and executes without one"),
                        @ConditionalBean(
                                name = "REQUIRES_NEW",
                                javaType = "org.apache.camel.spi.TransactedPolicy",
                                description = "Always starts a new transaction, suspending any existing one"),
                        @ConditionalBean(
                                name = "SUPPORTS",
                                javaType = "org.apache.camel.spi.TransactedPolicy",
                                description = "Joins existing transaction if present, otherwise runs without one")
                    }),
            @ConditionalBeanGroup(
                    id = "aggregation-repository",
                    description = "JDBC-backed aggregation repository for Camel aggregator EIP",
                    configEntry = "jdbc.aggregation.repository.enabled",
                    beans = {
                        @ConditionalBean(
                                nameFromConfig = "jdbc.aggregation.repository.name",
                                javaType = "org.apache.camel.processor.aggregate.jdbc.JdbcAggregationRepository",
                                description = "Transactional JDBC aggregation repository")
                    }),
            @ConditionalBeanGroup(
                    id = "idempotent-repository",
                    description = "JDBC-backed idempotent repository for message deduplication",
                    configEntry = "jdbc.idempotent.repository.enabled",
                    beans = {
                        @ConditionalBean(
                                nameFromConfig = "jdbc.idempotent.repository.table.name",
                                javaType = "org.apache.camel.processor.idempotent.jdbc.JdbcMessageIdRepository",
                                description = "JDBC message ID repository for idempotent consumer")
                    })
        })
```