### PR TITLE
Guardrails Support: Fix AgentBeanFactory to load guardrails via Servi…

### DIFF
--- a/library/ai/agents/forage-agent/pom.xml
+++ b/library/ai/agents/forage-agent/pom.xml
@@ -42,6 +42,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-guardrails</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/ForageAgentConfiguration.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/ForageAgentConfiguration.java
@@ -1,0 +1,111 @@
+package io.kaoto.forage.agent;
+
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.camel.component.langchain4j.agent.api.AgentConfiguration;
+
+/**
+ * Extended agent configuration that supports guardrail instances in addition to classes.
+ *
+ * <p>This class extends the standard Camel {@link AgentConfiguration} to provide support
+ * for pre-configured guardrail instances. When guardrail instances are provided, they
+ * take precedence over guardrail classes, allowing for properly configured guardrails
+ * loaded via ServiceLoader.
+ */
+public class ForageAgentConfiguration extends AgentConfiguration {
+
+    private List<InputGuardrail> inputGuardrails;
+    private List<OutputGuardrail> outputGuardrails;
+
+    public ForageAgentConfiguration() {
+        super();
+    }
+
+    /**
+     * Gets the list of input guardrail instances.
+     *
+     * @return the list of input guardrail instances, or null if not set
+     */
+    public List<InputGuardrail> getInputGuardrails() {
+        return inputGuardrails;
+    }
+
+    /**
+     * Sets the input guardrail instances.
+     *
+     * @param inputGuardrails the input guardrail instances
+     * @return this configuration for method chaining
+     */
+    public ForageAgentConfiguration withInputGuardrails(List<InputGuardrail> inputGuardrails) {
+        this.inputGuardrails = inputGuardrails;
+        return this;
+    }
+
+    /**
+     * Adds an input guardrail instance.
+     *
+     * @param inputGuardrail the input guardrail instance to add
+     * @return this configuration for method chaining
+     */
+    public ForageAgentConfiguration withInputGuardrail(InputGuardrail inputGuardrail) {
+        if (this.inputGuardrails == null) {
+            this.inputGuardrails = new ArrayList<>();
+        }
+        this.inputGuardrails.add(inputGuardrail);
+        return this;
+    }
+
+    /**
+     * Gets the list of output guardrail instances.
+     *
+     * @return the list of output guardrail instances, or null if not set
+     */
+    public List<OutputGuardrail> getOutputGuardrails() {
+        return outputGuardrails;
+    }
+
+    /**
+     * Sets the output guardrail instances.
+     *
+     * @param outputGuardrails the output guardrail instances
+     * @return this configuration for method chaining
+     */
+    public ForageAgentConfiguration withOutputGuardrails(List<OutputGuardrail> outputGuardrails) {
+        this.outputGuardrails = outputGuardrails;
+        return this;
+    }
+
+    /**
+     * Adds an output guardrail instance.
+     *
+     * @param outputGuardrail the output guardrail instance to add
+     * @return this configuration for method chaining
+     */
+    public ForageAgentConfiguration withOutputGuardrail(OutputGuardrail outputGuardrail) {
+        if (this.outputGuardrails == null) {
+            this.outputGuardrails = new ArrayList<>();
+        }
+        this.outputGuardrails.add(outputGuardrail);
+        return this;
+    }
+
+    /**
+     * Checks if input guardrail instances are available.
+     *
+     * @return true if input guardrail instances are configured
+     */
+    public boolean hasInputGuardrails() {
+        return inputGuardrails != null && !inputGuardrails.isEmpty();
+    }
+
+    /**
+     * Checks if output guardrail instances are available.
+     *
+     * @return true if output guardrail instances are configured
+     */
+    public boolean hasOutputGuardrails() {
+        return outputGuardrails != null && !outputGuardrails.isEmpty();
+    }
+}

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/simple/SimpleAgent.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/simple/SimpleAgent.java
@@ -1,8 +1,11 @@
 package io.kaoto.forage.agent.simple;
 
 import dev.langchain4j.data.message.Content;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.tool.ToolProvider;
+import io.kaoto.forage.agent.ForageAgentConfiguration;
 import io.kaoto.forage.agent.factory.ConfigurationAware;
 import java.util.List;
 import org.apache.camel.component.langchain4j.agent.api.Agent;
@@ -102,14 +105,22 @@ public class SimpleAgent implements Agent, ConfigurationAware {
             builder.retrievalAugmentor(configuration.getRetrievalAugmentor());
         }
 
