### PR TITLE
Fix ForageReloadWatcher not starting with camel run --dev

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageContextServicePlugin.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/ForageContextServicePlugin.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.camel.CamelContext;
+import org.apache.camel.spi.CamelEvent;
 import org.apache.camel.spi.ContextServicePlugin;
+import org.apache.camel.support.EventNotifierSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.common.BeanFactory;
@@ -35,15 +37,28 @@ public class ForageContextServicePlugin implements ContextServicePlugin {
             }
         });
 
-        // Register file watcher for hot-reload when enabled
-        if (!factories.isEmpty() && isReloadEnabled(camelContext)) {
-            try {
-                ForageReloadWatcher watcher = new ForageReloadWatcher(factories);
-                camelContext.addService(watcher);
-                LOG.info("Forage hot-reload enabled: watching for property file changes");
-            } catch (Exception e) {
-                LOG.warn("Failed to start Forage hot-reload watcher", e);
-            }
+        // Defer hot-reload watcher startup to after the CamelContext is fully started.
+        // At load() time, camel.main.routesReloadEnabled is not yet set on the
+        // PropertiesComponent (the dev profile is configured after build()), so
+        // isReloadEnabled() would return false. By waiting for CamelContextStartedEvent,
+        // all initial properties are guaranteed to be available.
+        if (!factories.isEmpty()) {
+            camelContext.getManagementStrategy().addEventNotifier(new EventNotifierSupport() {
+                @Override
+                public void notify(CamelEvent event) throws Exception {
+                    if (event instanceof CamelEvent.CamelContextStartedEvent) {
+                        if (isReloadEnabled(camelContext)) {
+                            try {
+                                ForageReloadWatcher watcher = new ForageReloadWatcher(factories);
+                                camelContext.addService(watcher);
+                                LOG.info("Forage hot-reload enabled: watching for property file changes");
+                            } catch (Exception e) {
+                                LOG.warn("Failed to start Forage hot-reload watcher", e);
+                            }
+                        }
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- `ForageContextServicePlugin.load()` runs during `camelContext.build()`, **before** Camel's `configurePropertiesService()` sets `camel.main.routesReloadEnabled` on the PropertiesComponent
- This caused `isReloadEnabled()` to return `false` when using `camel run --dev` (without the `forage` subcommand), preventing the hot-reload watcher from starting
- Defer the `isReloadEnabled()` check and watcher startup to `CamelContextStartedEvent`, when all initial properties are guaranteed to be available

## Test plan
- [ ] Run `camel run * --dev` from the `ai/single` example directory
- [ ] Verify `Forage hot-reload enabled: watching for property file changes` appears in the startup logs
- [ ] Modify `application.properties` while running and verify Forage beans are reconfigured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized hot-reload watcher initialization to start after the application context fully loads, improving detection reliability of code changes and ensuring more consistent automatic reloading during development sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->