### PR TITLE
memory.max.messages agent config is ignored when memory.kind is speci…

### DIFF
--- a/core/forage-core-ai/src/main/java/io/kaoto/forage/core/ai/MaxMessagesAware.java
+++ b/core/forage-core-ai/src/main/java/io/kaoto/forage/core/ai/MaxMessagesAware.java
@@ -1,0 +1,11 @@
+package io.kaoto.forage.core.ai;
+
+/**
+ * If a {@link ChatMemoryBeanProvider} supports configurable message window size,
+ * it should implement this interface so that the agent configuration can override
+ * the default max messages value.
+ */
+public interface MaxMessagesAware {
+
+    void withMaxMessages(int maxMessages);
+}

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
@@ -13,6 +13,7 @@ import io.kaoto.forage.core.ai.EmbeddingModelAware;
 import io.kaoto.forage.core.ai.EmbeddingModelProvider;
 import io.kaoto.forage.core.ai.EmbeddingStoreAware;
 import io.kaoto.forage.core.ai.EmbeddingStoreProvider;
+import io.kaoto.forage.core.ai.MaxMessagesAware;
 import io.kaoto.forage.core.ai.ModelProvider;
 import io.kaoto.forage.core.ai.RetrievalAugmentorProvider;
 import io.kaoto.forage.core.annotations.ForageBean;
@@ -378,6 +379,9 @@ public final class AgentCreator {
             if (annotation != null && annotation.value().equals(memoryKind)) {
                 LOG.debug("Found memory provider for kind '{}': {}", memoryKind, providerClass.getName());
                 ChatMemoryBeanProvider memoryProvider = provider.get();
+                if (memoryProvider instanceof MaxMessagesAware maxMessagesAware) {
+                    maxMessagesAware.withMaxMessages(config.memoryMaxMessages());
+                }
                 return memoryProvider.create();
             }
         }

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanMemoryBeanProvider.java
@@ -6,6 +6,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.ai.ChatMemoryBeanProvider;
+import io.kaoto.forage.core.ai.MaxMessagesAware;
 import io.kaoto.forage.core.annotations.ForageBean;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
@@ -47,9 +48,10 @@ import dev.langchain4j.memory.chat.MessageWindowChatMemory;
         components = {"camel-langchain4j-agent"},
         feature = "Memory",
         description = "Distributed storage using Infinispan")
