### PR TITLE
chore: upgrade actions/checkout to v6 and actions/setup-java to v5

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -20,13 +20,13 @@ jobs:
     if: github.repository == 'megacamelus/camel-forage'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: main
         persist-credentials: false
         fetch-depth: 0
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -42,9 +42,9 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -62,9 +62,9 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
Upgrade GitHub Actions dependencies in main-build.yml and pr-builds.yml:

- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5

The early-access.yml and release.yml workflows were already at the target versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow steps with newer versions of checkout and Java setup tool actions across main build and pull request pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->