### PR TITLE
Use JDK 21 in main-build CI workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
## Summary
- Camel 4.18.1 hardcodes `--java-version=21` when exporting projects for Quarkus/Spring Boot runtimes via `camel run`
- The main-build workflow must use JDK 21 to compile these exported projects
- Tracked follow-up for Camel 4.18.2+ in #276

## Test plan
- [ ] CI integration tests pass for all runtimes (plain, Quarkus, Spring Boot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use a newer Java version for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->