### PR TITLE
Upload test reports as CI artifacts

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -33,3 +33,13 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports
+        path: |
+          **/target/failsafe-reports/
+          **/target/surefire-reports/
+          **/target/.run/
+        retention-days: 7

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -73,3 +73,13 @@ jobs:
           cache: maven
       - name: Build with Maven and run integration tests
         run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/target/failsafe-reports/
+            **/target/surefire-reports/
+            **/target/.run/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Upload failsafe reports, surefire reports, and Citrus `.run/` directory as downloadable artifacts in both `main-build.yml` and `pr-builds.yml`
- Uses `if: always()` so artifacts are uploaded even when tests fail
- 7-day retention to keep storage manageable

## Test plan
- [ ] Verify artifact upload on a successful build
- [ ] Verify artifact upload on a failed build (reports should still be downloadable)
- [ ] Confirm `.run/` directory contains Camel integration stdout/stderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows to automatically capture and retain test reports for 7 days, improving visibility into test execution results across both main builds and pull request pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->