### PR TITLE
Update Forage documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,14 @@ public interface BeanProvider<T> {
 
 **@ForageBean** - Required on all provider classes:
 ```java
-@ForageBean(value = "provider-name", component = "camel-langchain4j-agent", description = "Description")
+@ForageBean(value = "provider-name", components = {"camel-langchain4j-agent"}, description = "Description")
 public class MyProvider implements ModelProvider { ... }
 ```
 
 **@ForageFactory** - Required on all factory classes:
 ```java
-@ForageFactory(value = "factory-name", component = "camel-langchain4j-agent",
-               description = "Description", factoryType = "Agent")
+@ForageFactory(value = "factory-name", components = {"camel-langchain4j-agent"},
+               description = "Description", type = FactoryType.AGENT)
 public class MyFactory implements AgentFactory { ... }
 ```
 
@@ -168,7 +168,7 @@ Create `META-INF/services/<interface-name>` files listing implementation classes
 
 ## Naming Conventions
 
-- **Artifacts**: `forage-<category>-<technology>` (e.g., `forage-model-openai`)
+- **Artifacts**: `forage-<category>-<technology>` (e.g., `forage-model-open-ai`)
 - **Packages**: `io.kaoto.forage.<category>.<technology>`
 - **Config env vars**: `FORAGE_<TECHNOLOGY>_<PROPERTY>` (e.g., `FORAGE_OPENAI_API_KEY`)
 - **Config properties**: `forage.<technology>.<property>` (e.g., `forage.openai.api.key`)

--- a/README.md
+++ b/README.md
@@ -26,25 +26,19 @@ Add the desired modules to your project. For example, to use the default agent f
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-model-open-ai</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 <!--This component provides support for the message window chat memory -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-memory-message-window</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
-<!--This component adds agent factories for single and multi-agent systems -->
-<dependency>
-    <groupId>io.kaoto.forage</groupId>
-    <artifactId>forage-agent-factories</artifactId>
-    <version>1.0-SNAPSHOT</version>
-</dependency>
-<!--This component adds the composable agent implementation -->
+<!--This component adds the composable agent implementation (pulls in agent factories transitively) -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -54,10 +48,10 @@ Simply reference the bean class in your Camel route:
 
 ```java
 from("direct:start")
-    .to("langchain4j-agent:test-memory-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory");
+    .to("langchain4j-agent:agent?agent=#ollama");
 ```
 
-The `io.kaoto.forage.agent.factory.MultiAgentFactory` class is a factory that builds AI agents automatically based on the dependencies available on the classpath and configured through properties. It supports both single-agent and multi-agent configurations.
+The `agent` parameter references a named bean configured via properties. In this example, `#ollama` refers to an Ollama model bean that is automatically discovered and configured through Forage's property-based configuration system.
 
 ## Available Modules
 
@@ -104,8 +98,7 @@ Forage provides JDBC data source factories that simplify database connectivity w
 #### Available JDBC Modules
 
 - **forage-jdbc** - Core pooled JDBC functionality
-- **forage-jdbc-factories** - Data source factory implementations
-- **forage-jdbc-postgres** - PostgreSQL data source provider
+- **forage-jdbc-postgresql** - PostgreSQL data source provider
 - **forage-jdbc-mysql** - MySQL data source provider  
 - **forage-jdbc-mariadb** - MariaDB data source provider
 - **forage-jdbc-oracle** - Oracle data source provider
@@ -119,24 +112,22 @@ Forage provides JDBC data source factories that simplify database connectivity w
 All JDBC modules support the following configuration properties with a flexible precedence hierarchy (environment variables → system properties → configuration files → defaults):
 
 **Database Connection:**
-- `jdbc.url` - JDBC connection URL (required)
-- `jdbc.username` - Database username (required)
-- `jdbc.password` - Database password (required)
+- `forage.jdbc.db.kind` - Database kind (required, e.g., `postgresql`, `mysql`)
+- `forage.jdbc.url` - JDBC connection URL (required)
+- `forage.jdbc.username` - Database username (required)
+- `forage.jdbc.password` - Database password (required)
 
 **Connection Pool Settings:**
-- `jdbc.pool.initial.size` - Initial pool size (default: 5)
-- `jdbc.pool.min.size` - Minimum pool size (default: 2)
-- `jdbc.pool.max.size` - Maximum pool size (default: 20)
-- `jdbc.pool.acquisition.timeout.seconds` - Connection acquisition timeout (default: 5)
-- `jdbc.pool.validation.timeout.seconds` - Connection validation timeout (default: 3)
-- `jdbc.pool.leak.timeout.minutes` - Connection leak detection timeout (default: 10)
-- `jdbc.pool.idle.validation.timeout.minutes` - Idle connection validation timeout (default: 3)
+- `forage.jdbc.pool.initial.size` - Initial pool size (default: 5)
+- `forage.jdbc.pool.min.size` - Minimum pool size (default: 2)
+- `forage.jdbc.pool.max.size` - Maximum pool size (default: 20)
+- `forage.jdbc.pool.acquisition.timeout.seconds` - Connection acquisition timeout (default: 5)
+- `forage.jdbc.pool.validation.timeout.seconds` - Connection validation timeout (default: 3)
+- `forage.jdbc.pool.leak.timeout.minutes` - Connection leak detection timeout (default: 10)
+- `forage.jdbc.pool.idle.validation.timeout.minutes` - Idle connection validation timeout (default: 3)
 
 **Transaction Settings:**
-- `jdbc.transaction.timeout.seconds` - Transaction timeout (default: 30)
-
-**Provider Configuration:**
-- `provider.datasource.class` - DataSource implementation class (auto-detected based on dependencies)
+- `forage.jdbc.transaction.timeout.seconds` - Transaction timeout (default: 30)
 
 #### Quick Start with PostgreSQL
 
@@ -149,13 +140,13 @@ camel infra run postgres
 ```xml
 <dependency>
     <groupId>io.kaoto.forage</groupId>
-    <artifactId>forage-jdbc-factories</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>forage-jdbc</artifactId>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 <dependency>
     <groupId>io.kaoto.forage</groupId>
-    <artifactId>forage-jdbc-postgres</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>forage-jdbc-postgresql</artifactId>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -168,7 +159,7 @@ public class Test extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("timer:java?period=1000")
-                .to("sql:select * from acme?dataSourceFactory=#class:io.kaoto.forage.jdbc.factory.DefaultDataSourceFactory")
+                .to("sql:select * from acme")
                 .log("${body}");
     }
 }
@@ -177,8 +168,8 @@ public class Test extends RouteBuilder {
 4. **Run with JBang:**
 ```bash
 camel run Test.java \
-  --dep=mvn:io.kaoto.forage:forage-jdbc-factories:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-jdbc-postgres:1.0-SNAPSHOT
+  --dep=mvn:io.kaoto.forage:forage-jdbc:1.1-SNAPSHOT \
+  --dep=mvn:io.kaoto.forage:forage-jdbc-postgresql:1.1-SNAPSHOT
 ```
 
 This provides a fully configured, pooled data source out-of-the-box with sensible defaults.
@@ -187,26 +178,26 @@ This provides a fully configured, pooled data source out-of-the-box with sensibl
 
 **Environment Variables:**
 ```bash
-export JDBC_URL="jdbc:postgresql://localhost:5432/mydb"
-export JDBC_USERNAME="myuser"
-export JDBC_PASSWORD="mypassword"
-export JDBC_POOL_MAX_SIZE="50"
+export FORAGE_JDBC_URL="jdbc:postgresql://localhost:5432/mydb"
+export FORAGE_JDBC_USERNAME="myuser"
+export FORAGE_JDBC_PASSWORD="mypassword"
+export FORAGE_JDBC_POOL_MAX_SIZE="50"
 ```
 
 **System Properties:**
 ```bash
--Djdbc.url=jdbc:postgresql://localhost:5432/mydb
--Djdbc.username=myuser
--Djdbc.password=mypassword
--Djdbc.pool.max.size=50
+-Dforage.jdbc.url=jdbc:postgresql://localhost:5432/mydb
+-Dforage.jdbc.username=myuser
+-Dforage.jdbc.password=mypassword
+-Dforage.jdbc.pool.max.size=50
 ```
 
 **Configuration File (forage-datasource-factory.properties):**
 ```properties
-jdbc.url=jdbc:postgresql://localhost:5432/mydb
-jdbc.username=myuser
-jdbc.password=mypassword
-jdbc.pool.max.size=50
+forage.jdbc.url=jdbc:postgresql://localhost:5432/mydb
+forage.jdbc.username=myuser
+forage.jdbc.password=mypassword
+forage.jdbc.pool.max.size=50
 ```
 
 ## Configuration
@@ -232,20 +223,20 @@ For immediate setup, here are minimal configuration examples:
 
 #### OpenAI
 ```bash
-export OPENAI_API_KEY="sk-your-api-key-here"
-export OPENAI_MODEL_NAME="gpt-4"  # Optional, defaults to gpt-3.5-turbo
+export FORAGE_OPENAI_API_KEY="sk-your-api-key-here"
+export FORAGE_OPENAI_MODEL_NAME="gpt-4"  # Optional, defaults to gpt-3.5-turbo
 ```
 
 #### Google Gemini
 ```bash
-export GOOGLE_API_KEY="your-google-api-key"
-export GOOGLE_MODEL_NAME="gemini-pro"
+export FORAGE_GOOGLE_API_KEY="your-google-api-key"
+export FORAGE_GOOGLE_MODEL_NAME="gemini-pro"
 ```
 
 #### Ollama
 ```bash
-export OLLAMA_BASE_URL="http://localhost:11434"  # Optional, this is the default
-export OLLAMA_MODEL_NAME="llama3"                # Optional, this is the default
+export FORAGE_OLLAMA_BASE_URL="http://localhost:11434"  # Optional, this is the default
+export FORAGE_OLLAMA_MODEL_NAME="llama3"                # Optional, this is the default
 ```
 
 ## Architecture
@@ -268,7 +259,7 @@ Example for a memory-less agent.
 ```java
 from("timer:ai?period=30000")
     .setBody(constant("Tell me a joke"))
-    .to("langchain4j-agent:joke-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:agent?agent=#ollama")
     .log("AI Response: ${body}");
 ```
 
@@ -279,7 +270,7 @@ public class MyRoutes extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("direct:chat")
-            .to("langchain4j-agent:chat-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+            .to("langchain4j-agent:agent?agent=#ollama")
             .log("Chat response: ${body}");
     }
 }

--- a/docs/adding-modules.md
+++ b/docs/adding-modules.md
@@ -544,7 +544,7 @@ Use these existing modules as templates:
 
 | Module | Complexity | Good for |
 |--------|-----------|----------|
-| AI chat model (e.g., `forage-model-openai`) | Simple | Provider-only modules (no Spring Boot/Quarkus integration needed) |
+| AI chat model (e.g., `forage-model-open-ai`) | Simple | Provider-only modules (no Spring Boot/Quarkus integration needed) |
 | Guardrails (e.g., `forage-guardrail-input-length`) | Simple | Config + provider with minimal boilerplate |
 | JDBC (`forage-jdbc-common` + starters) | Complex | Full three-runtime support with transactions and auxiliary beans |
 | JMS (`forage-jms-common` + starters) | Medium | Three-runtime support with property translation |

--- a/docs/contributing-beans.md
+++ b/docs/contributing-beans.md
@@ -72,7 +72,7 @@ Create a core component that contains the foundational interfaces:
 
 ```
 core/forage-vector-db/
-├── src/main/java/org/apache/camel/forage/core/vector/db/
+├── src/main/java/io/kaoto/forage/core/vector/db/
 │   ├── VectorDBFactory.java          # Factory interface
 │   └── VectorDBProvider.java         # Provider interface
 └── pom.xml
@@ -109,7 +109,7 @@ Create a common component with default implementations:
 
 ```
 library/vector-dbs/forage-default-vector-db-factory/
-├── src/main/java/org/apache/camel/forage/vector/db/
+├── src/main/java/io/kaoto/forage/vector/db/
 │   └── DefaultVectorDBFactory.java   # Default factory implementation
 └── pom.xml
 ```
@@ -148,7 +148,7 @@ Create specific provider implementations for each technology:
 
 ```
 library/vector-dbs/forage-milvus/
-├── src/main/java/org/apache/camel/forage/vector/db/milvus/
+├── src/main/java/io/kaoto/forage/vector/db/milvus/
 │   ├── MilvusProvider.java            # Provider implementation
 │   └── MilvusConfig.java              # Configuration class
 ├── src/main/resources/META-INF/services/
@@ -165,7 +165,7 @@ package io.kaoto.forage.vector.db.milvus;
 import io.kaoto.forage.core.vector.db.VectorDBProvider;
 import io.kaoto.forage.core.annotations.ForageBean;
 
-@ForageBean(value = "milvus", component = "camel-langchain4j-embeddings", description = "Milvus vector database provider")
+@ForageBean(value = "milvus", components = {"camel-langchain4j-embeddings"}, description = "Milvus vector database provider")
 public class MilvusProvider implements VectorDBProvider {
     
     @Override
@@ -190,38 +190,26 @@ Configuration in Forage uses a two-class pattern supporting named/prefixed confi
 ```java
 package io.kaoto.forage.vector.db.milvus;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import io.kaoto.forage.core.util.config.ConfigEntries;
-import io.kaoto.forage.core.util.config.ConfigEntry;
 import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigTag;
 
 public final class MilvusConfigEntries extends ConfigEntries {
-    public static final ConfigModule HOST = ConfigModule.of(MilvusConfig.class, "milvus.host");
-    public static final ConfigModule PORT = ConfigModule.of(MilvusConfig.class, "milvus.port");
-    public static final ConfigModule USERNAME = ConfigModule.of(MilvusConfig.class, "milvus.username");
-    public static final ConfigModule PASSWORD = ConfigModule.of(MilvusConfig.class, "milvus.password");
-
-    private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new HashMap<>();
+    public static final ConfigModule HOST = ConfigModule.of(
+            MilvusConfig.class, "forage.milvus.host",
+            "Milvus server host", "Host", "localhost", "string", false, ConfigTag.COMMON);
+    public static final ConfigModule PORT = ConfigModule.of(
+            MilvusConfig.class, "forage.milvus.port",
+            "Milvus server port", "Port", "19530", "integer", false, ConfigTag.COMMON);
+    public static final ConfigModule USERNAME = ConfigModule.of(
+            MilvusConfig.class, "forage.milvus.username",
+            "Username for authentication", "Username", null, "string", false, ConfigTag.COMMON);
+    public static final ConfigModule PASSWORD = ConfigModule.of(
+            MilvusConfig.class, "forage.milvus.password",
+            "Password for authentication", "Password", null, "string", true, ConfigTag.COMMON);
 
     static {
-        CONFIG_MODULES.put(HOST, ConfigEntry.fromModule(HOST, "MILVUS_HOST"));
-        CONFIG_MODULES.put(PORT, ConfigEntry.fromModule(PORT, "MILVUS_PORT"));
-        CONFIG_MODULES.put(USERNAME, ConfigEntry.fromModule(USERNAME, "MILVUS_USERNAME"));
-        CONFIG_MODULES.put(PASSWORD, ConfigEntry.fromModule(PASSWORD, "MILVUS_PASSWORD"));
-    }
-
-    public static Map<ConfigModule, ConfigEntry> entries() {
-        return Collections.unmodifiableMap(CONFIG_MODULES);
-    }
-
-    public static ConfigModule find(String prefix, String name) {
-        return find(CONFIG_MODULES, prefix, name);
-    }
-
-    public static void register(String prefix) {
-        register(CONFIG_MODULES, prefix);
+        initModules(MilvusConfigEntries.class, HOST, PORT, USERNAME, PASSWORD);
     }
 }
 ```
@@ -230,86 +218,42 @@ public final class MilvusConfigEntries extends ConfigEntries {
 ```java
 package io.kaoto.forage.vector.db.milvus;
 
+import io.kaoto.forage.core.util.config.AbstractConfig;
+
 import static io.kaoto.forage.vector.db.milvus.MilvusConfigEntries.HOST;
 import static io.kaoto.forage.vector.db.milvus.MilvusConfigEntries.PORT;
 import static io.kaoto.forage.vector.db.milvus.MilvusConfigEntries.USERNAME;
 import static io.kaoto.forage.vector.db.milvus.MilvusConfigEntries.PASSWORD;
 
-import io.kaoto.forage.core.util.config.Config;
-import io.kaoto.forage.core.util.config.ConfigModule;
-import io.kaoto.forage.core.util.config.ConfigStore;
+public class MilvusConfig extends AbstractConfig {
 
-/**
- * Configuration class for Milvus vector database integration.
- * 
- * <p>Supports both default and named configurations for multi-instance setups.
- * 
- * <p><strong>Configuration Parameters:</strong>
- * <ul>
- *   <li><strong>MILVUS_HOST</strong> - Milvus server host (default: "localhost")</li>
- *   <li><strong>MILVUS_PORT</strong> - Milvus server port (default: 19530)</li>
- *   <li><strong>MILVUS_USERNAME</strong> - Username for authentication (optional)</li>
- *   <li><strong>MILVUS_PASSWORD</strong> - Password for authentication (optional)</li>
- * </ul>
- * 
- * <p><strong>Named Configuration Example:</strong>
- * <pre>{@code
- * // Default configuration
- * MilvusConfig defaultConfig = new MilvusConfig();
- * 
- * // Named configurations
- * MilvusConfig vectorStoreConfig = new MilvusConfig("vectorstore");
- * MilvusConfig embeddingsConfig = new MilvusConfig("embeddings");
- * }</pre>
- */
-public class MilvusConfig implements Config {
-    
-    private static final String DEFAULT_HOST = "localhost";
-    private static final Integer DEFAULT_PORT = 19530;
-    private final String prefix;
-    
     public MilvusConfig() {
         this(null);
     }
-    
+
     public MilvusConfig(String prefix) {
-        this.prefix = prefix;
-        
-        MilvusConfigEntries.register(prefix);
-        ConfigStore.getInstance().add(MilvusConfig.class, this, this::register);
+        super(prefix, MilvusConfigEntries.class);
     }
-    
-    private ConfigModule resolve(String name) {
-        return MilvusConfigEntries.find(prefix, name);
-    }
-    
-    @Override
-    public void register(String name, String value) {
-        ConfigModule config = resolve(name);
-        ConfigStore.getInstance().set(config, value);
-    }
-    
+
     @Override
     public String name() {
         return "forage-vector-db-milvus";
     }
-    
+
     public String host() {
-        return ConfigStore.getInstance().get(HOST.asNamed(prefix)).orElse(DEFAULT_HOST);
+        return get(HOST).orElse(HOST.defaultValue());
     }
-    
+
     public Integer port() {
-        return ConfigStore.getInstance().get(PORT.asNamed(prefix))
-            .map(Integer::parseInt)
-            .orElse(DEFAULT_PORT);
+        return get(PORT).map(Integer::parseInt).orElse(Integer.parseInt(PORT.defaultValue()));
     }
-    
+
     public String username() {
-        return ConfigStore.getInstance().get(USERNAME.asNamed(prefix)).orElse(null);
+        return get(USERNAME).orElse(null);
     }
-    
+
     public String password() {
-        return ConfigStore.getInstance().get(PASSWORD.asNamed(prefix)).orElse(null);
+        return get(PASSWORD).orElse(null);
     }
 }
 ```
@@ -336,7 +280,7 @@ io.kaoto.forage.vector.db.milvus.MilvusProvider
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vector-dbs</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vector-db-milvus</artifactId>
@@ -381,7 +325,7 @@ Make sure to include the specific provider on your classpath:
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-vector-db-milvus</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -391,28 +335,28 @@ Make sure to include the specific provider on your classpath:
 Configure using environment variables:
 
 ```bash
-export MILVUS_HOST="milvus.example.com"
-export MILVUS_PORT="19530"
-export MILVUS_USERNAME="admin"
-export MILVUS_PASSWORD="password123"
+export FORAGE_MILVUS_HOST="milvus.example.com"
+export FORAGE_MILVUS_PORT="19530"
+export FORAGE_MILVUS_USERNAME="admin"
+export FORAGE_MILVUS_PASSWORD="password123"
 ```
 
 Or using system properties:
 
 ```bash
--Dmilvus.host=milvus.example.com
--Dmilvus.port=19530
--Dmilvus.username=admin
--Dmilvus.password=password123
+-Dforage.milvus.host=milvus.example.com
+-Dforage.milvus.port=19530
+-Dforage.milvus.username=admin
+-Dforage.milvus.password=password123
 ```
 
 Or using configuration files (`forage-vector-db-milvus.properties`):
 
 ```properties
-host=milvus.example.com
-port=19530
-username=admin
-password=password123
+forage.milvus.host=milvus.example.com
+forage.milvus.port=19530
+forage.milvus.username=admin
+forage.milvus.password=password123
 ```
 
 #### Named/Prefixed Configuration
@@ -420,19 +364,19 @@ For multi-instance setups using named configurations:
 
 ```bash
 # Environment variables (prefix becomes uppercase)
-export MILVUS_HOST="default.milvus.com"           # Default config
-export vectorstore.milvus.host="vs.milvus.com"   # "vectorstore" config
-export embeddings.milvus.host="emb.milvus.com"   # "embeddings" config
+export FORAGE_MILVUS_HOST="default.milvus.com"           # Default config
+export forage.vectorstore.milvus.host="vs.milvus.com"   # "vectorstore" config
+export forage.embeddings.milvus.host="emb.milvus.com"   # "embeddings" config
 
 # System properties
--Dmilvus.host=default.milvus.com                  # Default config
--Dvectorstore.milvus.host=vs.milvus.com          # "vectorstore" config
--Dembeddings.milvus.host=emb.milvus.com          # "embeddings" config
+-Dforage.milvus.host=default.milvus.com                  # Default config
+-Dforage.vectorstore.milvus.host=vs.milvus.com          # "vectorstore" config
+-Dforage.embeddings.milvus.host=emb.milvus.com          # "embeddings" config
 ```
 
 In your provider code:
 ```java
-@ForageBean(value = "milvus-multi", component = "camel-langchain4j-embeddings", description = "Multi-instance Milvus vector database provider")
+@ForageBean(value = "milvus-multi", components = {"camel-langchain4j-embeddings"}, description = "Multi-instance Milvus vector database provider")
 public class MultiInstanceMilvusProvider implements VectorDBProvider {
     @Override
     public VectorDatabase create(String id) {
@@ -453,7 +397,7 @@ public class MultiInstanceMilvusProvider implements VectorDBProvider {
 **MANDATORY**: All provider classes must be annotated with `@ForageBean`:
 
 ```java
-@ForageBean(value = "unique-name", component = "supported-component", description = "What it does")
+@ForageBean(value = "unique-name", components = {"supported-component"}, description = "What it does")
 public class YourProvider implements ProviderInterface {
     // Implementation
 }
@@ -461,10 +405,10 @@ public class YourProvider implements ProviderInterface {
 
 **Annotation Parameters:**
 - `value`: Unique identifier for the bean (e.g., "milvus", "azure-openai", "message-window")
-- `component`: Supported Camel component - use standard components:
-  - "camel-langchain4j-agent" for model providers and memory providers
-  - "camel-langchain4j-embeddings" for vector database providers
+- `components`: Supported Camel components (String array)
 - `description`: Human-readable description of what the provider does
+- `feature`: Feature group (e.g., "Chat Model", "Memory") — optional
+- `configClass`: Config class for properties file association — optional
 
 **Required Import:**
 ```java
@@ -477,10 +421,10 @@ import io.kaoto.forage.core.annotations.ForageBean;
 
 ```java
 @ForageFactory(
-    value = "unique-factory-name", 
-    component = "supported-component", 
+    value = "unique-factory-name",
+    components = {"supported-component"},
     description = "What the factory creates",
-    factoryType = "CreatedObjectType")
+    type = FactoryType.AGENT)
 public class YourFactory implements FactoryInterface {
     // Implementation
 }
@@ -488,9 +432,9 @@ public class YourFactory implements FactoryInterface {
 
 The annotation parameters:
 - `value`: Unique identifier for the factory (e.g., "default-agent", "multi-agent", "redis-memory")
-- `component`: Supported Camel component (e.g., "camel-langchain4j-agent", "camel-langchain4j-embeddings")
+- `components`: Supported Camel components (String array)
 - `description`: Human-readable description of what the factory creates
-- `factoryType`: Type of objects this factory creates (e.g., "Agent", "ChatMemoryProvider", "EmbeddingStore")
+- `type`: Type of objects this factory creates (enum `FactoryType`, e.g., `FactoryType.AGENT`)
 
 **Required Import:**
 ```java
@@ -501,8 +445,8 @@ import io.kaoto.forage.core.annotations.ForageFactory;
 - Always follow the Forage two-class configuration pattern with `Config` and `ConfigEntries` classes
 - Create a `*ConfigEntries` class extending `ConfigEntries` with static fields and maps
 - Support both default and named/prefixed configurations in the main `Config` class
-- Use meaningful environment variable names with a consistent prefix (e.g., `MILVUS_*`)
-- Use dot-notation for ConfigModule names (e.g., `milvus.host`, `milvus.port`)
+- Use meaningful environment variable names with a consistent prefix (e.g., `FORAGE_MILVUS_*`)
+- Use dot-notation for ConfigModule names (e.g., `forage.milvus.host`)
 - Provide sensible defaults where appropriate
 - Document all configuration parameters comprehensively including named configuration examples
 

--- a/docs/multi-agent-guide.md
+++ b/docs/multi-agent-guide.md
@@ -33,38 +33,23 @@ Forage provides an opinionated library of beans for Apache Camel that simplifies
 
 ### 1. Configuration Files
 
-Create configuration files for each component:
+All agent configuration goes in a single `forage-agent-factory.properties` file. Each agent is identified by a unique prefix (e.g., `foo`, `bar`) and uses the `forage.<prefix>.agent.*` property pattern.
 
 #### forage-agent-factory.properties
 ```properties
-# Define multi agents
-multi.agent.names=google,ollama
+forage.foo.agent.model.kind=google-gemini
+forage.foo.agent.model.name=gemini-2.5-flash-lite
+forage.foo.agent.api.key=<my-api-key>
+forage.foo.agent.features=memory
+forage.foo.agent.memory.kind=message-window
+forage.foo.agent.memory.max.messages=20
 
-# Google Agent Configuration
-google.provider.agent.class=io.kaoto.forage.agent.simple.SimpleAgent
-google.provider.model.factory.class=io.kaoto.forage.models.chat.google.GoogleGeminiProvider
-google.provider.features=memory
-google.provider.features.memory.factory.class=io.kaoto.forage.memory.chat.messagewindow.MessageWindowChatMemoryBeanProvider
-
-# Ollama Agent Configuration
-ollama.provider.agent.class=io.kaoto.forage.agent.memoryless.MemorylessAgent
-ollama.provider.model.factory.class=io.kaoto.forage.models.chat.ollama.OllamaProvider
-ollama.provider.features=memoryless
-ollama.provider.features.memory.factory.class=io.kaoto.forage.memory.chat.messagewindow.MessageWindowChatMemoryBeanProvider
-```
-
-#### forage-model-google-gemini.properties
-```properties
-# Google API Configuration
-google.api.key=your-google-api-key-here
-google.model.name=gemini-2.5-flash
-```
-
-#### forage-model-ollama.properties
-```properties
-# Ollama Configuration
-ollama.base.url=http://localhost:11434
-ollama.model.name=llama3.1:latest
+forage.bar.agent.model.kind=ollama
+forage.bar.agent.model.name=granite4:3b
+forage.bar.agent.base.url=http://localhost:11434
+forage.bar.agent.features=memory
+forage.bar.agent.memory.kind=message-window
+forage.bar.agent.memory.max.messages=20
 ```
 
 ### 2. Agent ID Source Configuration
@@ -75,38 +60,38 @@ The MultiAgentFactory supports different strategies for extracting agent IDs fro
 
 | Source Type | Description | Configuration Property | Additional Configuration Required |
 |-------------|-------------|----------------------|----------------------------------|
-| `route` | Extract from route ID (default) | `multi.agent.id.source=route` | None |
-| `header` | Extract from exchange header | `multi.agent.id.source=header` | `multi.agent.id.source.header=HeaderName` |
-| `property` | Extract from exchange property | `multi.agent.id.source=property` | `multi.agent.id.source.property=PropertyName` |
-| `variable` | Extract from exchange variable | `multi.agent.id.source=variable` | `multi.agent.id.source.variable=VariableName` |
+| `route` | Extract from route ID (default) | `forage.multi.agent.id.source=route` | None |
+| `header` | Extract from exchange header | `forage.multi.agent.id.source=header` | `forage.multi.agent.id.source.header=HeaderName` |
+| `property` | Extract from exchange property | `forage.multi.agent.id.source=property` | `forage.multi.agent.id.source.property=PropertyName` |
+| `variable` | Extract from exchange variable | `forage.multi.agent.id.source=variable` | `forage.multi.agent.id.source.variable=VariableName` |
 
 #### Configuration Examples
 
 **Route ID Source (Default):**
 ```properties
 # Uses the route ID to determine which agent to use
-multi.agent.id.source=route
+forage.multi.agent.id.source=route
 ```
 
 **Header Source:**
 ```properties
 # Extract agent ID from the "AgentType" header
-multi.agent.id.source=header
-multi.agent.id.source.header=AgentType
+forage.multi.agent.id.source=header
+forage.multi.agent.id.source.header=AgentType
 ```
 
 **Property Source:**
 ```properties
 # Extract agent ID from the "agent.name" exchange property
-multi.agent.id.source=property
-multi.agent.id.source.property=agent.name
+forage.multi.agent.id.source=property
+forage.multi.agent.id.source.property=agent.name
 ```
 
 **Variable Source:**
 ```properties
 # Extract agent ID from the "selectedAgent" exchange variable
-multi.agent.id.source=variable
-multi.agent.id.source.variable=selectedAgent
+forage.multi.agent.id.source=variable
+forage.multi.agent.id.source.variable=selectedAgent
 ```
 
 #### Route Examples with Different ID Sources
@@ -125,7 +110,7 @@ multi.agent.id.source.variable=selectedAgent
         - to:
             uri: langchain4j-agent:dynamic
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: "#google"
         - log: "Response from ${header.AgentType}: ${body}"
 ```
 
@@ -143,7 +128,7 @@ multi.agent.id.source.variable=selectedAgent
         - to:
             uri: langchain4j-agent:dynamic
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: "#google"
         - log: "Response from ${exchangeProperty.agent.name}: ${body}"
 ```
 
@@ -161,13 +146,24 @@ multi.agent.id.source.variable=selectedAgent
         - to:
             uri: langchain4j-agent:dynamic
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: "#google"
         - log: "Response from ${variable.selectedAgent}: ${body}"
 ```
 
 ### 3. Camel Route Configuration
 
 #### Single Agent Example (agent.camel.yaml)
+
+Uses `application.properties` for configuration:
+```properties
+forage.ollama.agent.model.kind=ollama
+forage.ollama.agent.model.name=granite4:3b
+forage.ollama.agent.base.url=http://localhost:11434
+forage.ollama.agent.features=memory
+forage.ollama.agent.memory.kind=message-window
+forage.ollama.agent.memory.max.messages=20
+```
+
 ```yaml
 - route:
     id: single-agent-route
@@ -186,7 +182,7 @@ multi.agent.id.source.variable=selectedAgent
         - to:
             uri: langchain4j-agent:test
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: '#ollama'
               tags: users
         - log: ${body}
 
@@ -206,12 +202,15 @@ multi.agent.id.source.variable=selectedAgent
 ```
 
 #### Multi-Agent Example (multi-agent.camel.yaml)
+
+Uses `forage-agent-factory.properties` for configuration (see section 1 above).
+
 ```yaml
 - route:
-    id: google-agent
+    id: foo-agent
     description: Route using Google Gemini Agent
     from:
-      uri: timer:google
+      uri: timer:foo
       parameters:
         repeatCount: "1"
       steps:
@@ -223,17 +222,17 @@ multi.agent.id.source.variable=selectedAgent
         - setBody:
             simple: give the details of user 123
         - to:
-            uri: langchain4j-agent:google-test
+            uri: langchain4j-agent:foo-test
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: "#foo"
               tags: users
-        - log: "Google Agent Response: ${body}"
+        - log: "Foo Agent Response: ${body}"
 
 - route:
-    id: ollama-agent
+    id: bar-agent
     description: Route using local Ollama Agent
     from:
-      uri: timer:ollama
+      uri: timer:bar
       parameters:
         repeatCount: "1"
       steps:
@@ -245,10 +244,10 @@ multi.agent.id.source.variable=selectedAgent
         - setBody:
             simple: What is the timezone in Brasilia?
         - to:
-            uri: langchain4j-agent:ollama-test
+            uri: langchain4j-agent:bar-test
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
-        - log: "Ollama Agent Response: ${body}"
+              agent: "#bar"
+        - log: "Bar Agent Response: ${body}"
 
 # Shared tools available to all agents
 - route:
@@ -272,30 +271,26 @@ multi.agent.id.source.variable=selectedAgent
 
 1. **Camel JBang 4.14+**
 2. **JBang 0.129.0+**
-3. **API Keys**: Configure Google API key in `forage-model-google-gemini.properties`
+3. **API Keys**: Configure Google API key in `forage-agent-factory.properties`
 4. **Ollama**: For local model integration, ensure Ollama is running on localhost:11434
 
 ### Single Agent Execution
 
 ```bash
 camel run agent.camel.yaml \
-  --dep=mvn:io.kaoto.forage:forage-agent-factories:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-agent:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-memory-message-window:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-model-google-gemini:1.0-SNAPSHOT \
-  --dep=camel-langchain4j-agent
+  --dep=mvn:io.kaoto.forage:forage-agent:1.1-SNAPSHOT \
+  --dep=mvn:io.kaoto.forage:forage-memory-message-window:1.1-SNAPSHOT \
+  --dep=mvn:io.kaoto.forage:forage-model-ollama:1.1-SNAPSHOT
 ```
 
 ### Multi-Agent Execution
 
 ```bash
 camel run multi-agent.camel.yaml \
-  --dep=mvn:io.kaoto.forage:forage-agent-factories:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-agent:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-memory-message-window:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-model-google-gemini:1.0-SNAPSHOT \
-  --dep=mvn:io.kaoto.forage:forage-model-ollama:1.0-SNAPSHOT \
-  --dep=camel-langchain4j-agent
+  --dep=mvn:io.kaoto.forage:forage-agent:1.1-SNAPSHOT \
+  --dep=mvn:io.kaoto.forage:forage-memory-message-window:1.1-SNAPSHOT \
+  --dep=mvn:io.kaoto.forage:forage-model-google-gemini:1.1-SNAPSHOT \
+  --dep=mvn:io.kaoto.forage:forage-model-ollama:1.1-SNAPSHOT
 ```
 
 ## Kaoto Integration
@@ -330,7 +325,7 @@ When designing routes in Kaoto, ensure the following structure:
             id: to-component-id
             uri: langchain4j-agent:agent-name
             parameters:
-              agentFactory: "#class:factory.class"
+              agent: "#agent-prefix"
 ```
 
 ### Best Practices for Kaoto
@@ -369,23 +364,24 @@ When designing routes in Kaoto, ensure the following structure:
 #### **Customer Support Routing**
 ```properties
 # Route high-priority tickets to advanced AI
-multi.agent.id.source=property
-multi.agent.id.source.property=ticket.priority
+forage.multi.agent.id.source=property
+forage.multi.agent.id.source.property=ticket.priority
 
 # Configure agents
-multi.agent.names=basic,advanced
-basic.provider.model.factory.class=io.kaoto.forage.models.chat.ollama.OllamaProvider
-advanced.provider.model.factory.class=io.kaoto.forage.models.chat.google.GoogleGeminiProvider
+forage.basic.agent.model.kind=ollama
+forage.basic.agent.model.name=granite4:3b
+forage.basic.agent.base.url=http://localhost:11434
+
+forage.advanced.agent.model.kind=google-gemini
+forage.advanced.agent.model.name=gemini-2.5-flash-lite
+forage.advanced.agent.api.key=<my-api-key>
 ```
 
 #### **User Preference-Based Routing**
 ```properties
 # Let users choose their preferred AI model
-multi.agent.id.source=header
-multi.agent.id.source.header=X-Preferred-Agent
-
-# Configure agents
-multi.agent.names=google,ollama,openai
+forage.multi.agent.id.source=header
+forage.multi.agent.id.source.header=X-Preferred-Agent
 ```
 
 ## Advanced Multi-Agent Patterns
@@ -403,11 +399,11 @@ Chain agents to create sophisticated workflows:
         - to:
             uri: langchain4j-agent:analysis
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: "#analysis"
         - to:
-            uri: langchain4j-agent:synthesis  
+            uri: langchain4j-agent:synthesis
             parameters:
-              agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+              agent: "#synthesis"
         - log: "Final result: ${body}"
 ```
 
@@ -429,13 +425,13 @@ Use Camel's choice component for dynamic agent selection:
                   - to:
                       uri: langchain4j-agent:advanced
                       parameters:
-                        agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+                        agent: "#advanced"
             otherwise:
               steps:
                 - to:
                     uri: langchain4j-agent:simple
                     parameters:
-                      agentFactory: "#class:io.kaoto.forage.agent.factory.MultiAgentFactory"
+                      agent: "#simple"
 ```
 
 ### Memory Management
@@ -444,13 +440,14 @@ Configure different memory strategies per agent:
 
 ```properties
 # Long-term memory agent
-agent1.provider.features.memory.factory.class=io.kaoto.forage.memory.chat.redis.RedisChatMemoryFactory
+forage.agent1.agent.memory.kind=redis
 
 # Short-term memory agent
-agent2.provider.features.memory.factory.class=io.kaoto.forage.memory.chat.messagewindow.MessageWindowChatMemoryBeanProvider
+forage.agent2.agent.memory.kind=message-window
+forage.agent2.agent.memory.max.messages=20
 
 # Stateless agent
-agent3.provider.features=memoryless
+forage.agent3.agent.features=memoryless
 ```
 
 ### Guardrails
@@ -463,10 +460,10 @@ Configure guardrails in your `forage-agent-factory.properties` file:
 
 ```properties
 # Input guardrails - executed before the agent processes input
-guardrails.input.classes=com.example.ContentFilterGuardrail,com.example.RateLimitGuardrail
+forage.guardrails.input.classes=com.example.ContentFilterGuardrail,com.example.RateLimitGuardrail
 
 # Output guardrails - executed after the agent produces output
-guardrails.output.classes=com.example.PiiRedactionGuardrail,com.example.ToxicityFilterGuardrail
+forage.guardrails.output.classes=com.example.PiiRedactionGuardrail,com.example.ToxicityFilterGuardrail
 ```
 
 #### Named Agent Guardrails
@@ -474,19 +471,18 @@ guardrails.output.classes=com.example.PiiRedactionGuardrail,com.example.Toxicity
 For multi-agent configurations, use prefixed guardrails for each agent:
 
 ```properties
-# Define agents
-multi.agent.names=secure,standard
-
 # Secure agent with strict guardrails
-secure.provider.agent.class=io.kaoto.forage.agent.simple.SimpleAgent
-secure.provider.model.factory.class=io.kaoto.forage.models.chat.openai.OpenAIProvider
-secure.guardrails.input.classes=com.example.StrictContentFilter,com.example.AuthorizationGuardrail
-secure.guardrails.output.classes=com.example.PiiRedactionGuardrail,com.example.ComplianceGuardrail
+forage.secure.agent.model.kind=openai
+forage.secure.agent.model.name=gpt-4
+forage.secure.agent.api.key=<my-api-key>
+forage.secure.guardrails.input.classes=com.example.StrictContentFilter,com.example.AuthorizationGuardrail
+forage.secure.guardrails.output.classes=com.example.PiiRedactionGuardrail,com.example.ComplianceGuardrail
 
 # Standard agent with minimal guardrails
-standard.provider.agent.class=io.kaoto.forage.agent.simple.SimpleAgent
-standard.provider.model.factory.class=io.kaoto.forage.models.chat.ollama.OllamaProvider
-standard.guardrails.output.classes=com.example.BasicOutputFilter
+forage.standard.agent.model.kind=ollama
+forage.standard.agent.model.name=granite4:3b
+forage.standard.agent.base.url=http://localhost:11434
+forage.standard.guardrails.output.classes=com.example.BasicOutputFilter
 ```
 
 #### Environment Variable Configuration
@@ -495,13 +491,13 @@ Guardrails can also be configured via environment variables:
 
 ```bash
 # Single guardrail
-export GUARDRAILS_INPUT_CLASSES=com.example.ContentFilterGuardrail
+export FORAGE_GUARDRAILS_INPUT_CLASSES=com.example.ContentFilterGuardrail
 
 # Multiple guardrails (comma-separated)
-export GUARDRAILS_OUTPUT_CLASSES=com.example.PiiRedactionGuardrail,com.example.ToxicityFilterGuardrail
+export FORAGE_GUARDRAILS_OUTPUT_CLASSES=com.example.PiiRedactionGuardrail,com.example.ToxicityFilterGuardrail
 
 # Named agent guardrails (prefix with agent name in uppercase)
-export SECURE_GUARDRAILS_INPUT_CLASSES=com.example.StrictContentFilter
+export FORAGE_SECURE_GUARDRAILS_INPUT_CLASSES=com.example.StrictContentFilter
 ```
 
 ## Configuration Reference
@@ -510,29 +506,27 @@ export SECURE_GUARDRAILS_INPUT_CLASSES=com.example.StrictContentFilter
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `GOOGLE_API_KEY` | Google Gemini API key | `sk-...` |
-| `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434` |
-| `OLLAMA_MODEL_NAME` | Ollama model name | `llama3.1:latest` |
-| `MULTI_AGENT_NAMES` | Comma-separated agent names | `google,ollama,openai` |
-| `MULTI_AGENT_ID_SOURCE` | Agent ID extraction strategy | `route`, `header`, `property`, `variable` |
-| `MULTI_AGENT_ID_SOURCE_HEADER` | Header name for agent ID (when using header source) | `AgentType` |
-| `MULTI_AGENT_ID_SOURCE_PROPERTY` | Property name for agent ID (when using property source) | `agent.name` |
-| `MULTI_AGENT_ID_SOURCE_VARIABLE` | Variable name for agent ID (when using variable source) | `selectedAgent` |
-| `GUARDRAILS_INPUT_CLASSES` | Comma-separated input guardrail class names | `com.example.InputFilter` |
-| `GUARDRAILS_OUTPUT_CLASSES` | Comma-separated output guardrail class names | `com.example.OutputFilter` |
+| `FORAGE_GOOGLE_API_KEY` | Google Gemini API key | `sk-...` |
+| `FORAGE_OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434` |
+| `FORAGE_OLLAMA_MODEL_NAME` | Ollama model name | `granite4:3b` |
+| `FORAGE_MULTI_AGENT_ID_SOURCE` | Agent ID extraction strategy | `route`, `header`, `property`, `variable` |
+| `FORAGE_MULTI_AGENT_ID_SOURCE_HEADER` | Header name for agent ID (when using header source) | `AgentType` |
+| `FORAGE_MULTI_AGENT_ID_SOURCE_PROPERTY` | Property name for agent ID (when using property source) | `agent.name` |
+| `FORAGE_MULTI_AGENT_ID_SOURCE_VARIABLE` | Variable name for agent ID (when using variable source) | `selectedAgent` |
+| `FORAGE_GUARDRAILS_INPUT_CLASSES` | Comma-separated input guardrail class names | `com.example.InputFilter` |
+| `FORAGE_GUARDRAILS_OUTPUT_CLASSES` | Comma-separated output guardrail class names | `com.example.OutputFilter` |
 
 ### System Properties
 
 Configure via `-D` flags:
 
 ```bash
--Dgoogle.api.key=your-key
--Dollama.base.url=http://localhost:11434
--Dmulti.agent.names=google,ollama
--Dmulti.agent.id.source=header
--Dmulti.agent.id.source.header=AgentType
--Dguardrails.input.classes=com.example.InputFilter
--Dguardrails.output.classes=com.example.OutputFilter
+-Dforage.google.api.key=your-key
+-Dforage.ollama.base.url=http://localhost:11434
+-Dforage.multi.agent.id.source=header
+-Dforage.multi.agent.id.source.header=AgentType
+-Dforage.guardrails.input.classes=com.example.InputFilter
+-Dforage.guardrails.output.classes=com.example.OutputFilter
 ```
 
 ### Named Configurations
@@ -540,12 +534,14 @@ Configure via `-D` flags:
 Support multiple instances with prefixes:
 
 ```properties
-# Default configuration
-provider.model.factory.class=io.kaoto.forage.models.chat.openai.OpenAIProvider
+# Named configurations using the kind-based pattern
+forage.google.agent.model.kind=google-gemini
+forage.google.agent.model.name=gemini-2.5-flash-lite
+forage.google.agent.api.key=<my-api-key>
 
-# Named configurations
-google.provider.model.factory.class=io.kaoto.forage.models.chat.google.GoogleGeminiProvider
-ollama.provider.model.factory.class=io.kaoto.forage.models.chat.ollama.OllamaProvider
+forage.ollama.agent.model.kind=ollama
+forage.ollama.agent.model.name=granite4:3b
+forage.ollama.agent.base.url=http://localhost:11434
 ```
 
 ## Troubleshooting
@@ -557,14 +553,14 @@ ollama.provider.model.factory.class=io.kaoto.forage.models.chat.ollama.OllamaPro
 3. **Model Availability**: Check that configured models are available and accessible
 4. **Memory Configuration**: Ensure memory providers are properly configured for stateful agents
 5. **Agent ID Source Issues**:
-   - **Unknown Agent Error**: Check that the extracted agent ID matches one of the configured agent names in `multi.agent.names`
+   - **Unknown Agent Error**: Check that the extracted agent ID matches one of the configured agent prefixes
    - **Header/Property/Variable Not Found**: Verify the header, property, or variable is set before reaching the agent endpoint
    - **Missing Source Configuration**: When using `header`, `property`, or `variable` sources, ensure the corresponding name configuration is set
-   - **Invalid Source Type**: Check that `multi.agent.id.source` is set to one of: `route`, `header`, `property`, `variable`
+   - **Invalid Source Type**: Check that `forage.multi.agent.id.source` is set to one of: `route`, `header`, `property`, `variable`
 6. **Guardrail Issues**:
    - **ClassNotFoundException**: Ensure guardrail class names are fully-qualified (e.g., `com.example.MyGuardrail`) and the classes are available on the classpath
    - **RuntimeForageException**: Check that guardrail classes can be loaded by the application's class loader; in Quarkus or Spring Boot, ensure classes are properly packaged
-   - **Guardrails Not Executing**: Verify the configuration property names are correct (`guardrails.input.classes` or `guardrails.output.classes`) and for named agents, include the prefix (e.g., `myagent.guardrails.input.classes`)
+   - **Guardrails Not Executing**: Verify the configuration property names are correct (`forage.guardrails.input.classes` or `forage.guardrails.output.classes`) and for named agents, include the prefix (e.g., `forage.myagent.guardrails.input.classes`)
 
 ### Debug Mode
 

--- a/library/ai/agents/README.md
+++ b/library/ai/agents/README.md
@@ -37,42 +37,33 @@ Flexible agent implementation that can work with or without memory based on conf
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
 ### 2. Add Required Dependencies
-
-**Agent factories (always required):**
-```xml
-<dependency>
-    <groupId>io.kaoto.forage</groupId>
-    <artifactId>forage-agent-factories</artifactId>
-    <version>1.0-SNAPSHOT</version>
-</dependency>
-```
 
 **Model provider (choose one):**
 ```xml
 <!-- OpenAI -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
-    <artifactId>forage-model-openai</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>forage-model-open-ai</artifactId>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 
 <!-- Google Gemini -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-model-google-gemini</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 
 <!-- Ollama -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-model-ollama</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -81,7 +72,7 @@ Flexible agent implementation that can work with or without memory based on conf
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-memory-message-window</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -162,20 +153,16 @@ All configuration classes follow the same precedence order:
 #### Multi-Instance Configuration Examples
 
 ```bash
-# Environment variables for different configurations
-export OPENAI_API_KEY="default-key"              # Default config
-export agent1.openai.api.key="agent-key"        # "agent1" config  
-export api.openai.api.key="api-key"             # "api" config
+# Environment variables
+export FORAGE_OLLAMA_BASE_URL="http://localhost:11434"
+export FORAGE_OLLAMA_MODEL_NAME="granite4:3b"
 
-export MILVUS_HOST="localhost"                   # Default config
-export rag-system.milvus.host="vector-db.internal"  # "rag-system" config
+# Named configurations (with prefix)
+export FORAGE_AGENT1_OLLAMA_BASE_URL="http://server1:11434"
 
-# System properties (alternative to environment variables)
--Dopenai.api.key=default-key                    # Default config
--Dagent1.openai.api.key=agent-key              # "agent1" config
--Dapi.openai.api.key=api-key                   # "api" config
--Dmilvus.host=localhost                         # Default config
--Drag-system.milvus.host=vector-db.internal     # "rag-system" config
+# System properties
+-Dforage.ollama.base.url=http://localhost:11434
+-Dforage.ollama.model.name=granite4:3b
 ```
 
 #### Configuration Files
@@ -183,13 +170,13 @@ export rag-system.milvus.host="vector-db.internal"  # "rag-system" config
 Each module can also be configured via properties files:
 
 ```properties
-# forage-model-openai.properties (default config)
-api-key=default-key
-model-name=gpt-4
-
-# agent1.forage-model-openai.properties (prefixed config)  
-api-key=agent-key
-model-name=gpt-3.5-turbo
+# forage-agent-factory.properties (or application.properties)
+forage.ollama.agent.model.kind=ollama
+forage.ollama.agent.model.name=granite4:3b
+forage.ollama.agent.base.url=http://localhost:11434
+forage.ollama.agent.features=memory
+forage.ollama.agent.memory.kind=message-window
+forage.ollama.agent.memory.max.messages=20
 ```
 
 #### Provider Factory Integration
@@ -219,7 +206,7 @@ public class ChatBotRoutes extends RouteBuilder {
         from("timer:conversation?period=30s")
             .setHeader("CamelLangChain4jAgent.memoryId", constant("user-123"))
             .setBody(constant("How are you today?"))
-            .to("langchain4j-agent:chatbot?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+            .to("langchain4j-agent:chatbot?agent=#ollama")
             .log("Bot: ${body}");
     }
 }
@@ -232,7 +219,7 @@ public class ApiRoutes extends RouteBuilder {
     @Override
     public void configure() throws Exception {
         from("rest:post:/ask")
-            .to("langchain4j-agent:api?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+            .to("langchain4j-agent:api?agent=#api")
             .log("API Response: ${body}");
     }
 }
@@ -243,7 +230,7 @@ public class ApiRoutes extends RouteBuilder {
 ```java
 from("file:questions?noop=true")
     .split(body().tokenize("\n"))
-    .to("langchain4j-agent:processor?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:processor?agent=#processor")
     .to("file:answers");
 ```
 

--- a/library/ai/agents/forage-agent-factories/README.md
+++ b/library/ai/agents/forage-agent-factories/README.md
@@ -24,7 +24,7 @@ The `forage-agent-factories` module provides the `MultiAgentFactory` implementat
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent-factories</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ The `forage-agent-factories` module provides the `MultiAgentFactory` implementat
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 
@@ -45,28 +45,28 @@ For a working setup, include these dependencies:
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent-factories</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 
 <!-- Agent implementation -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 
 <!-- Model provider -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
-    <artifactId>forage-model-openai</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>forage-model-open-ai</artifactId>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 
 <!-- Memory provider (optional) -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-memory-message-window</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -126,6 +126,20 @@ The factories automatically configure agents with:
 - **Retrieval Augmentor**: Configured through the agent if supported
 - **Guardrails**: Configured through the agent if supported
 - **Multi-Agent Coordination**: Agent selectors and orchestration (MultiAgentFactory)
+
+### Properties File Configuration
+
+Agent configuration is specified in `forage-agent-factory.properties` (or `application.properties` for Spring Boot):
+
+```properties
+# forage-agent-factory.properties
+forage.foo.agent.model.kind=google-gemini
+forage.foo.agent.model.name=gemini-2.5-flash-lite
+forage.foo.agent.api.key=<my-api-key>
+forage.foo.agent.features=memory
+forage.foo.agent.memory.kind=message-window
+forage.foo.agent.memory.max.messages=20
+```
 
 ## Error Handling
 

--- a/library/ai/agents/forage-agent/README.md
+++ b/library/ai/agents/forage-agent/README.md
@@ -23,7 +23,7 @@ The `forage-agent` module provides a complete AI agent implementation (`SimpleAg
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -35,13 +35,13 @@ The composable agent is automatically discovered and used when you include this 
 from("direct:chat")
     .setBody(constant("My name is Alice"))
     .setHeader(Headers.MEMORY_ID, constant(1))
-    .to("langchain4j-agent:memory-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:memory-agent?agent=#ollama")
     .log("Response: ${body}");
 
 from("timer:check?delay=5000&repeatCount=1")
          .setBody(constant("What is my name?"))
         .setHeader(Headers.MEMORY_ID, constant(1))
-        .to("langchain4j-agent:test-memory-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+        .to("langchain4j-agent:test-memory-agent?agent=#ollama")
         .log("${body}");
 ```
 
@@ -51,11 +51,27 @@ The second route should have a response similar to `Your name is Alice.`
 
 For a complete setup, you'll also need:
 
-- A chat model provider (e.g., `forage-model-openai`, `forage-model-google-gemini`)
+- A chat model provider (e.g., `forage-model-open-ai`, `forage-model-google-gemini`)
 - A chat memory provider (e.g., `forage-memory-message-window`) - optional for memory support
 - Agent factories (`forage-agent-factories`)
 
 ## Configuration
+
+### Properties File Configuration
+
+Agent configuration is specified in `forage-agent-factory.properties` (or `application.properties` for Spring Boot):
+
+```properties
+# In application.properties or forage-agent-factory.properties
+forage.ollama.agent.model.kind=ollama
+forage.ollama.agent.model.name=granite4:3b
+forage.ollama.agent.base.url=http://localhost:11434
+forage.ollama.agent.features=memory
+forage.ollama.agent.memory.kind=message-window
+forage.ollama.agent.memory.max.messages=20
+```
+
+### Automatic Configuration
 
 The SimpleAgent is configured automatically by the agent factories using ServiceLoader discovery. Configuration includes:
 

--- a/library/ai/models/chat/forage-model-anthropic/README.md
+++ b/library/ai/models/chat/forage-model-anthropic/README.md
@@ -76,7 +76,7 @@ Once functional, it will be automatically discovered via ServiceLoader:
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 

--- a/library/ai/models/chat/forage-model-azure-openai/README.md
+++ b/library/ai/models/chat/forage-model-azure-openai/README.md
@@ -86,7 +86,7 @@ The provider is automatically discovered via ServiceLoader. Use it in your Camel
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 

--- a/library/ai/models/chat/forage-model-bedrock/README.md
+++ b/library/ai/models/chat/forage-model-bedrock/README.md
@@ -172,7 +172,7 @@ Bedrock models require opt-in before use:
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:bedrock?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:bedrock?agent=#bedrock")
     .log("Response: ${body}");
 ```
 
@@ -184,11 +184,11 @@ System.setProperty("advanced.bedrock.model.id", "anthropic.claude-3-5-sonnet-202
 
 from("direct:fast-chat")
     .setHeader("agentId", constant("fast"))
-    .to("langchain4j-agent:fast?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory");
+    .to("langchain4j-agent:fast?agent=#fast");
 
 from("direct:advanced-chat")
     .setHeader("agentId", constant("advanced"))
-    .to("langchain4j-agent:advanced?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory");
+    .to("langchain4j-agent:advanced?agent=#advanced");
 ```
 
 ### Using BedrockModelId Enum

--- a/library/ai/models/chat/forage-model-dashscope/README.md
+++ b/library/ai/models/chat/forage-model-dashscope/README.md
@@ -82,7 +82,7 @@ Once functional, it will be automatically discovered via ServiceLoader:
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 

--- a/library/ai/models/chat/forage-model-hugging-face/README.md
+++ b/library/ai/models/chat/forage-model-hugging-face/README.md
@@ -60,7 +60,7 @@ The provider is automatically discovered via ServiceLoader. Use it in your Camel
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 

--- a/library/ai/models/chat/forage-model-local-ai/README.md
+++ b/library/ai/models/chat/forage-model-local-ai/README.md
@@ -86,7 +86,7 @@ The provider is automatically discovered via ServiceLoader. Use it in your Camel
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 

--- a/library/ai/models/chat/forage-model-mistral-ai/README.md
+++ b/library/ai/models/chat/forage-model-mistral-ai/README.md
@@ -80,7 +80,7 @@ The provider is automatically discovered via ServiceLoader. Use it in your Camel
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 

--- a/library/ai/models/chat/forage-model-watsonx-ai/README.md
+++ b/library/ai/models/chat/forage-model-watsonx-ai/README.md
@@ -104,7 +104,7 @@ The provider is automatically discovered via ServiceLoader. Use it in your Camel
 
 ```java
 from("direct:chat")
-    .to("langchain4j-agent:my-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:my-agent?agent=#myAgent")
     .log("Response: ${body}");
 ```
 
@@ -178,7 +178,7 @@ export WATSONXAI_PROJECT_ID="your-project-id"
 
 ```java
 from("direct:watsonx-chat")
-    .to("langchain4j-agent:watsonx-agent?agentFactory=#class:io.kaoto.forage.agent.factory.MultiAgentFactory")
+    .to("langchain4j-agent:watsonx-agent?agent=#watsonxAgent")
     .log("Watsonx.ai Response: ${body}");
 ```
 


### PR DESCRIPTION
The documentation was old and not updated.

Updated documentation to the latest code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Configuration keys renamed with `FORAGE_` prefix (e.g., `OPENAI_API_KEY` → `FORAGE_OPENAI_API_KEY`)
  * Module artifacts renamed: `forage-model-openai` → `forage-model-open-ai`, `forage-jdbc-postgres` → `forage-jdbc-postgresql`
  * Route configuration updated: `agentFactory` parameter replaced with direct `agent` references
  * Annotation parameters changed: `component` → `components` (array), `factoryType` → typed enums

* **Documentation**
  * Updated guides reflecting new configuration structure and naming conventions
  * Configuration examples aligned across all modules

* **Chores**
  * Dependency versions bumped to 1.1-SNAPSHOT

<!-- end of auto-generated comment: release notes by coderabbit.ai -->