### PR TITLE
Add Forage logo to website home page

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,5 +1,9 @@
 # Forage
 
+<p align="center">
+  <img src="assets/forage-logo.png" alt="Forage Logo" width="400">
+</p>
+
 **Opinionated bean factories for Apache Camel.**
 
 Forage eliminates manual Java bean instantiation by providing factory classes configurable through properties files, environment variables, or system properties. Write your Camel routes — Forage handles the wiring.


### PR DESCRIPTION
## Summary
- Adds the full Forage logo to the website home page, displayed centered below the title heading

## Test plan
- [ ] Verify the logo renders correctly on the MkDocs site (`mkdocs serve`)
- [ ] Confirm the symlink `assets/forage-logo.png` resolves properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Forage logo to the documentation homepage for improved visual branding and recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->