### PR TITLE
 Rag support (via referenced retrieval augmentor bean)

### DIFF
--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentBeanFactory.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentBeanFactory.java
@@ -5,6 +5,7 @@ import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.rag.RetrievalAugmentor;
 import io.kaoto.forage.agent.factory.ConfigurationAware;
 import io.kaoto.forage.core.ai.ChatMemoryBeanProvider;
 import io.kaoto.forage.core.ai.ModelProvider;
@@ -173,6 +174,24 @@ public class AgentBeanFactory implements BeanFactory {
             if (!outputGuardrails.isEmpty()) {
                 agentConfiguration.withOutputGuardrails(outputGuardrails);
                 LOG.info("Configured {} output guardrails for agent '{}'", outputGuardrails.size(), name);
+            }
+
+            // RAG
+
+            if (config.ragRetrievalAugmentorBeanName() != null) {
+                try {
+                    Object augmentatorBean = camelContext.getRegistry().lookupByName(config.ragRetrievalAugmentorBeanName());
+                    if (augmentatorBean instanceof RetrievalAugmentor) {
+                        agentConfiguration.withRetrievalAugmentor((RetrievalAugmentor) augmentatorBean);
+                    } else {
+                        LOG.warn(
+                                "Failed to find a retrieval augmentor bean with a name: {}",
+                                config.ragRetrievalAugmentorBeanName());
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to create default agent: {}", e.getMessage());
+                    LOG.debug("Agent creation exception details", e);
+                }
             }
 
             configurationAware.configure(agentConfiguration);

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfig.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfig.java
@@ -176,4 +176,12 @@ public class AgentConfig implements Config {
                 .get(MEMORY_INFINISPAN_CACHE_NAME.asNamed(prefix))
                 .orElse("chat-memory");
     }
+
+    // RAG
+
+    public String ragRetrievalAugmentorBeanName() {
+        return ConfigStore.getInstance()
+                .get(RAG_RETRIEVAL_AUGMENTOR_BEAN_NAME.asNamed(prefix))
+                .orElse(null);
+    }
 }

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
@@ -243,6 +243,16 @@ public final class AgentConfigEntries extends ConfigEntries {
             false,
             ConfigTag.COMMON);
 
+    public static final ConfigModule RAG_RETRIEVAL_AUGMENTOR_BEAN_NAME = ConfigModule.of(
+            AgentConfig.class,
+            "forage.agent.rag.augmentor.bean.name",
+            "Name of the RetrievalAugmentator bean",
+            "RetrievalAugmentor bean name",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
     private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new ConcurrentHashMap<>();
 
     static {
@@ -279,6 +289,9 @@ public final class AgentConfigEntries extends ConfigEntries {
         CONFIG_MODULES.put(MEMORY_REDIS_PASSWORD, ConfigEntry.fromModule());
         CONFIG_MODULES.put(MEMORY_INFINISPAN_SERVER_LIST, ConfigEntry.fromModule());
         CONFIG_MODULES.put(MEMORY_INFINISPAN_CACHE_NAME, ConfigEntry.fromModule());
+
+        // RAG
+        CONFIG_MODULES.put(RAG_RETRIEVAL_AUGMENTOR_BEAN_NAME, ConfigEntry.fromModule());
     }
 
     public static Map<ConfigModule, ConfigEntry> entries() {


### PR DESCRIPTION
fixes https://github.com/KaotoIO/forage/issues/183

Adds a config option to add a retrievalAugmentor for an ai agent. 
This PR provides a config entry `forage.agent.rag.augmentor.bean.name`. When the name is != null, bean is used for the agent creation.
I'm working on an example using this feature.