### PR TITLE
Fix property file resolution when running from subdirectories (#267)

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageReloadWatcher.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageReloadWatcher.java
@@ -82,7 +82,8 @@ public class ForageReloadWatcher extends ServiceSupport implements CamelContextA
     protected void doStart() throws Exception {
         super.doStart();
 
-        File dir = new File(".").getAbsoluteFile();
+        String configDir = System.getProperty("forage.config.dir");
+        File dir = (configDir != null ? new File(configDir) : new File(".")).getAbsoluteFile();
         if (!dir.exists() || !dir.isDirectory()) {
             LOG.warn("Working directory does not exist, Forage hot-reload disabled");
             return;

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigHelper.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigHelper.java
@@ -265,6 +265,27 @@ public final class ConfigHelper {
             LOG.debug("Failed to load application.properties from working directory", ex);
         }
 
+        // Fallback to forage.config.dir / FORAGE_CONFIG_DIR
+        if (input == null) {
+            String configDir = System.getProperty("forage.config.dir");
+            if (configDir == null) {
+                configDir = System.getenv("FORAGE_CONFIG_DIR");
+            }
+            if (configDir != null) {
+                try {
+                    java.io.File file = java.nio.file.Path.of(configDir, "application.properties")
+                            .toAbsolutePath()
+                            .toFile();
+                    if (file.exists()) {
+                        LOG.debug("Loading application.properties from config dir: {}", file.getAbsolutePath());
+                        input = new java.io.FileInputStream(file);
+                    }
+                } catch (IOException ex) {
+                    LOG.debug("Failed to load application.properties from config dir", ex);
+                }
+            }
+        }
+
         // Fallback to classpath — try multiple classloaders since in Quarkus
         // augmentation the deployment classloader may not see the application's resources
         if (input == null) {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
@@ -111,7 +111,8 @@ public class CatalogDrivenExportCustomizer implements ExportCustomizer {
     private Map<String, Map<String, List<String>>> getScannedProperties() {
         if (scannedProperties == null) {
             try {
-                File workingDir = new File(System.getProperty("user.dir"));
+                String configDir = System.getProperty("forage.config.dir");
+                File workingDir = configDir != null ? new File(configDir) : new File(System.getProperty("user.dir"));
                 ForageCatalogReader catalog = ForageCatalogReader.getInstance();
                 scannedProperties = ForagePropertyScanner.scanProperties(workingDir, catalog);
             } catch (IOException e) {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
@@ -49,7 +49,8 @@ public final class ForagePropertyValidator {
         }
 
         try {
-            File workingDir = new File(System.getProperty("user.dir"));
+            String configDir = System.getProperty("forage.config.dir");
+            File workingDir = configDir != null ? new File(configDir) : new File(System.getProperty("user.dir"));
             ForageCatalogReader catalog = ForageCatalogReader.getInstance();
 
             ValidationResult validation = validate(workingDir, catalog);

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageRun.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageRun.java
@@ -1,14 +1,21 @@
 package io.kaoto.forage.plugin;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.Run;
 import org.apache.camel.main.KameletMain;
+import org.apache.camel.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.common.ExportCustomizer;
 import io.kaoto.forage.core.common.RuntimeType;
 import picocli.CommandLine;
 
 public class ForageRun extends Run {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForageRun.class);
 
     @CommandLine.Mixin
     private PropertyValidationMixin validation;
@@ -19,6 +26,8 @@ public class ForageRun extends Run {
 
     @Override
     public Integer doCall() throws Exception {
+        resolveConfigDir();
+
         // Validate properties before running
         int validationResult = validation.validateAndReport(printer());
         if (validationResult != 0) {
@@ -26,6 +35,72 @@ public class ForageRun extends Run {
         }
 
         return super.doCall();
+    }
+
+    /**
+     * Derives the configuration directory from the file arguments, mirroring
+     * how Camel's {@code Run} resolves its base directory.
+     *
+     * <ul>
+     *   <li>Single directory argument (e.g., {@code camel forage run agent}) — use that directory</li>
+     *   <li>Multiple files sharing a common parent different from CWD
+     *       (e.g., shell-expanded {@code agent/*}) — use that common parent</li>
+     *   <li>Otherwise — leave unset (CWD is fine)</li>
+     * </ul>
+     *
+     * <p>Sets {@code forage.config.dir} system property so that {@code ConfigStore},
+     * {@code ConfigHelper}, {@code ForagePropertyValidator}, and {@code ForageReloadWatcher}
+     * all resolve properties from the correct location.
+     */
+    private void resolveConfigDir() {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+
+        Path configDir = null;
+
+        // Single directory argument — same logic as Camel's Run (Run.java line 452-462)
+        if (files.size() == 1) {
+            String name = FileUtil.stripTrailingSeparator(files.get(0));
+            Path first = Path.of(name);
+            if (Files.isDirectory(first)) {
+                configDir = first;
+            }
+        }
+
+        // Multiple files (e.g., shell-expanded glob) — find common parent
+        if (configDir == null && files.size() > 1) {
+            configDir = commonParent(files);
+        }
+
+        if (configDir != null) {
+            Path cwd = Path.of("").toAbsolutePath();
+            Path resolved = configDir.toAbsolutePath().normalize();
+            if (!resolved.equals(cwd)) {
+                LOG.debug("Setting forage.config.dir={} (derived from file arguments)", resolved);
+                System.setProperty("forage.config.dir", resolved.toString());
+            }
+        }
+    }
+
+    /**
+     * Returns the common parent directory of the given file paths,
+     * or {@code null} if there is no single common parent.
+     */
+    static Path commonParent(java.util.List<String> filePaths) {
+        Path common = null;
+        for (String filePath : filePaths) {
+            Path parent = Path.of(filePath).toAbsolutePath().normalize().getParent();
+            if (parent == null) {
+                return null;
+            }
+            if (common == null) {
+                common = parent;
+            } else if (!common.equals(parent)) {
+                return null;
+            }
+        }
+        return common;
     }
 
     /**


### PR DESCRIPTION
- ForageRun derives the config directory from the `files` list (single directory arg or common parent of glob-expanded files) and sets `forage.config.dir` system property
- CatalogDrivenExportCustomizer, ForagePropertyValidator, ConfigHelper, and ForageReloadWatcher now honor `forage.config.dir` (similar behaviour as Camel) before falling back to CWD