### PR TITLE
[camel-4.19.0] Sets java version for integration-tests based on CI

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageIntegrationTest.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageIntegrationTest.java
@@ -6,6 +6,7 @@ import org.citrusframework.TestActionSupport;
 import org.citrusframework.actions.camel.CamelIntegrationRunCustomizedActionBuilder;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import io.kaoto.forage.plugin.ExportHelper;
 
 /**
  * Interface required for special test cases:
@@ -54,7 +55,7 @@ public interface ForageIntegrationTest extends TestActionSupport {
         if (!Strings.isNullOrEmpty(camelRoute)) {
             builder.addResource(classResource(camelRoute));
         }
-        return builder;
+        return builder.withArgs("--java-version=" + ExportHelper.getCiJavaVersion());
     }
 
     default Resource classResource(String resourceRelativePath) {

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <langchain4j.version>1.11.0</langchain4j.version>
         <langchain4j-beta.version>1.11.0-beta19</langchain4j-beta.version>
         <langchain4j-community.version>1.11.0-beta19</langchain4j-community.version>
+        <ci-java.version>17</ci-java.version> <!--Version of java used in the CI, required for integration tests to export apps for the right version-->
 
         <agroal.version>2.8</agroal.version>
         <assertj-core.version>3.27.6</assertj-core.version>

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ExportHelper.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ExportHelper.java
@@ -56,6 +56,17 @@ public final class ExportHelper {
         return getString(
                 "project.version", ResourceType.versions, "Could not determine project version from properties file.");
     }
+    /**
+     * Gets the project version from the versions.properties file. (which is populated during buildtime)
+     *
+     * @return the project version
+     */
+    public static String getCiJavaVersion() {
+        return getString(
+                "ci-java.version",
+                ResourceType.versions,
+                "Could not determine ci-java.version version from properties file.");
+    }
 
     /**
      * Reads property from the file versions.properties (which contains build time resolved versions)

--- a/tooling/camel-jbang-plugin-forage/src/main/resources/versions.properties
+++ b/tooling/camel-jbang-plugin-forage/src/main/resources/versions.properties
@@ -1,3 +1,4 @@
 project.version=@project.version@
 quarkus.version=@quarkus.version@
 camel.version=@camel.version@
+ci-java.version=@ci-java.version@


### PR DESCRIPTION
fixes https://github.com/KaotoIO/forage/issues/243

Requires camel with https://issues.apache.org/jira/browse/CAMEL-23208
(please revert workaround https://github.com/KaotoIO/forage/pull/244)