### PR TITLE
Fix misplaced Javadoc @return tag on void methods

### DIFF
--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanMemoryBeanProvider.java
@@ -113,6 +113,12 @@ public class InfinispanMemoryBeanProvider implements ChatMemoryBeanProvider, Max
         // Cache manager and store are initialized statically
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void withMaxMessages(int maxMessages) {
+        this.maxMessagesOverride = maxMessages;
+    }
+
     /**
      * Creates a new chat memory provider that uses Infinispan for persistent storage.
      *
@@ -133,11 +139,6 @@ public class InfinispanMemoryBeanProvider implements ChatMemoryBeanProvider, Max
      * @return a new chat memory provider backed by Infinispan storage, never {@code null}
      * @throws RuntimeException if Infinispan connection cannot be established or configured
      */
-    @Override
-    public void withMaxMessages(int maxMessages) {
-        this.maxMessagesOverride = maxMessages;
-    }
-
     @Override
     public ChatMemoryProvider create() {
         int maxMessages = maxMessagesOverride != null ? maxMessagesOverride : DEFAULT_MAX_MESSAGES;

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisMemoryBeanProvider.java
@@ -117,6 +117,12 @@ public class RedisMemoryBeanProvider implements ChatMemoryBeanProvider, MaxMessa
         // Redis pool and store are initialized statically
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void withMaxMessages(int maxMessages) {
+        this.maxMessagesOverride = maxMessages;
+    }
+
     /**
      * Creates a new chat memory provider that uses Redis for persistent storage.
      *
@@ -137,11 +143,6 @@ public class RedisMemoryBeanProvider implements ChatMemoryBeanProvider, MaxMessa
      * @return a new chat memory provider backed by Redis storage, never {@code null}
      * @throws RuntimeException if Redis connection cannot be established or configured
      */
-    @Override
-    public void withMaxMessages(int maxMessages) {
-        this.maxMessagesOverride = maxMessages;
-    }
-
     @Override
     public ChatMemoryProvider create() {
         int maxMessages = maxMessagesOverride != null ? maxMessagesOverride : DEFAULT_MAX_MESSAGES;


### PR DESCRIPTION
## Summary
- Moved Javadoc `@return`/`@throws` tags from `void withMaxMessages()` to the `create()` method where they belong, in both `InfinispanMemoryBeanProvider` and `RedisMemoryBeanProvider`
- Fixes `javadoc:jar` build failure in the snapshot publish CI job

## Test plan
- [x] `mvn clean install -DskipTests` passes all modules
- [x] `mvn javadoc:jar` passes all modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal code reorganization in memory providers with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->