### PR TITLE
Revert passing --java-version to Camel JBang run

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageTestCaseRunner.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageTestCaseRunner.java
@@ -43,7 +43,6 @@ public class ForageTestCaseRunner extends DefaultTestCaseRunner {
 
     private <T extends TestAction> void initializeTestAction(CamelIntegrationRunCustomizedActionBuilder<?, ?> builder) {
         builder.withSystemProperty("camel.jbang.quarkusVersion", ExportHelper.getQuarkusVersion());
-        builder.withArg("--java-version=" + System.getProperty("java.specification.version"));
         String runtime = System.getProperty(
                 IntegrationTestSetupExtension.RUNTIME_PROPERTY,
                 System.getenv(IntegrationTestSetupExtension.RUNTIME_PROPERTY));


### PR DESCRIPTION
## Summary
- Reverts #274 — the `--java-version` flag does not exist on the `run` command in Camel 4.18.1, causing `Unknown option: '--java-version=21'` and exit code 2 on every integration test
- JDK 21 in CI (#277) is sufficient since Camel 4.18.1 hardcodes Java 21 for runtime exports
- Tracked for re-introduction with Camel 4.18.2+ in #276

## Test plan
- [ ] CI integration tests no longer fail with `Unknown option: '--java-version=21'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test initialization configuration for internal testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->