### PR TITLE
Allow .dumpIntegrationOutput(true) for jdbc integration tests (already allowed in other tests)

### DIFF
--- a/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/JdbcTest.java
+++ b/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/JdbcTest.java
@@ -71,6 +71,7 @@ public class JdbcTest implements ForageIntegrationTest {
         // running jbang forage run with required resources and required runtime
         runner.when(forageRun(INTEGRATION_NAME, "forage-datasource-factory.properties", "jdbc-routes.camel.yaml")
                 .addResource(classResource("MyAggregationStrategy.java"))
+                .dumpIntegrationOutput(true)
                 // required if more test are using the same route
                 .autoRemove(false)
                 .withEnvs(Collections.singletonMap("FORAGE_JDBC_URL", postgres.getJdbcUrl())));


### PR DESCRIPTION
Allow .dumpIntegrationOutput(true) for better CI failure investigation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test diagnostics to improve debugging and output visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->