### PR TITLE
Support hot-reload of Forage properties in Camel JBang dev mode

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageContextServicePlugin.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageContextServicePlugin.java
@@ -1,5 +1,7 @@
 package io.kaoto.forage.core;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spi.ContextServicePlugin;
@@ -12,6 +14,8 @@ public class ForageContextServicePlugin implements ContextServicePlugin {
 
     @Override
     public void load(CamelContext camelContext) {
+        List<BeanFactory> factories = new ArrayList<>();
+
         ServiceLoader<BeanFactory> loader =
                 ServiceLoader.load(BeanFactory.class, camelContext.getApplicationContextClassLoader());
 
@@ -19,6 +23,7 @@ public class ForageContextServicePlugin implements ContextServicePlugin {
             try {
                 beanFactory.setCamelContext(camelContext);
                 beanFactory.configure();
+                factories.add(beanFactory);
                 LOG.debug(
                         "Successfully configured bean factory: {}",
                         beanFactory.getClass().getName());
@@ -29,5 +34,37 @@ public class ForageContextServicePlugin implements ContextServicePlugin {
                         e);
             }
         });
+
+        // Register file watcher for hot-reload when enabled
+        if (!factories.isEmpty() && isReloadEnabled(camelContext)) {
+            try {
+                ForageReloadWatcher watcher = new ForageReloadWatcher(factories);
+                camelContext.addService(watcher);
+                LOG.info("Forage hot-reload enabled: watching for property file changes");
+            } catch (Exception e) {
+                LOG.warn("Failed to start Forage hot-reload watcher", e);
+            }
+        }
+    }
+
+    /**
+     * Checks whether hot-reload should be enabled.
+     *
+     * <p>Reload is enabled when either:
+     * <ul>
+     *   <li>The system property {@code forage.reload.enabled} is set to {@code true}</li>
+     *   <li>The Camel property {@code camel.main.routesReloadEnabled} is {@code true}
+     *       (set by the {@code --dev} flag in Camel JBang)</li>
+     * </ul>
+     */
+    private boolean isReloadEnabled(CamelContext camelContext) {
+        if ("true".equals(System.getProperty("forage.reload.enabled"))) {
+            return true;
+        }
+        return camelContext
+                .getPropertiesComponent()
+                .resolveProperty("camel.main.routesReloadEnabled")
+                .filter("true"::equals)
+                .isPresent();
     }
 }

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageReloadWatcher.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageReloadWatcher.java
@@ -1,0 +1,313 @@
+package io.kaoto.forage.core;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.apache.camel.support.service.ServiceSupport;
+import org.apache.camel.util.FileUtil;
+import org.apache.camel.util.IOHelper;
+import org.apache.camel.util.ObjectHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.common.BeanFactory;
+import io.kaoto.forage.core.util.config.ConfigStore;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+/**
+ * File watcher that monitors the working directory for changes to {@code .properties} files
+ * containing Forage configuration ({@code forage.*} keys) and triggers bean hot-reload.
+ *
+ * <p>This class mirrors the architecture of Camel's {@code FileWatcherResourceReloadStrategy}:
+ * <ul>
+ *   <li>Extends {@link ServiceSupport} for proper lifecycle management</li>
+ *   <li>Uses CamelContext's {@code ExecutorServiceManager} for the background thread</li>
+ *   <li>Uses Java NIO {@link WatchService} with macOS workaround</li>
+ *   <li>Polls with a configurable timeout (default 2 seconds)</li>
+ * </ul>
+ *
+ * <p>When a property file change is detected, the reload cycle is:
+ * <ol>
+ *   <li><strong>Cleanup</strong> — call {@link BeanFactory#cleanup()} on all factories
+ *       (old config is still in ConfigStore for bean name resolution)</li>
+ *   <li><strong>Clear config</strong> — call {@link ConfigStore#reload()} to clear cached values</li>
+ *   <li><strong>Reconfigure</strong> — call {@link BeanFactory#configure()} on all factories
+ *       (re-reads properties from disk, creates new beans, binds to registry)</li>
+ * </ol>
+ *
+ * @since 1.1
+ */
+public class ForageReloadWatcher extends ServiceSupport implements CamelContextAware {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForageReloadWatcher.class);
+
+    private final List<BeanFactory> beanFactories;
+    private CamelContext camelContext;
+    private WatchService watcher;
+    private ExecutorService executorService;
+    private WatchFileChangesTask task;
+    private long pollTimeout = 2000;
+
+    public ForageReloadWatcher(List<BeanFactory> beanFactories) {
+        this.beanFactories = beanFactories;
+    }
+
+    public void setPollTimeout(long pollTimeout) {
+        this.pollTimeout = pollTimeout;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        File dir = new File(".").getAbsoluteFile();
+        if (!dir.exists() || !dir.isDirectory()) {
+            LOG.warn("Working directory does not exist, Forage hot-reload disabled");
+            return;
+        }
+
+        LOG.info("Forage hot-reload enabled: watching directory {} for property file changes", dir);
+
+        WatchEvent.Modifier modifier = null;
+
+        // macOS workaround: enable SensitivityWatchEventModifier.HIGH for faster polling
+        // (same pattern as Camel's FileWatcherResourceReloadStrategy)
+        String os = ObjectHelper.getSystemProperty("os.name", "");
+        if (os.toLowerCase(Locale.US).startsWith("mac")) {
+            Class<WatchEvent.Modifier> clazz = camelContext
+                    .getClassResolver()
+                    .resolveClass("com.sun.nio.file.SensitivityWatchEventModifier", WatchEvent.Modifier.class);
+            if (clazz != null) {
+                WatchEvent.Modifier[] modifiers = clazz.getEnumConstants();
+                for (WatchEvent.Modifier mod : modifiers) {
+                    if ("HIGH".equals(mod.name())) {
+                        modifier = mod;
+                        break;
+                    }
+                }
+            }
+            if (modifier != null) {
+                LOG.debug(
+                        "On Mac OS X the JDK WatchService is slow by default so enabling SensitivityWatchEventModifier.HIGH as workaround");
+            } else {
+                LOG.warn(
+                        "On Mac OS X the JDK WatchService is slow and it may take up till 10 seconds to notice file changes");
+            }
+        }
+
+        try {
+            Path path = dir.toPath();
+            watcher = path.getFileSystem().newWatchService();
+            if (modifier != null) {
+                path.register(watcher, new WatchEvent.Kind<?>[] {ENTRY_CREATE, ENTRY_MODIFY}, modifier);
+            } else {
+                path.register(watcher, ENTRY_CREATE, ENTRY_MODIFY);
+            }
+
+            task = new WatchFileChangesTask(watcher, path);
+
+            executorService =
+                    camelContext.getExecutorServiceManager().newSingleThreadExecutor(this, "ForageReloadWatcher");
+            executorService.submit(task);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to start Forage file watcher", e);
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+
+        if (executorService != null) {
+            camelContext.getExecutorServiceManager().shutdown(executorService);
+            executorService = null;
+        }
+
+        if (watcher != null) {
+            IOHelper.close(watcher);
+        }
+    }
+
+    private void reloadBeans() {
+        LOG.info("Forage property change detected, reloading beans...");
+
+        // Phase 1: cleanup (old config still in ConfigStore for bean name resolution)
+        // Note: AutoCloseable resources (e.g., DataSource pools) are NOT closed here
+        // because Camel components cache references at the component level (e.g., SqlComponent.dataSource).
+        // Closing the pool would break in-flight requests and cached references.
+        // The old resources are unbound and will be GC'd after route reload.
+        for (BeanFactory factory : beanFactories) {
+            try {
+                factory.cleanup();
+            } catch (Exception e) {
+                LOG.warn(
+                        "Failed to cleanup bean factory: {}", factory.getClass().getName(), e);
+            }
+        }
+
+        // Phase 2: clear config cache
+        LOG.debug("Clearing ConfigStore and ConfigHelper caches");
+        ConfigStore.getInstance().reload();
+
+        // Phase 3: reconfigure with fresh values from disk
+        for (BeanFactory factory : beanFactories) {
+            try {
+                factory.configure();
+                LOG.info("Reloaded bean factory: {}", factory.getClass().getName());
+            } catch (Exception e) {
+                LOG.warn("Failed to reload bean factory: {}", factory.getClass().getName(), e);
+            }
+        }
+
+        // Phase 4: remove Camel components so they are recreated from scratch on next
+        // route start. Components cache bean references in different ways:
+        // - SqlComponent caches DataSource via @Metadata(autowired)
+        // - JmsComponent caches ConnectionFactory via JmsConfiguration
+        // Stop/start doesn't clear these — only removing forces a fresh instance.
+        removeComponents();
+
+        // Phase 5: reload routes so they pick up the new bean/component references.
+        // Camel's RouteWatcherReloadStrategy may also detect the .properties change and
+        // reload routes — in that case a harmless "duplicate route id" warning is logged.
+        // But we must reload here because Camel's watcher may not watch .properties files
+        // (depends on the route file pattern passed to the run command).
+        try {
+            LOG.info("Reloading routes to pick up new bean references...");
+            camelContext.getRouteController().reloadAllRoutes();
+        } catch (Exception e) {
+            LOG.warn("Failed to reload routes after bean refresh: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Removes all Camel components so they are recreated from scratch when routes
+     * are restarted by Camel's RouteWatcherReloadStrategy. This ensures components
+     * pick up new bean references (DataSource, ConnectionFactory, etc.) from the registry.
+     */
+    private void removeComponents() {
+        // Copy the list to avoid ConcurrentModificationException
+        for (String name : new java.util.ArrayList<>(camelContext.getComponentNames())) {
+            try {
+                camelContext.removeComponent(name);
+                LOG.debug("Removed component '{}' for re-creation", name);
+            } catch (Exception e) {
+                LOG.debug("Could not remove component '{}': {}", name, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Checks whether a properties file contains any Forage configuration keys.
+     */
+    private static boolean containsForageProperties(File file) {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            Properties props = new Properties();
+            props.load(fis);
+            return props.keySet().stream().anyMatch(key -> key.toString().startsWith("forage."));
+        } catch (IOException e) {
+            LOG.debug("Could not read properties file {}: {}", file, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Background task that polls for property file changes.
+     * Mirrors Camel's {@code WatchFileChangesTask} pattern.
+     */
+    private class WatchFileChangesTask implements Runnable {
+
+        private final WatchService watcher;
+        private final Path folder;
+        private volatile boolean running;
+
+        WatchFileChangesTask(WatchService watcher, Path folder) {
+            this.watcher = watcher;
+            this.folder = folder;
+        }
+
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public void run() {
+            LOG.debug("ForageReloadWatcher is starting to watch folder: {}", folder);
+
+            while (isStarting() || isRunAllowed()) {
+                running = true;
+
+                WatchKey key;
+                try {
+                    key = watcher.poll(pollTimeout, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ex) {
+                    LOG.info("ForageReloadWatcher interrupted");
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+
+                if (key != null) {
+                    boolean shouldReload = false;
+
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        @SuppressWarnings("unchecked")
+                        WatchEvent<Path> we = (WatchEvent<Path>) event;
+                        Path path = we.context();
+                        File file = folder.resolve(path).toFile();
+
+                        if (file.isDirectory()) {
+                            continue;
+                        }
+
+                        String name = FileUtil.compactPath(file.getPath());
+                        if (name.endsWith(".properties")) {
+                            LOG.debug("Detected modified properties file: {}", name);
+                            if (containsForageProperties(file)) {
+                                LOG.debug("File contains forage properties: {}", name);
+                                shouldReload = true;
+                            }
+                        }
+                    }
+
+                    // Batch: reload once even if multiple files changed simultaneously
+                    if (shouldReload) {
+                        try {
+                            reloadBeans();
+                        } catch (Exception e) {
+                            LOG.warn("Error during Forage bean reload: {}", e.getMessage(), e);
+                        }
+                    }
+
+                    boolean valid = key.reset();
+                    if (!valid) {
+                        break;
+                    }
+                }
+            }
+
+            running = false;
+            LOG.debug("ForageReloadWatcher stopped watching folder: {}", folder);
+        }
+    }
+}

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/BeanFactory.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/BeanFactory.java
@@ -18,6 +18,27 @@ public interface BeanFactory extends CamelContextAware {
     void configure();
 
     /**
+     * Cleans up beans previously created by this factory.
+     *
+     * <p>Called before {@link #configure()} during hot-reload to allow closing resources
+     * (connection pools, JMS connections, etc.) and unbinding old beans from the registry.
+     * This ensures that {@code configure()} can re-create and re-bind beans with fresh
+     * configuration values.
+     *
+     * <p>Implementations should:
+     * <ul>
+     *   <li>Close any {@link AutoCloseable} resources (e.g., DataSource connection pools)</li>
+     *   <li>Unbind beans from the Camel registry so they can be re-bound by {@code configure()}</li>
+     * </ul>
+     *
+     * <p>The default implementation is a no-op. Factories that manage stateful resources
+     * should override this method.
+     */
+    default void cleanup() {
+        // no-op by default
+    }
+
+    /**
      * Utility method to find service providers of a specific type using ServiceLoader.
      *
      * @param <K> the type of service to find

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigHelper.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigHelper.java
@@ -314,9 +314,25 @@ public final class ConfigHelper {
 
     private static Properties getCamelMainConfig() {
         if (camelConfig == null) {
+            LOG.debug("getCamelMainConfig() - cache miss, loading application.properties from disk");
             camelConfig = loadApplicationProperties();
+            if (camelConfig != null) {
+                LOG.debug("getCamelMainConfig() - loaded {} properties", camelConfig.size());
+            }
+        } else {
+            LOG.trace("getCamelMainConfig() - returning cached properties ({} entries)", camelConfig.size());
         }
         return camelConfig;
+    }
+
+    /**
+     * Clears cached configuration sources so that properties are re-read from disk
+     * on next access. Called by {@link ConfigStore#reload()} during hot-reload.
+     */
+    static void clearCache() {
+        camelConfig = null;
+        springBootConfig = null;
+        quarkusAppProps = null;
     }
 
     /**

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
@@ -432,4 +432,21 @@ public final class ConfigStore {
     public Set<Map.Entry<Object, Object>> entries() {
         return properties.entrySet();
     }
+
+    /**
+     * Clears all cached configuration values so they will be re-read from their
+     * sources (property files, environment variables, system properties) on next access.
+     *
+     * <p>This method is used during hot-reload to force a fresh read of configuration
+     * values from disk. Resolvers are not affected as they are stateless and read
+     * live values on each call.
+     *
+     * @since 1.1
+     */
+    public void reload() {
+        LOG.debug("ConfigStore.reload() - clearing {} cached properties", properties.size());
+        properties.clear();
+        ConfigHelper.clearCache();
+        LOG.debug("ConfigStore.reload() - caches cleared");
+    }
 }

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/DefaultConfigResolver.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/DefaultConfigResolver.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default configuration resolver that reads from environment variables, system properties,
@@ -29,6 +31,8 @@ import java.util.stream.Collectors;
  */
 public class DefaultConfigResolver implements ConfigResolver {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultConfigResolver.class);
+
     @Override
     public Optional<String> resolve(String propertyName) {
         // 1. Environment variables: convert dot notation to UPPER_SNAKE_CASE
@@ -45,11 +49,16 @@ public class DefaultConfigResolver implements ConfigResolver {
         }
 
         // 3. Runtime-specific fallback
-        return switch (ConfigHelper.getRuntime()) {
-            case springBoot -> ConfigHelper.getSpringBootProperty(propertyName);
-            case quarkus -> ConfigHelper.getQuarkusProperty(propertyName);
-            case main -> ConfigHelper.getCamelMainProperty(propertyName);
-        };
+        Optional<String> result =
+                switch (ConfigHelper.getRuntime()) {
+                    case springBoot -> ConfigHelper.getSpringBootProperty(propertyName);
+                    case quarkus -> ConfigHelper.getQuarkusProperty(propertyName);
+                    case main -> ConfigHelper.getCamelMainProperty(propertyName);
+                };
+        if (result.isPresent()) {
+            LOG.debug("Resolved '{}' from runtime config", propertyName);
+        }
+        return result;
     }
 
     @Override

--- a/docs/hot-reload.md
+++ b/docs/hot-reload.md
@@ -1,0 +1,40 @@
+# Forage Hot-Reload
+
+Forage supports hot-reloading of configuration properties when running in dev mode. When a `.properties` file containing `forage.*` keys is modified, Forage automatically destroys and recreates the affected beans with the updated configuration — without restarting the application.
+
+## Activation
+
+Hot-reload is enabled when **either** condition is true:
+
+- **Camel JBang dev mode:** `camel forage run --dev myroute.yaml`
+- **System property:** `-Dforage.reload.enabled=true`
+
+## What can be hot-reloaded
+
+Configuration **values** within the same provider type can be changed at runtime:
+
+- API keys (e.g., `forage.openai.api.key`)
+- Connection URLs (e.g., `forage.jdbc.url`)
+- Model names (e.g., `forage.agent.model.name`)
+- Connection parameters (pool sizes, timeouts, etc.)
+- Any other `forage.*` property value
+
+## What requires a restart
+
+The following changes **cannot** be hot-reloaded and require restarting the application:
+
+- **Provider type changes** — Changing `forage.jdbc.db.kind` from `postgresql` to `mysql`, or `forage.agent.model.kind` from `openai` to `ollama`. These require different JARs on the classpath, which cannot be added at runtime.
+- **Adding new factory types** — Adding JDBC configuration when only AI was initially configured. The required dependencies are resolved at startup.
+- **Environment variable changes** — The file watcher monitors `.properties` files on disk. Changes to environment variables (e.g., `FORAGE_OPENAI_API_KEY`) are not detected. Restart the application or update the corresponding properties file instead.
+
+## How it works
+
+Forage registers a file watcher (`ForageReloadWatcher`) that monitors the working directory for changes to `.properties` files. When a change is detected in a file containing `forage.*` keys, the following reload cycle executes:
+
+1. **Cleanup** — Each `BeanFactory` unbinds old beans from the Camel registry. AutoCloseable resources (e.g., DataSource connection pools, JMS connection factories) are intentionally **not** closed at this stage to avoid breaking in-flight requests — they are left for garbage collection after components are reset.
+2. **Clear config** — The `ConfigStore` cache is cleared so values are re-read from disk.
+3. **Reconfigure** — Each `BeanFactory` re-reads configuration, creates new bean instances, and binds them to the Camel registry.
+4. **Reset components** — Camel components (e.g., `SqlComponent`, `JmsComponent`) that cache bean references are removed so they are recreated with fresh references when routes restart.
+5. **Reload routes** — Routes are reloaded so they pick up the new beans and components.
+
+Route files (YAML, XML) are handled separately by Camel's built-in route reload mechanism.

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentBeanFactory.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentBeanFactory.java
@@ -47,6 +47,17 @@ public class AgentBeanFactory implements BeanFactory {
     private CamelContext camelContext;
 
     @Override
+    public void cleanup() {
+        ClassLoader cl = camelContext.getApplicationContextClassLoader();
+        Set<String> prefixes = AgentCreator.detectPrefixes(cl);
+
+        for (String agentName : prefixes) {
+            camelContext.getRegistry().unbind(agentName);
+        }
+        camelContext.getRegistry().unbind(AgentCreator.DEFAULT_AGENT);
+    }
+
+    @Override
     public void configure() {
         ClassLoader cl = camelContext.getApplicationContextClassLoader();
         Set<String> prefixes = AgentCreator.detectPrefixes(cl);

--- a/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
@@ -99,6 +99,52 @@ public class DataSourceBeanFactory implements BeanFactory {
     private static final String DEFAULT_DATASOURCE = "dataSource";
 
     @Override
+    public void cleanup() {
+        DataSourceFactoryConfig config = new DataSourceFactoryConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jdbc"));
+
+        for (String name : prefixes) {
+            closeAndUnbind(name);
+        }
+        closeAndUnbind(DEFAULT_DATASOURCE);
+
+        // Unbind JTA transaction policies if they were registered
+        if (config.transactionEnabled()) {
+            for (String name : List.of(
+                    "PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS")) {
+                camelContext.getRegistry().unbind(name);
+            }
+        }
+
+        // Unbind aggregation and idempotent repositories (root config)
+        unbindRepositories(config);
+
+        // Unbind per-prefix aggregation and idempotent repositories
+        for (String name : prefixes) {
+            DataSourceFactoryConfig prefixConfig = new DataSourceFactoryConfig(name);
+            unbindRepositories(prefixConfig);
+        }
+    }
+
+    private void unbindRepositories(DataSourceFactoryConfig dsConfig) {
+        if (dsConfig.aggregationRepositoryName() != null) {
+            camelContext.getRegistry().unbind(dsConfig.aggregationRepositoryName());
+        }
+        if (dsConfig.enableIdempotentRepository()) {
+            camelContext.getRegistry().unbind(dsConfig.idempotentRepositoryTableName());
+        }
+    }
+
+    private void closeAndUnbind(String name) {
+        // Note: we intentionally do NOT close AutoCloseable resources here.
+        // Camel components (e.g., SqlComponent) cache DataSource references at the component level.
+        // Closing the pool before the component is reset would break in-flight requests.
+        // The old DataSource is unbound and will be GC'd after the component is reset and routes reloaded.
+        camelContext.getRegistry().unbind(name);
+    }
+
+    @Override
     public void configure() {
 
         DataSourceFactoryConfig config = new DataSourceFactoryConfig();

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -84,6 +84,33 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
     private static final String DEFAULT_CONNECTION_FACTORY = "connectionFactory";
 
     @Override
+    public void cleanup() {
+        ConnectionFactoryConfig config = new ConnectionFactoryConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jms"));
+
+        for (String name : prefixes) {
+            closeAndUnbind(name);
+        }
+        closeAndUnbind(DEFAULT_CONNECTION_FACTORY);
+
+        // Unbind JTA transaction policies if they were registered
+        if (config.transactionEnabled()) {
+            for (String name : List.of(
+                    "PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS")) {
+                camelContext.getRegistry().unbind(name);
+            }
+        }
+    }
+
+    private void closeAndUnbind(String name) {
+        // Note: we intentionally do NOT close AutoCloseable resources here.
+        // Camel components cache references at the component level.
+        // The old resource is unbound and will be GC'd after the component is reset and routes reloaded.
+        camelContext.getRegistry().unbind(name);
+    }
+
+    @Override
     public void configure() {
 
         ConnectionFactoryConfig config = new ConnectionFactoryConfig();

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageRun.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageRun.java
@@ -3,6 +3,7 @@ package io.kaoto.forage.plugin;
 import java.util.Set;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.Run;
+import org.apache.camel.main.KameletMain;
 import io.kaoto.forage.core.common.ExportCustomizer;
 import io.kaoto.forage.core.common.RuntimeType;
 import picocli.CommandLine;
@@ -25,6 +26,20 @@ public class ForageRun extends Run {
         }
 
         return super.doCall();
+    }
+
+    /**
+     * Propagates the --dev flag as forage.reload.enabled system property so that
+     * ForageContextServicePlugin can detect dev mode and start the file watcher.
+     *
+     * <p>This method is called after the --dev flag has been processed (Run.java line 592)
+     * and camel.main.routesReloadEnabled has been added to initial properties.
+     */
+    @Override
+    protected void doAddInitialProperty(KameletMain main) {
+        if ("true".equals(main.getInitialProperties().getProperty("camel.main.routesReloadEnabled"))) {
+            System.setProperty("forage.reload.enabled", "true");
+        }
     }
 
     /**


### PR DESCRIPTION
https://github.com/KaotoIO/forage/issues/260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hot-reload for forage.* configuration in dev mode: watches .properties, clears config cache, performs a batched reload (teardown, reconfigure, reset cached components, and reload routes), and logs failures without disrupting prior configuration.
  * Lifecycle cleanup hook added so providers can unbind/teardown before reload.

* **Documentation**
  * New hot-reload guide describing activation, supported updates, and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->