### PR TITLE
Temporary workaround before CAMEL-23208

### DIFF
--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven and run integration tests


### PR DESCRIPTION
relates https://github.com/KaotoIO/forage/issues/243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use JDK 21, replacing the previous JDK 17 configuration in the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->