### PR TITLE
chore: standardize Maven POM property names and consolidate plugin versions

### DIFF
--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -440,7 +440,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${maven-resources-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-catalog-to-resources</id>
@@ -467,7 +467,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${build-helper-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-catalog-json</id>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -45,7 +45,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -53,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>io.kaoto.forage:integration-tests-common</dependency>

--- a/library/ai/models/chat/forage-model-anthropic/pom.xml
+++ b/library/ai/models/chat/forage-model-anthropic/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-azure-openai/pom.xml
+++ b/library/ai/models/chat/forage-model-azure-openai/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-azure-open-ai</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-dashscope/pom.xml
+++ b/library/ai/models/chat/forage-model-dashscope/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-google-gemini/pom.xml
+++ b/library/ai/models/chat/forage-model-google-gemini/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-google-ai-gemini</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-hugging-face/pom.xml
+++ b/library/ai/models/chat/forage-model-hugging-face/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-hugging-face</artifactId>
-            <version>${langchain4j-community-version}</version>
+            <version>${langchain4j-community.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-local-ai/pom.xml
+++ b/library/ai/models/chat/forage-model-local-ai/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-mistral-ai/pom.xml
+++ b/library/ai/models/chat/forage-model-mistral-ai/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-mistral-ai</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/library/ai/vector-dbs/forage-vectordb-chroma/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/pom.xml
@@ -77,7 +77,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-default/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-default/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${langchain4j-version}</version>
+            <version>${langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/library/ai/vector-dbs/forage-vectordb-infinispan/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-infinispan/pom.xml
@@ -71,7 +71,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-mariadb/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-mariadb/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-mariadb</artifactId>
-            <version>${langchain4j-beta-version}</version>
+            <version>${langchain4j-beta.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-milvus</artifactId>
-            <version>${langchain4j-beta-version}</version>
+            <version>${langchain4j-beta.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-community-neo4j</artifactId>
-            <version>${langchain4j-community-version}</version>
+            <version>${langchain4j-community.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-pgvector</artifactId>
-            <version>${langchain4j-beta-version}</version>
+            <version>${langchain4j-beta.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-pinecone</artifactId>
-            <version>${langchain4j-beta-version}</version>
+            <version>${langchain4j-beta.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-qdrant</artifactId>
-            <version>${langchain4j-beta-version}</version>
+            <version>${langchain4j-beta.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-redis/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-redis/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-community-redis</artifactId>
-            <version>${langchain4j-community-version}</version>
+            <version>${langchain4j-community.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -66,7 +66,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-weaviate</artifactId>
-            <version>${langchain4j-beta-version}</version>
+            <version>${langchain4j-beta.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/cloud/pom.xml
+++ b/library/cloud/pom.xml
@@ -21,7 +21,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/library/vertx/forage-vertx/pom.xml
+++ b/library/vertx/forage-vertx/pom.xml
@@ -46,7 +46,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
 
     <properties>
         <camel.version>4.18.0</camel.version>
-        <langchain4j-version>1.11.0</langchain4j-version>
-        <langchain4j-beta-version>1.11.0-beta19</langchain4j-beta-version>
-        <langchain4j-community-version>1.11.0-beta19</langchain4j-community-version>
+        <langchain4j.version>1.11.0</langchain4j.version>
+        <langchain4j-beta.version>1.11.0-beta19</langchain4j-beta.version>
+        <langchain4j-community.version>1.11.0-beta19</langchain4j-community.version>
 
         <infinispan.version>16.0.5</infinispan.version>
         <agroal.version>2.8</agroal.version>
@@ -32,15 +32,18 @@
         <junit-jupiter-suite.version>1.13.4</junit-jupiter-suite.version>
         <junit-jupiter.version>6.0.2</junit-jupiter.version>
         <log4j.version>2.25.3</log4j.version>
-        <maven-plugin-javadoc.version>3.12.0</maven-plugin-javadoc.version>
-        <maven-plugin-central-publishing.version>0.10.0</maven-plugin-central-publishing.version>
-        <maven-plugin-gpg.version>3.2.8</maven-plugin-gpg.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
 
-        <maven-plugin-source.version>3.4.0</maven-plugin-source.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
         <maven-plugin-api.version>3.9.11</maven-plugin-api.version>
         <maven-plugin-plugin.version>3.15.2</maven-plugin-plugin.version>
         <maven-plugin-testing-harness.version>3.5.1</maven-plugin-testing-harness.version>
+        <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.version>3.9.11</maven.version>
@@ -59,7 +62,7 @@
         <palantir-format.version>2.71.0</palantir-format.version>
         <spring-boot.version>3.5.5</spring-boot.version>
         <spring.version>6.2.11</spring.version>
-        <surefire-plugin.version>3.5.4</surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <vertx.version>4.5.20</vertx.version>
 
@@ -119,7 +122,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-bom</artifactId>
-                <version>${langchain4j-version}</version>
+                <version>${langchain4j.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -143,7 +146,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j</artifactId>
-                <version>${langchain4j-version}</version>
+                <version>${langchain4j.version}</version>
             </dependency>
 
             <dependency>
@@ -219,6 +222,21 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -264,7 +282,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-plugin-javadoc.version}</version>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -282,7 +300,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>${maven-plugin-source.version}</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -298,7 +316,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>${maven-plugin-central-publishing.version}</version>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
@@ -308,7 +326,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>${maven-plugin-gpg.version}</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/tooling/forage-maven-catalog-plugin/pom.xml
+++ b/tooling/forage-maven-catalog-plugin/pom.xml
@@ -131,7 +131,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -142,7 +141,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- **Property naming**: Rename Maven plugin properties to follow `maven-<name>-plugin.version` convention (`maven-javadoc-plugin.version`, `maven-gpg-plugin.version`, `maven-source-plugin.version`, `central-publishing-maven-plugin.version`, `maven-surefire-plugin.version`)
- **Property naming**: Rename `langchain4j-version` / `langchain4j-beta-version` / `langchain4j-community-version` to use `.version` suffix (`langchain4j.version`, etc.)
- **Plugin consolidation**: Add `maven-surefire-plugin`, `maven-failsafe-plugin`, and `maven-compiler-plugin` to root `pluginManagement` and remove hardcoded versions from 14 child POMs (versions ranged from 3.0.0 to 3.5.3, now unified at 3.5.4)
- **Missing versions**: `maven-compiler-plugin` in 2 Quarkus deployment POMs now inherits version 3.15.0 from root `pluginManagement`
- **Hardcoded versions**: Replace hardcoded `maven-resources-plugin` and `build-helper-maven-plugin` versions in `forage-catalog/pom.xml` with property references

## Test plan
- [x] Full `mvn compile` passes across all modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Maven property naming conventions across build configuration files for improved consistency and maintainability.
  * Centralized plugin version management in the root build configuration to reduce version duplication across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->