-        // Input Guardrails
-        if (configuration.getInputGuardrailClasses() != null
+        // Input Guardrails - prefer instances over classes
+        if (configuration instanceof ForageAgentConfiguration forageConfig && forageConfig.hasInputGuardrails()) {
+            List<InputGuardrail> inputGuardrails = forageConfig.getInputGuardrails();
+            builder.inputGuardrails(inputGuardrails.toArray(new InputGuardrail[0]));
+            LOG.debug("Using {} input guardrail instances", inputGuardrails.size());
+        } else if (configuration.getInputGuardrailClasses() != null
                 && !configuration.getInputGuardrailClasses().isEmpty()) {
             builder.inputGuardrailClasses((List) configuration.getInputGuardrailClasses());
         }
 
-        // Output Guardrails
-        if (configuration.getOutputGuardrailClasses() != null
+        // Output Guardrails - prefer instances over classes
+        if (configuration instanceof ForageAgentConfiguration forageConfig && forageConfig.hasOutputGuardrails()) {
+            List<OutputGuardrail> outputGuardrails = forageConfig.getOutputGuardrails();
+            builder.outputGuardrails(outputGuardrails.toArray(new OutputGuardrail[0]));
+            LOG.debug("Using {} output guardrail instances", outputGuardrails.size());
+        } else if (configuration.getOutputGuardrailClasses() != null
                 && !configuration.getOutputGuardrailClasses().isEmpty()) {
             builder.outputGuardrailClasses((List) configuration.getOutputGuardrailClasses());
         }

--- a/library/ai/guardrails/forage-guardrails-input/src/main/java/io/kaoto/forage/guardrails/input/KeywordFilterGuardrailConfig.java
+++ b/library/ai/guardrails/forage-guardrails-input/src/main/java/io/kaoto/forage/guardrails/input/KeywordFilterGuardrailConfig.java
@@ -41,9 +41,9 @@ public class KeywordFilterGuardrailConfig implements Config {
     }
 
     public Set<String> blockedWords() {
-        return ConfigStore.getInstance()
-                .get(BLOCKED_WORDS.asNamed(prefix))
-                .map(s -> {
+        ConfigModule module = BLOCKED_WORDS.asNamed(prefix);
+        Optional<String> value = ConfigStore.getInstance().get(module);
+        return value.map(s -> {
                     Set<String> words = new HashSet<>();
                     Arrays.stream(s.split(","))
                             .map(String::trim)

--- a/library/ai/guardrails/forage-guardrails-input/src/main/java/io/kaoto/forage/guardrails/input/KeywordFilterGuardrailProvider.java
+++ b/library/ai/guardrails/forage-guardrails-input/src/main/java/io/kaoto/forage/guardrails/input/KeywordFilterGuardrailProvider.java
@@ -39,10 +39,15 @@ public class KeywordFilterGuardrailProvider implements InputGuardrailProvider {
         boolean wholeWordMatch = config.wholeWordMatch();
 
         LOG.trace(
-                "Creating KeywordFilterGuardrail with blockedWords={}, caseSensitive={}, wholeWordMatch={}",
+                "Creating KeywordFilterGuardrail with id={}, blockedWords={}, caseSensitive={}, wholeWordMatch={}",
+                id,
                 blockedWords,
                 caseSensitive,
                 wholeWordMatch);
+
+        if (blockedWords.isEmpty()) {
+            LOG.warn("KeywordFilterGuardrail has no blocked words configured for id={}, guardrail will have no effect", id);
+        }
 
         return KeywordFilterGuardrail.builder()
                 .blockedWords(blockedWords)


### PR DESCRIPTION
…ceLoader

  The AgentBeanFactory was not loading input/output guardrails, causing
  guardrails on the classpath to be ignored when using the standard agent
  factory. This fix adds ServiceLoader-based guardrail discovery and passes
  pre-configured guardrail instances to the AI service.

  Key changes:
  - Add forage-core-guardrails dependency to forage-agent module
  - Create ForageAgentConfiguration extending AgentConfiguration to hold guardrail instances (not just classes)
  - Add loadInputGuardrails() and loadOutputGuardrails() methods that use ServiceLoader to discover guardrail providers
  - Modify SimpleAgent to prefer guardrail instances over classes when building the AiServices, using inputGuardrails() instead of inputGuardrailClasses()
  - Improve logging in KeywordFilterGuardrailProvider for debugging
