### PR TITLE
Pass --java-version to Camel JBang matching the running JDK

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageTestCaseRunner.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageTestCaseRunner.java
@@ -43,6 +43,7 @@ public class ForageTestCaseRunner extends DefaultTestCaseRunner {
 
     private <T extends TestAction> void initializeTestAction(CamelIntegrationRunCustomizedActionBuilder<?, ?> builder) {
         builder.withSystemProperty("camel.jbang.quarkusVersion", ExportHelper.getQuarkusVersion());
+        builder.withArg("--java-version=" + System.getProperty("java.specification.version"));
         String runtime = System.getProperty(
                 IntegrationTestSetupExtension.RUNTIME_PROPERTY,
                 System.getenv(IntegrationTestSetupExtension.RUNTIME_PROPERTY));


### PR DESCRIPTION
## Summary
- Camel 4.18.1 defaults `--java-version` to 21 when exporting projects, causing compilation failures on CI runners with JDK 17
- Pass `--java-version` using `java.specification.version` so the exported project always targets the available JDK

## Test plan
- [ ] CI build passes with JDK 17 (Quarkus and Spring Boot runtimes no longer fail with `release version 21 not supported`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to pass Java version information during test initialization, improving test execution environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->