### PR TITLE
chore: add --no-transfer-progress to Maven CI builds

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -38,4 +38,4 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
           export GPG_TTY=$(tty)
-          mvn -DskipTests -Pdist -B --file pom.xml deploy
+          mvn -DskipTests -Pdist -B --no-transfer-progress --file pom.xml deploy

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -32,4 +32,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml
+      run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -50,7 +50,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' package --file pom.xml
+        run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' package --file pom.xml
 
   build-with-integration-tests:
     if: github.repository == 'KaotoIO/forage'
@@ -71,4 +71,4 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven and run integration tests
-        run: mvn -B '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml
+        run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
           ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           
-          mvn -DskipTests -Darguments="-DskipTests" -Pdist -B --file pom.xml -Dtag=v${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
+          mvn -DskipTests -Darguments="-DskipTests" -Pdist -B --no-transfer-progress --file pom.xml -Dtag=v${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
 
       # Create a release
 


### PR DESCRIPTION
## Summary
- Add `--no-transfer-progress` flag to all Maven commands in GitHub Actions workflows
- Affects `early-access.yml`, `main-build.yml`, `pr-builds.yml`, and `release.yml`
- Suppresses download/upload progress output for cleaner CI logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD build pipeline efficiency by optimizing Maven output suppression across all GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->