### PR TITLE
Fix #210: Move ForageCatalog to shared module and add configuration catalog reader

### DIFF
--- a/core/forage-catalog-reader/pom.xml
+++ b/core/forage-catalog-reader/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>core</artifactId>
+        <version>1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-catalog-reader</artifactId>
+    <name>Forage :: Core :: Catalog Reader</name>
+    <description>Shared readers for querying Forage catalog JSON files</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-catalog-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageConfigurationCatalogReader.java
+++ b/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageConfigurationCatalogReader.java
@@ -1,0 +1,161 @@
+package io.kaoto.forage.catalog.reader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import io.kaoto.forage.catalog.model.ConfigEntry;
+import io.kaoto.forage.catalog.model.ConfigurationModule;
+import io.kaoto.forage.catalog.model.ForageConfigurationCatalog;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Helper class to load and query the Forage configuration catalog.
+ * The configuration catalog contains metadata about all configuration entries
+ * across all modules, unlike the factory catalog which only includes configs
+ * associated with factories.
+ */
+public final class ForageConfigurationCatalogReader {
+
+    private static final String CATALOG_RESOURCE = "catalog/forage-configuration-catalog.json";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static volatile ForageConfigurationCatalogReader instance;
+    private final ForageConfigurationCatalog catalog;
+    // Maps config name (e.g., "forage.openai.api.key") to its ConfigEntry
+    private final Map<String, ConfigEntry> configNameToEntry;
+    // Maps artifactId (e.g., "forage-model-openai") to its ConfigurationModule
+    private final Map<String, ConfigurationModule> artifactIdToModule;
+
+    private ForageConfigurationCatalogReader(ForageConfigurationCatalog catalog) {
+        this.catalog = catalog;
+        this.configNameToEntry = new HashMap<>();
+        this.artifactIdToModule = new HashMap<>();
+        buildIndexes();
+    }
+
+    public static ForageConfigurationCatalogReader getInstance() {
+        if (instance == null) {
+            synchronized (ForageConfigurationCatalogReader.class) {
+                if (instance == null) {
+                    instance = loadCatalog();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Creates a ForageConfigurationCatalogReader from the given input stream.
+     * This is useful for testing or for loading catalogs from non-classpath sources.
+     *
+     * @param inputStream the input stream containing the configuration catalog JSON
+     * @return a new ForageConfigurationCatalogReader instance
+     * @throws IOException if the catalog cannot be read
+     */
+    public static ForageConfigurationCatalogReader fromInputStream(InputStream inputStream) throws IOException {
+        ForageConfigurationCatalog catalogModel =
+                OBJECT_MAPPER.readValue(inputStream, ForageConfigurationCatalog.class);
+        return new ForageConfigurationCatalogReader(catalogModel);
+    }
+
+    private static ForageConfigurationCatalogReader loadCatalog() {
+        try (InputStream is =
+                ForageConfigurationCatalogReader.class.getClassLoader().getResourceAsStream(CATALOG_RESOURCE)) {
+            if (is == null) {
+                throw new IllegalStateException("Forage configuration catalog not found: " + CATALOG_RESOURCE);
+            }
+            return fromInputStream(is);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load Forage configuration catalog", e);
+        }
+    }
+
+    private void buildIndexes() {
+        List<ConfigurationModule> modules = catalog.getModules();
+        if (modules == null) {
+            return;
+        }
+
+        for (ConfigurationModule module : modules) {
+            String artifactId = module.getArtifactId();
+            if (artifactId != null) {
+                artifactIdToModule.put(artifactId, module);
+            }
+
+            List<ConfigEntry> entries = module.getConfigEntries();
+            if (entries != null) {
+                for (ConfigEntry entry : entries) {
+                    String name = entry.getName();
+                    if (name != null) {
+                        configNameToEntry.put(name, entry);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if the given configuration name is a valid (known) configuration entry.
+     *
+     * @param name the configuration name (e.g., "forage.openai.api.key")
+     * @return true if the config name exists in the catalog
+     */
+    public boolean isValidConfig(String name) {
+        if (name == null) {
+            return false;
+        }
+        return configNameToEntry.containsKey(name);
+    }
+
+    /**
+     * Gets the configuration entry for the given name.
+     *
+     * @param name the configuration name (e.g., "forage.openai.api.key")
+     * @return Optional containing the ConfigEntry if found
+     */
+    public Optional<ConfigEntry> getConfigEntry(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(configNameToEntry.get(name));
+    }
+
+    /**
+     * Gets the configuration module for the given artifact ID.
+     *
+     * @param artifactId the Maven artifact ID (e.g., "forage-model-openai")
+     * @return Optional containing the ConfigurationModule if found
+     */
+    public Optional<ConfigurationModule> getModule(String artifactId) {
+        if (artifactId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(artifactIdToModule.get(artifactId));
+    }
+
+    /**
+     * Gets all configuration modules in the catalog.
+     *
+     * @return unmodifiable list of all configuration modules
+     */
+    public List<ConfigurationModule> getAllModules() {
+        List<ConfigurationModule> modules = catalog.getModules();
+        if (modules == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(modules);
+    }
+
+    /**
+     * Gets the raw catalog model.
+     *
+     * @return the ForageConfigurationCatalog model
+     */
+    public ForageConfigurationCatalog getCatalog() {
+        return catalog;
+    }
+}

--- a/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageCatalogReaderTest.java
+++ b/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageCatalogReaderTest.java
@@ -1,0 +1,196 @@
+package io.kaoto.forage.catalog.reader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ForageCatalogReaderTest {
+
+    private static final String TEST_CATALOG_JSON =
+            """
+            {
+              "version": "1.0-test",
+              "generatedBy": "test",
+              "timestamp": 1234567890,
+              "factories": [
+                {
+                  "name": "JDBC DataSource Factory",
+                  "factoryType": "javax.sql.DataSource",
+                  "description": "Creates JDBC DataSource beans",
+                  "propertiesFile": "forage-jdbc.properties",
+                  "variants": {
+                    "base": { "className": "io.kaoto.forage.jdbc.JdbcFactory", "gav": "io.kaoto.forage:forage-jdbc:1.0" },
+                    "springboot": { "className": "io.kaoto.forage.jdbc.sb.JdbcFactory", "gav": "io.kaoto.forage:forage-jdbc-springboot:1.0" }
+                  },
+                  "configEntries": [
+                    { "name": "forage.jdbc.name", "type": "prefix", "description": "Instance name", "required": false },
+                    { "name": "forage.jdbc.url", "type": "string", "description": "JDBC URL", "required": true }
+                  ],
+                  "beansByFeature": [
+                    {
+                      "feature": "javax.sql.DataSource",
+                      "beans": [
+                        {
+                          "name": "postgresql",
+                          "description": "PostgreSQL DataSource",
+                          "className": "io.kaoto.forage.jdbc.PostgresqlProvider",
+                          "gav": "io.kaoto.forage:forage-jdbc-postgresql:1.0",
+                          "configEntries": [
+                            { "name": "forage.postgresql.url", "type": "string", "description": "URL" }
+                          ]
+                        },
+                        {
+                          "name": "h2",
+                          "description": "H2 DataSource",
+                          "className": "io.kaoto.forage.jdbc.H2Provider",
+                          "gav": "io.kaoto.forage:forage-jdbc-h2:1.0"
+                        }
+                      ]
+                    }
+                  ],
+                  "conditionalBeans": [
+                    {
+                      "id": "transaction-manager",
+                      "description": "Transaction manager",
+                      "configEntry": "jdbc.transaction.enabled",
+                      "beans": [
+                        { "name": "txManager", "javaType": "javax.transaction.TransactionManager", "description": "TX manager" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    private ForageCatalogReader reader;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        InputStream is = new ByteArrayInputStream(TEST_CATALOG_JSON.getBytes(StandardCharsets.UTF_8));
+        reader = ForageCatalogReader.fromInputStream(is);
+    }
+
+    @Test
+    void testGetFactoryMetadata() {
+        Optional<ForageCatalogReader.FactoryMetadata> metadata = reader.getFactoryMetadata("jdbc");
+        assertThat(metadata).isPresent();
+        assertThat(metadata.get().factoryName()).isEqualTo("JDBC DataSource Factory");
+        assertThat(metadata.get().factoryType()).isEqualTo("javax.sql.DataSource");
+        assertThat(metadata.get().propertiesFileName()).isEqualTo("forage-jdbc.properties");
+        assertThat(metadata.get().prefixPropertyName()).isEqualTo("forage.jdbc.name");
+        assertThat(metadata.get().factoryTypeKey()).isEqualTo("jdbc");
+    }
+
+    @Test
+    void testGetFactoryMetadataNotFound() {
+        Optional<ForageCatalogReader.FactoryMetadata> metadata = reader.getFactoryMetadata("nonexistent");
+        assertThat(metadata).isEmpty();
+    }
+
+    @Test
+    void testGetAllFactories() {
+        Collection<ForageCatalogReader.FactoryMetadata> factories = reader.getAllFactories();
+        assertThat(factories).hasSize(1);
+    }
+
+    @Test
+    void testGetBeanGavs() {
+        Collection<String> gavs = reader.getBeanGavs("postgresql");
+        assertThat(gavs).containsExactly("io.kaoto.forage:forage-jdbc-postgresql:1.0");
+    }
+
+    @Test
+    void testGetBeanGavsNotFound() {
+        Collection<String> gavs = reader.getBeanGavs("unknown");
+        assertThat(gavs).isEmpty();
+    }
+
+    @Test
+    void testFindFactoryTypeKeyForBeanName() {
+        Optional<String> key = reader.findFactoryTypeKeyForBeanName("postgresql");
+        assertThat(key).isPresent().hasValue("jdbc");
+
+        key = reader.findFactoryTypeKeyForBeanName("h2");
+        assertThat(key).isPresent().hasValue("jdbc");
+    }
+
+    @Test
+    void testFindFactoryTypeKeyForBeanNameNotFound() {
+        Optional<String> key = reader.findFactoryTypeKeyForBeanName("unknown");
+        assertThat(key).isEmpty();
+    }
+
+    @Test
+    void testGetBeanFeature() {
+        Optional<String> feature = reader.getBeanFeature("postgresql");
+        assertThat(feature).isPresent().hasValue("javax.sql.DataSource");
+    }
+
+    @Test
+    void testGetConditionalBeans() {
+        var conditionalBeans = reader.getConditionalBeans("jdbc");
+        assertThat(conditionalBeans).hasSize(1);
+        assertThat(conditionalBeans.get(0).getId()).isEqualTo("transaction-manager");
+    }
+
+    @Test
+    void testGetConditionalBeansEmpty() {
+        var conditionalBeans = reader.getConditionalBeans("nonexistent");
+        assertThat(conditionalBeans).isEmpty();
+    }
+
+    @Test
+    void testGetFactoryVariantGav() {
+        Optional<String> gav = reader.getFactoryVariantGav("jdbc", "base");
+        assertThat(gav).isPresent().hasValue("io.kaoto.forage:forage-jdbc:1.0");
+
+        gav = reader.getFactoryVariantGav("jdbc", "springboot");
+        assertThat(gav).isPresent().hasValue("io.kaoto.forage:forage-jdbc-springboot:1.0");
+
+        gav = reader.getFactoryVariantGav("jdbc", "quarkus");
+        assertThat(gav).isEmpty();
+    }
+
+    @Test
+    void testGetPrefixPropertyName() {
+        Optional<String> prefix = reader.getPrefixPropertyName("jdbc");
+        assertThat(prefix).isPresent().hasValue("forage.jdbc.name");
+    }
+
+    @Test
+    void testGetPropertiesFileName() {
+        Optional<String> fileName = reader.getPropertiesFileName("jdbc");
+        assertThat(fileName).isPresent().hasValue("forage-jdbc.properties");
+    }
+
+    @Test
+    void testFindFactoryTypeKeyForInputProperty() {
+        Optional<String> key = reader.findFactoryTypeKeyForInputProperty("forage.jdbc.url");
+        assertThat(key).isPresent().hasValue("jdbc");
+
+        key = reader.findFactoryTypeKeyForInputProperty("jdbc.url");
+        assertThat(key).isPresent().hasValue("jdbc");
+    }
+
+    @Test
+    void testNormalizePropertyKey() {
+        assertThat(reader.normalizePropertyKey("forage.jdbc.url")).isEqualTo("jdbc.url");
+        assertThat(reader.normalizePropertyKey("jdbc.url")).isEqualTo("jdbc.url");
+    }
+
+    @Test
+    void testShortPrefixPropertyKey() {
+        Optional<ForageCatalogReader.FactoryMetadata> metadata = reader.getFactoryMetadata("jdbc");
+        assertThat(metadata).isPresent();
+        Optional<String> shortKey = metadata.get().getShortPrefixPropertyKey();
+        assertThat(shortKey).isPresent().hasValue("jdbc.name");
+    }
+}

--- a/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageConfigurationCatalogReaderTest.java
+++ b/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageConfigurationCatalogReaderTest.java
@@ -1,0 +1,149 @@
+package io.kaoto.forage.catalog.reader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import io.kaoto.forage.catalog.model.ConfigEntry;
+import io.kaoto.forage.catalog.model.ConfigurationModule;
+import io.kaoto.forage.catalog.model.ForageConfigurationCatalog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ForageConfigurationCatalogReaderTest {
+
+    private static final String TEST_CATALOG_JSON =
+            """
+            {
+              "version": "1.0-test",
+              "generatedBy": "test",
+              "timestamp": 1234567890,
+              "modules": [
+                {
+                  "artifactId": "forage-model-openai",
+                  "groupId": "io.kaoto.forage",
+                  "propertiesFile": "forage-agent.properties",
+                  "configEntries": [
+                    {
+                      "name": "forage.openai.api.key",
+                      "type": "string",
+                      "description": "OpenAI API key",
+                      "required": true,
+                      "defaultValue": null,
+                      "example": "sk-..."
+                    },
+                    {
+                      "name": "forage.openai.model.name",
+                      "type": "string",
+                      "description": "Model name to use",
+                      "required": false,
+                      "defaultValue": "gpt-4o",
+                      "example": "gpt-4o-mini"
+                    }
+                  ]
+                },
+                {
+                  "artifactId": "forage-jdbc-postgresql",
+                  "groupId": "io.kaoto.forage",
+                  "propertiesFile": "forage-jdbc.properties",
+                  "configEntries": [
+                    {
+                      "name": "forage.postgresql.url",
+                      "type": "string",
+                      "description": "PostgreSQL JDBC URL",
+                      "required": true
+                    },
+                    {
+                      "name": "forage.postgresql.username",
+                      "type": "string",
+                      "description": "Database username",
+                      "required": false,
+                      "defaultValue": "postgres"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    private ForageConfigurationCatalogReader reader;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        InputStream is = new ByteArrayInputStream(TEST_CATALOG_JSON.getBytes(StandardCharsets.UTF_8));
+        reader = ForageConfigurationCatalogReader.fromInputStream(is);
+    }
+
+    @Test
+    void testIsValidConfigReturnsTrue() {
+        assertThat(reader.isValidConfig("forage.openai.api.key")).isTrue();
+        assertThat(reader.isValidConfig("forage.postgresql.url")).isTrue();
+    }
+
+    @Test
+    void testIsValidConfigReturnsFalse() {
+        assertThat(reader.isValidConfig("forage.nonexistent.key")).isFalse();
+        assertThat(reader.isValidConfig(null)).isFalse();
+    }
+
+    @Test
+    void testGetConfigEntry() {
+        Optional<ConfigEntry> entry = reader.getConfigEntry("forage.openai.api.key");
+        assertThat(entry).isPresent();
+        assertThat(entry.get().getType()).isEqualTo("string");
+        assertThat(entry.get().getDescription()).isEqualTo("OpenAI API key");
+        assertThat(entry.get().isRequired()).isTrue();
+        assertThat(entry.get().getDefaultValue()).isNull();
+    }
+
+    @Test
+    void testGetConfigEntryWithDefaults() {
+        Optional<ConfigEntry> entry = reader.getConfigEntry("forage.openai.model.name");
+        assertThat(entry).isPresent();
+        assertThat(entry.get().isRequired()).isFalse();
+        assertThat(entry.get().getDefaultValue()).isEqualTo("gpt-4o");
+        assertThat(entry.get().getExample()).isEqualTo("gpt-4o-mini");
+    }
+
+    @Test
+    void testGetConfigEntryNotFound() {
+        Optional<ConfigEntry> entry = reader.getConfigEntry("forage.nonexistent.key");
+        assertThat(entry).isEmpty();
+    }
+
+    @Test
+    void testGetModule() {
+        Optional<ConfigurationModule> module = reader.getModule("forage-model-openai");
+        assertThat(module).isPresent();
+        assertThat(module.get().getGroupId()).isEqualTo("io.kaoto.forage");
+        assertThat(module.get().getPropertiesFile()).isEqualTo("forage-agent.properties");
+        assertThat(module.get().getConfigEntries()).hasSize(2);
+    }
+
+    @Test
+    void testGetModuleNotFound() {
+        Optional<ConfigurationModule> module = reader.getModule("nonexistent-module");
+        assertThat(module).isEmpty();
+    }
+
+    @Test
+    void testGetAllModules() {
+        List<ConfigurationModule> modules = reader.getAllModules();
+        assertThat(modules).hasSize(2);
+        assertThat(modules.stream().map(ConfigurationModule::getArtifactId))
+                .containsExactly("forage-model-openai", "forage-jdbc-postgresql");
+    }
+
+    @Test
+    void testGetCatalog() {
+        ForageConfigurationCatalog catalog = reader.getCatalog();
+        assertThat(catalog).isNotNull();
+        assertThat(catalog.getVersion()).isEqualTo("1.0-test");
+        assertThat(catalog.getGeneratedBy()).isEqualTo("test");
+        assertThat(catalog.getTimestamp()).isEqualTo(1234567890L);
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,6 +14,7 @@
 
     <modules>
         <module>forage-catalog-model</module>
+        <module>forage-catalog-reader</module>
         <module>forage-core-common</module>
         <module>forage-core-ai</module>
         <module>forage-core-guardrails</module>

--- a/tooling/camel-jbang-plugin-forage/pom.xml
+++ b/tooling/camel-jbang-plugin-forage/pom.xml
@@ -27,6 +27,12 @@
 
         <dependency>
             <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-catalog-reader</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
             <artifactId>forage-jdbc-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigReadCommand.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigReadCommand.java
@@ -20,6 +20,7 @@ import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import io.kaoto.forage.catalog.model.ConditionalBeanGroup;
 import io.kaoto.forage.catalog.model.ConditionalBeanInfo;
+import io.kaoto.forage.catalog.reader.ForageCatalogReader;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import picocli.CommandLine;
@@ -58,7 +59,7 @@ public class ConfigReadCommand extends CamelCommand {
             defaultValue = "application")
     private String strategy;
 
-    private ForageCatalog catalog;
+    private ForageCatalogReader catalog;
 
     public ConfigReadCommand(CamelJBangMain main) {
         super(main);
@@ -77,7 +78,7 @@ public class ConfigReadCommand extends CamelCommand {
     @Override
     public Integer doCall() throws Exception {
         try {
-            catalog = ForageCatalog.getInstance();
+            catalog = ForageCatalogReader.getInstance();
 
             if (directory == null) {
                 directory = new File(System.getProperty("user.dir"));
@@ -150,7 +151,7 @@ public class ConfigReadCommand extends CamelCommand {
             targetFileNames.add("application.properties");
         } else {
             // Get properties file names from the catalog
-            for (ForageCatalog.FactoryMetadata metadata : catalog.getAllFactories()) {
+            for (ForageCatalogReader.FactoryMetadata metadata : catalog.getAllFactories()) {
                 String propsFile = metadata.propertiesFileName();
                 if (propsFile != null && !propsFile.isEmpty()) {
                     targetFileNames.add(propsFile);
@@ -286,7 +287,7 @@ public class ConfigReadCommand extends CamelCommand {
         String beanKind = determineBeanKind(instance);
 
         // Get factory metadata
-        Optional<ForageCatalog.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(instance.factoryType);
+        Optional<ForageCatalogReader.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(instance.factoryType);
 
         // Determine the Java type
         String javaType = metadataOpt.isPresent() ? getFactoryJavaType(metadataOpt.get(), instance) : "Unknown";
@@ -318,7 +319,7 @@ public class ConfigReadCommand extends CamelCommand {
         }
 
         // Use default bean name derived from the catalog's factoryType
-        Optional<ForageCatalog.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(instance.factoryType);
+        Optional<ForageCatalogReader.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(instance.factoryType);
         if (metadataOpt.isPresent()) {
             return deriveDefaultBeanName(metadataOpt.get());
         }
@@ -334,7 +335,7 @@ public class ConfigReadCommand extends CamelCommand {
      *       "jakarta.jms.ConnectionFactory" -> "connectionFactory"
      *       "org.apache.camel.component.langchain4j.agent.api.Agent" -> "agent"
      */
-    private String deriveDefaultBeanName(ForageCatalog.FactoryMetadata metadata) {
+    private String deriveDefaultBeanName(ForageCatalogReader.FactoryMetadata metadata) {
         String factoryType = metadata.factoryType();
         if (factoryType == null || factoryType.isEmpty()) {
             return metadata.factoryTypeKey();
@@ -368,7 +369,7 @@ public class ConfigReadCommand extends CamelCommand {
         return null;
     }
 
-    private String getFactoryJavaType(ForageCatalog.FactoryMetadata metadata, InstanceProperties instance) {
+    private String getFactoryJavaType(ForageCatalogReader.FactoryMetadata metadata, InstanceProperties instance) {
         // For beans with a specific bean type, look up the feature to determine the Java type
         if (instance.beanType != null) {
             Optional<String> featureOpt = catalog.getBeanFeature(instance.beanType);

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigWriteCommand.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigWriteCommand.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.camel.dsl.jbang.core.commands.CamelCommand;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import io.kaoto.forage.catalog.reader.ForageCatalogReader;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -58,7 +59,7 @@ public class ConfigWriteCommand extends CamelCommand {
             defaultValue = "application")
     private String strategy;
 
-    private ForageCatalog catalog;
+    private ForageCatalogReader catalog;
 
     public ConfigWriteCommand(CamelJBangMain main) {
         super(main);
@@ -67,7 +68,7 @@ public class ConfigWriteCommand extends CamelCommand {
     @Override
     public Integer doCall() throws Exception {
         try {
-            catalog = ForageCatalog.getInstance();
+            catalog = ForageCatalogReader.getInstance();
 
             if (directory == null) {
                 directory = new File(System.getProperty("user.dir"));
@@ -263,9 +264,9 @@ public class ConfigWriteCommand extends CamelCommand {
             String factoryTypeKey = factoryTypeOpt.get();
 
             // Check if this key is the prefix/name property for this factory
-            Optional<ForageCatalog.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(factoryTypeKey);
+            Optional<ForageCatalogReader.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(factoryTypeKey);
             if (metadataOpt.isPresent()) {
-                ForageCatalog.FactoryMetadata metadata = metadataOpt.get();
+                ForageCatalogReader.FactoryMetadata metadata = metadataOpt.get();
                 Optional<String> shortPrefixKeyOpt = metadata.getShortPrefixPropertyKey();
                 if (shortPrefixKeyOpt.isPresent() && normalizedKey.equals(shortPrefixKeyOpt.get())) {
                     // This is the bean name property - only store non-empty values
@@ -328,9 +329,9 @@ public class ConfigWriteCommand extends CamelCommand {
             String kindForFactory = factoryKinds.getOrDefault(factoryTypeKey, globalKind);
 
             // Skip the factory-specific name property itself - it's used for prefixing, not stored directly
-            Optional<ForageCatalog.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(factoryTypeKey);
+            Optional<ForageCatalogReader.FactoryMetadata> metadataOpt = catalog.getFactoryMetadata(factoryTypeKey);
             if (metadataOpt.isPresent()) {
-                ForageCatalog.FactoryMetadata metadata = metadataOpt.get();
+                ForageCatalogReader.FactoryMetadata metadata = metadataOpt.get();
                 Optional<String> shortPrefixKeyOpt = metadata.getShortPrefixPropertyKey();
                 if (shortPrefixKeyOpt.isPresent() && normalizedKey.equals(shortPrefixKeyOpt.get())) {
                     // Skip the name property, but ensure we have an entry for this factory
@@ -528,7 +529,7 @@ public class ConfigWriteCommand extends CamelCommand {
 
     private String getFactoryDisplayName(String factoryTypeKey) {
         return catalog.getFactoryMetadata(factoryTypeKey)
-                .map(ForageCatalog.FactoryMetadata::factoryName)
+                .map(ForageCatalogReader.FactoryMetadata::factoryName)
                 .orElse(factoryTypeKey + " factory");
     }
 
@@ -676,7 +677,7 @@ public class ConfigWriteCommand extends CamelCommand {
                 propertiesFilesToScan.add(appProps);
             }
         } else {
-            for (ForageCatalog.FactoryMetadata metadata : catalog.getAllFactories()) {
+            for (ForageCatalogReader.FactoryMetadata metadata : catalog.getAllFactories()) {
                 String propertiesFileName = getPropertiesFileName(metadata.factoryTypeKey());
                 if (propertiesFileName != null) {
                     File propertiesFile = new File(directory, propertiesFileName);


### PR DESCRIPTION
## Summary
- Create new `core/forage-catalog-reader` module with shared catalog reader classes
- Move `ForageCatalog` from `camel-jbang-plugin-forage` to the new module as `ForageCatalogReader`, making it reusable across modules
- Add `ForageConfigurationCatalogReader` for querying `forage-configuration-catalog.json` with index maps and lookup API (`isValidConfig`, `getConfigEntry`, `getModule`, `getAllModules`, `getCatalog`)
- Update jbang plugin (`ConfigReadCommand`, `ConfigWriteCommand`) to use the relocated class
- Add 25 tests covering both readers with hand-crafted JSON fixtures

## Test plan
- [x] `cd core/forage-catalog-reader && mvn install` — 25 tests pass
- [x] `cd tooling/camel-jbang-plugin-forage && mvn test` — existing tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new catalog reader module with configuration validation and metadata lookup capabilities.
  * Added public APIs for reading catalog data from custom input streams and querying configuration entries, modules, and factory metadata.

* **Tests**
  * Added comprehensive test coverage for catalog reader and configuration catalog functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->