### PR TITLE
Add description, components and autowired to FactoryMetadata

### DIFF
--- a/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageCatalogReader.java
+++ b/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageCatalogReader.java
@@ -132,8 +132,20 @@ public final class ForageCatalogReader {
 
             if (factoryTypeKey != null) {
 
+                String description = factory.getDescription();
+                List<String> components = factory.getComponents();
+                boolean autowired = factory.isAutowired();
+
                 FactoryMetadata metadata = new FactoryMetadata(
-                        factoryName, factoryType, propertiesFile, prefixPropertyName, factoryTypeKey, configEntries);
+                        factoryName,
+                        factoryType,
+                        description,
+                        components,
+                        autowired,
+                        propertiesFile,
+                        prefixPropertyName,
+                        factoryTypeKey,
+                        configEntries);
                 factoryMetadataByKey.put(factoryTypeKey, metadata);
 
                 // Store factory variants
@@ -474,6 +486,9 @@ public final class ForageCatalogReader {
     public record FactoryMetadata(
             String factoryName,
             String factoryType,
+            String description,
+            List<String> components,
+            boolean autowired,
             String propertiesFileName,
             String prefixPropertyName,
             String factoryTypeKey,

--- a/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageCatalogReaderTest.java
+++ b/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageCatalogReaderTest.java
@@ -24,6 +24,8 @@ class ForageCatalogReaderTest {
                   "name": "JDBC DataSource Factory",
                   "factoryType": "javax.sql.DataSource",
                   "description": "Creates JDBC DataSource beans",
+                  "components": ["camel-sql"],
+                  "autowired": true,
                   "propertiesFile": "forage-jdbc.properties",
                   "variants": {
                     "base": { "className": "io.kaoto.forage.jdbc.JdbcFactory", "gav": "io.kaoto.forage:forage-jdbc:1.0" },
@@ -87,6 +89,9 @@ class ForageCatalogReaderTest {
         assertThat(metadata.get().propertiesFileName()).isEqualTo("forage-jdbc.properties");
         assertThat(metadata.get().prefixPropertyName()).isEqualTo("forage.jdbc.name");
         assertThat(metadata.get().factoryTypeKey()).isEqualTo("jdbc");
+        assertThat(metadata.get().description()).isEqualTo("Creates JDBC DataSource beans");
+        assertThat(metadata.get().components()).containsExactly("camel-sql");
+        assertThat(metadata.get().autowired()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Enrich `ForageCatalogReader.FactoryMetadata` record with `description`, `components`, and `autowired` fields
- These fields are already present on the underlying `ForageFactory` model but were not exposed through `FactoryMetadata`
- Enables consumers (e.g., CFM) to use `ForageCatalogReader` directly without needing to parse the raw catalog JSON

## Test plan

- [x] Updated `ForageCatalogReaderTest` to verify the new fields are populated from catalog JSON
- [x] All 25 existing catalog reader tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enriched factory metadata with additional information: descriptions, component listings, and autowiring status for improved catalog discoverability and configuration management.

* **Tests**
  * Updated test coverage to verify new metadata fields are correctly extracted and populated from catalog sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->