### PR TITLE
chore: restrict GitHub Actions to KaotoIO/forage repository

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -6,6 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish-snapshot:
     name: Publish Snapshot
+    if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    if: github.repository == 'megacamelus/camel-forage'
+    if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build:
-    if: github.repository == 'megacamelus/camel-forage'
+    if: github.repository == 'KaotoIO/forage'
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -53,6 +53,7 @@ jobs:
         run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' package --file pom.xml
 
   build-with-integration-tests:
+    if: github.repository == 'KaotoIO/forage'
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   release:
     name: Release
+    if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR restricts GitHub Actions workflows to only run when the repository is `KaotoIO/forage`. This prevents workflows from running on forks, which is often desirable for security and cost reasons. Standardized the job-level `if` condition across all workflow files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and deployment workflows to enforce repository-specific execution controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->