-public class InfinispanMemoryBeanProvider implements ChatMemoryBeanProvider {
+public class InfinispanMemoryBeanProvider implements ChatMemoryBeanProvider, MaxMessagesAware {
     private static final Logger LOG = LoggerFactory.getLogger(InfinispanMemoryBeanProvider.class);
     private static final int DEFAULT_MAX_MESSAGES = 10;
+    private volatile Integer maxMessagesOverride;
 
     private static final InfinispanConfig CONFIG = new InfinispanConfig();
     private static final RemoteCacheManager CACHE_MANAGER;
@@ -132,12 +134,18 @@ public class InfinispanMemoryBeanProvider implements ChatMemoryBeanProvider {
      * @throws RuntimeException if Infinispan connection cannot be established or configured
      */
     @Override
+    public void withMaxMessages(int maxMessages) {
+        this.maxMessagesOverride = maxMessages;
+    }
+
+    @Override
     public ChatMemoryProvider create() {
+        int maxMessages = maxMessagesOverride != null ? maxMessagesOverride : DEFAULT_MAX_MESSAGES;
         return memoryId -> {
-            LOG.debug("Creating message window chat memory for ID: {}", memoryId);
+            LOG.debug("Creating message window chat memory for ID: {} with maxMessages={}", memoryId, maxMessages);
             return MessageWindowChatMemory.builder()
                     .id(memoryId)
-                    .maxMessages(DEFAULT_MAX_MESSAGES)
+                    .maxMessages(maxMessages)
                     .chatMemoryStore(INFINISPAN_STORE)
                     .build();
         };

--- a/library/ai/chat-memory/forage-memory-message-window/src/main/java/io/kaoto/forage/memory/chat/messagewindow/MessageWindowChatMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-message-window/src/main/java/io/kaoto/forage/memory/chat/messagewindow/MessageWindowChatMemoryBeanProvider.java
@@ -3,6 +3,7 @@ package io.kaoto.forage.memory.chat.messagewindow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.ai.ChatMemoryBeanProvider;
+import io.kaoto.forage.core.ai.MaxMessagesAware;
 import io.kaoto.forage.core.annotations.ForageBean;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
@@ -13,34 +14,34 @@ import dev.langchain4j.memory.chat.MessageWindowChatMemory;
         feature = "Memory",
         configClass = MessageWindowConfig.class,
         description = "In-memory storage with configurable message window size")
-public class MessageWindowChatMemoryBeanProvider implements ChatMemoryBeanProvider {
+public class MessageWindowChatMemoryBeanProvider implements ChatMemoryBeanProvider, MaxMessagesAware {
     private static final Logger LOG = LoggerFactory.getLogger(MessageWindowChatMemoryBeanProvider.class);
 
     private static final PersistentChatMemoryStore PERSISTENT_CHAT_MEMORY_STORE = new PersistentChatMemoryStore();
     private static final MessageWindowConfig CONFIG = new MessageWindowConfig();
-    private final ChatMemoryProvider chatMemoryProvider;
+    private volatile Integer maxMessagesOverride;
 
-    public MessageWindowChatMemoryBeanProvider() {
-        chatMemoryProvider = getChatMemoryProvider();
+    public MessageWindowChatMemoryBeanProvider() {}
+
+    @Override
+    public void withMaxMessages(int maxMessages) {
+        this.maxMessagesOverride = maxMessages;
     }
 
     @Override
-    public synchronized ChatMemoryProvider create() {
-        return chatMemoryProvider;
+    public ChatMemoryProvider create() {
+        int maxMessages = maxMessagesOverride != null ? maxMessagesOverride : CONFIG.maxMessages();
+        LOG.trace("Creating MessageWindowChatMemoryFactory with maxMessages={}", maxMessages);
+        return memoryId -> MessageWindowChatMemory.builder()
+                .id(memoryId)
+                .maxMessages(maxMessages)
+                .chatMemoryStore(PERSISTENT_CHAT_MEMORY_STORE)
+                .build();
     }
 
     @Override
     public ChatMemoryProvider create(String id) {
         throw new UnsupportedOperationException(
                 "Named chat memory stores are not yet supported for the memory chat window");
-    }
-
-    private static ChatMemoryProvider getChatMemoryProvider() {
-        LOG.trace("Creating MessageWindowChatMemoryFactory with maxMessages={}", CONFIG.maxMessages());
-        return memoryId -> MessageWindowChatMemory.builder()
-                .id(memoryId)
-                .maxMessages(CONFIG.maxMessages())
-                .chatMemoryStore(PERSISTENT_CHAT_MEMORY_STORE)
-                .build();
     }
 }

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisMemoryBeanProvider.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.ai.ChatMemoryBeanProvider;
+import io.kaoto.forage.core.ai.MaxMessagesAware;
 import io.kaoto.forage.core.annotations.ForageBean;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
@@ -48,9 +49,10 @@ import redis.clients.jedis.exceptions.JedisException;
         components = {"camel-langchain4j-agent"},
         feature = "Memory",
         description = "Persistent storage using Redis")
-public class RedisMemoryBeanProvider implements ChatMemoryBeanProvider {
+public class RedisMemoryBeanProvider implements ChatMemoryBeanProvider, MaxMessagesAware {
     private static final Logger LOG = LoggerFactory.getLogger(RedisMemoryBeanProvider.class);
     private static final int DEFAULT_MAX_MESSAGES = 100;
+    private volatile Integer maxMessagesOverride;
 
     private static final RedisConfig CONFIG = new RedisConfig();
     private static final JedisPool JEDIS_POOL;
@@ -136,12 +138,18 @@ public class RedisMemoryBeanProvider implements ChatMemoryBeanProvider {
      * @throws RuntimeException if Redis connection cannot be established or configured
      */
     @Override
+    public void withMaxMessages(int maxMessages) {
+        this.maxMessagesOverride = maxMessages;
+    }
+
+    @Override
     public ChatMemoryProvider create() {
+        int maxMessages = maxMessagesOverride != null ? maxMessagesOverride : DEFAULT_MAX_MESSAGES;
         return memoryId -> {
-            LOG.debug("Creating message window chat memory for ID: {}", memoryId);
+            LOG.debug("Creating message window chat memory for ID: {} with maxMessages={}", memoryId, maxMessages);
             return MessageWindowChatMemory.builder()
                     .id(memoryId)
-                    .maxMessages(DEFAULT_MAX_MESSAGES)
+                    .maxMessages(maxMessages)
                     .chatMemoryStore(REDIS_STORE)
                     .build();
         };


### PR DESCRIPTION
…fied

`.maxMessages(CONFIG.maxMessages())` cannot be used anymore, since named beans were introduced and properties like `forage.myagent.agent.memory.max.messages=20` are not picked up anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public contract to allow components to accept a runtime-configured maximum message window.
  * Chat memory providers now support per-provider runtime overrides for the number of retained messages.
  * Resolved max-message values are included in debug logs; default behavior remains unchanged when no override is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->