### PR TITLE
chore: pass -DskipTests to forked Maven builds during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
           ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           
-          mvn -DskipTests -Pdist -B --file pom.xml -Dtag=v${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
+          mvn -DskipTests -Darguments="-DskipTests" -Pdist -B --file pom.xml -Dtag=v${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
 
       # Create a release
 


### PR DESCRIPTION
The existing `-DskipTests` flag only applies to the outer Maven invocation. The `release:prepare` and `release:perform` goals fork separate Maven processes internally that don't inherit this flag.

Adding `-Darguments="-DskipTests"` ensures the forked builds also skip tests during release.