### PR TITLE
Fix #307: Improve catalog generation performance

### DIFF
--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
@@ -99,10 +99,16 @@ public class CodeScanner {
     public ScanResult scanAllInOnePass(Artifact artifact, Path rootDir) {
         ScanResult result = new ScanResult();
 
-        // Find the source directory (cached)
-        Path sourceDir = findSourceDirectory(artifact, rootDir);
-        if (sourceDir == null || !Files.exists(sourceDir)) {
+        // Find the module directory (cached), then narrow to src/main/java
+        Path moduleDir = findSourceDirectory(artifact, rootDir);
+        if (moduleDir == null || !Files.exists(moduleDir)) {
             log.debug("No source directory found for artifact: " + artifact.getArtifactId());
+            return result;
+        }
+
+        Path sourceDir = moduleDir.resolve("src").resolve("main").resolve("java");
+        if (!Files.exists(sourceDir)) {
+            log.debug("No src/main/java in module: " + artifact.getArtifactId());
             return result;
         }
 
@@ -114,7 +120,6 @@ public class CodeScanner {
             // JavaParser instance via ThreadLocal, so parallel processing is safe.
             try (Stream<Path> paths = Files.walk(sourceDir)) {
                 paths.filter(path -> path.toString().endsWith(".java"))
-                        .filter(path -> !path.toString().contains("/test/"))
                         .parallel()
                         .forEach(javaFile -> {
                             try {

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
@@ -51,16 +51,18 @@ public class CodeScanner {
 
     private final Log log;
     private final Map<String, Path> sourceDirectoryCache = new ConcurrentHashMap<>();
-    private final JavaParser parser;
+    private final ThreadLocal<JavaParser> parserLocal = ThreadLocal.withInitial(CodeScanner::createConfiguredParser);
+    private final DocumentBuilderFactory documentBuilderFactory;
 
     public CodeScanner(Log log) {
         this.log = log;
-        this.parser = createConfiguredParser();
+        this.documentBuilderFactory = createDocumentBuilderFactory();
     }
 
     /**
      * Creates a JavaParser with optimized configuration for better performance.
      * Disables features not needed for annotation scanning.
+     * Each thread gets its own instance via ThreadLocal since JavaParser is not thread-safe.
      */
     private static JavaParser createConfiguredParser() {
         ParserConfiguration config = new ParserConfiguration();
@@ -71,6 +73,22 @@ public class CodeScanner {
         // Disable storing tokens for better memory usage
         config.setStoreTokens(false);
         return new JavaParser(config);
+    }
+
+    /**
+     * Creates a DocumentBuilderFactory with XXE protection, reused for all POM parsing.
+     */
+    private static DocumentBuilderFactory createDocumentBuilderFactory() {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        try {
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        } catch (Exception e) {
+            // Should not happen with standard JDK XML implementations
+            throw new IllegalStateException("Failed to configure XML parser security features", e);
+        }
+        return factory;
     }
 
     /**
@@ -91,10 +109,13 @@ public class CodeScanner {
         try {
             log.debug("Scanning source directory: " + sourceDir);
 
-            // Walk through all Java files ONCE and extract all information
+            // Walk through all Java files and extract all information in parallel.
+            // ScanResult uses thread-safe collections and each thread gets its own
+            // JavaParser instance via ThreadLocal, so parallel processing is safe.
             try (Stream<Path> paths = Files.walk(sourceDir)) {
                 paths.filter(path -> path.toString().endsWith(".java"))
                         .filter(path -> !path.toString().contains("/test/"))
+                        .parallel()
                         .forEach(javaFile -> {
                             try {
                                 scanJavaFileForAllInfo(javaFile, result);
@@ -130,7 +151,8 @@ public class CodeScanner {
      */
     private void scanJavaFileForAllInfo(Path javaFile, ScanResult result) {
         try {
-            Optional<CompilationUnit> parseResult = parser.parse(javaFile).getResult();
+            Optional<CompilationUnit> parseResult =
+                    parserLocal.get().parse(javaFile).getResult();
 
             if (parseResult.isEmpty()) {
                 log.debug("Failed to parse Java file: " + javaFile);
@@ -263,24 +285,13 @@ public class CodeScanner {
     }
 
     /**
-     * Extracts the artifactId from a pom.xml file.
+     * Extracts the artifactId from a pom.xml file's direct child element.
      * Returns null if the POM cannot be parsed or has no artifactId.
+     * Reuses the shared DocumentBuilderFactory for performance.
      */
     private String extractArtifactIdFromPom(Path pomPath) {
-        return isModuleArtifactId(pomPath) ? getArtifactIdFromPom(pomPath) : null;
-    }
-
-    /**
-     * Gets the artifactId from a pom.xml file's direct child element.
-     */
-    private String getArtifactIdFromPom(Path pomPath) {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
             Document doc = builder.parse(pomPath.toFile());
 
             Element root = doc.getDocumentElement();
@@ -298,13 +309,6 @@ public class CodeScanner {
             log.debug("Failed to parse POM file: " + pomPath);
         }
         return null;
-    }
-
-    /**
-     * Checks if the given POM file is a valid Maven project POM (has a project root and artifactId).
-     */
-    private boolean isModuleArtifactId(Path pomPath) {
-        return getArtifactIdFromPom(pomPath) != null;
     }
 
     /**

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/ScanResult.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/ScanResult.java
@@ -1,19 +1,21 @@
 package io.kaoto.forage.maven.catalog;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import io.kaoto.forage.catalog.model.ConfigEntry;
 
 /**
  * Holds all scan results in one structure.
+ * Collections are thread-safe to support parallel file scanning.
  */
 public class ScanResult {
-    private final List<ScannedBean> beans = new ArrayList<>();
-    private final List<ScannedFactory> factories = new ArrayList<>();
-    private final List<ConfigEntry> configProperties = new ArrayList<>();
-    private final Map<String, String> configClasses = new HashMap<>();
+    private final List<ScannedBean> beans = Collections.synchronizedList(new ArrayList<>());
+    private final List<ScannedFactory> factories = Collections.synchronizedList(new ArrayList<>());
+    private final List<ConfigEntry> configProperties = Collections.synchronizedList(new ArrayList<>());
+    private final Map<String, String> configClasses = new ConcurrentHashMap<>();
 
     public List<ScannedBean> getBeans() {
         return beans;

--- a/tooling/forage-maven-catalog-plugin/src/test/java/io/kaoto/forage/maven/catalog/CodeScannerTest.java
+++ b/tooling/forage-maven-catalog-plugin/src/test/java/io/kaoto/forage/maven/catalog/CodeScannerTest.java
@@ -1,0 +1,234 @@
+package io.kaoto.forage.maven.catalog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for CodeScanner, covering POM parsing, annotation scanning, and parallel execution.
+ */
+public class CodeScannerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CodeScanner scanner;
+    private Log log;
+
+    @BeforeEach
+    void setUp() {
+        log = new SystemStreamLog();
+        scanner = new CodeScanner(log);
+    }
+
+    @Test
+    void testScanFindsForageBean() throws IOException {
+        // Set up a module with a pom.xml and a Java file with @ForageBean
+        Path moduleDir = tempDir.resolve("forage-test-module");
+        Files.createDirectories(moduleDir.resolve("src/main/java/com/example"));
+
+        writePom(moduleDir, "forage-test-module");
+
+        Files.writeString(
+                moduleDir.resolve("src/main/java/com/example/TestProvider.java"),
+                """
+                package com.example;
+
+                import io.kaoto.forage.core.annotations.ForageBean;
+
+                @ForageBean(value = "test-provider",
+                    components = {"camel-langchain4j-chat"},
+                    description = "A test provider")
+                public class TestProvider {
+                }
+                """);
+
+        Artifact artifact = createArtifact("forage-test-module");
+        ScanResult result = scanner.scanAllInOnePass(artifact, tempDir);
+
+        assertThat(result.getBeans()).hasSize(1);
+        assertThat(result.getBeans().get(0).getName()).isEqualTo("test-provider");
+        assertThat(result.getBeans().get(0).getDescription()).isEqualTo("A test provider");
+        assertThat(result.getBeans().get(0).getComponents()).containsExactly("camel-langchain4j-chat");
+    }
+
+    @Test
+    void testScanFindsForageFactory() throws IOException {
+        Path moduleDir = tempDir.resolve("forage-test-factory");
+        Files.createDirectories(moduleDir.resolve("src/main/java/com/example"));
+
+        writePom(moduleDir, "forage-test-factory");
+
+        Files.writeString(
+                moduleDir.resolve("src/main/java/com/example/TestFactory.java"),
+                """
+                package com.example;
+
+                import io.kaoto.forage.core.annotations.ForageFactory;
+                import io.kaoto.forage.core.annotations.FactoryType;
+
+                @ForageFactory(value = "test-factory",
+                    components = {"camel-langchain4j-chat"},
+                    description = "A test factory",
+                    type = FactoryType.DATA_SOURCE)
+                public class TestFactory {
+                }
+                """);
+
+        Artifact artifact = createArtifact("forage-test-factory");
+        ScanResult result = scanner.scanAllInOnePass(artifact, tempDir);
+
+        assertThat(result.getFactories()).hasSize(1);
+        assertThat(result.getFactories().get(0).getName()).isEqualTo("test-factory");
+        assertThat(result.getFactories().get(0).getDescription()).isEqualTo("A test factory");
+    }
+
+    @Test
+    void testScanSkipsTestDirectory() throws IOException {
+        Path moduleDir = tempDir.resolve("forage-test-skip");
+        Files.createDirectories(moduleDir.resolve("src/main/java/com/example"));
+        Files.createDirectories(moduleDir.resolve("src/test/java/com/example"));
+
+        writePom(moduleDir, "forage-test-skip");
+
+        // Production source
+        Files.writeString(
+                moduleDir.resolve("src/main/java/com/example/MainProvider.java"),
+                """
+                package com.example;
+
+                import io.kaoto.forage.core.annotations.ForageBean;
+
+                @ForageBean(value = "main-provider", components = {"comp"}, description = "Main")
+                public class MainProvider {
+                }
+                """);
+
+        // Test source — should be ignored
+        Files.writeString(
+                moduleDir.resolve("src/test/java/com/example/TestOnlyProvider.java"),
+                """
+                package com.example;
+
+                import io.kaoto.forage.core.annotations.ForageBean;
+
+                @ForageBean(value = "test-only-provider", components = {"comp"}, description = "Test only")
+                public class TestOnlyProvider {
+                }
+                """);
+
+        Artifact artifact = createArtifact("forage-test-skip");
+        ScanResult result = scanner.scanAllInOnePass(artifact, tempDir);
+
+        assertThat(result.getBeans()).hasSize(1);
+        assertThat(result.getBeans().get(0).getName()).isEqualTo("main-provider");
+    }
+
+    @Test
+    void testScanMultipleFilesInParallel() throws IOException {
+        Path moduleDir = tempDir.resolve("forage-test-parallel");
+        Files.createDirectories(moduleDir.resolve("src/main/java/com/example"));
+
+        writePom(moduleDir, "forage-test-parallel");
+
+        // Create multiple Java files to exercise parallel scanning
+        for (int i = 0; i < 10; i++) {
+            Files.writeString(
+                    moduleDir.resolve("src/main/java/com/example/Provider" + i + ".java"),
+                    """
+                    package com.example;
+
+                    import io.kaoto.forage.core.annotations.ForageBean;
+
+                    @ForageBean(value = "provider-%d", components = {"comp"}, description = "Provider %d")
+                    public class Provider%d {
+                    }
+                    """
+                            .formatted(i, i, i));
+        }
+
+        Artifact artifact = createArtifact("forage-test-parallel");
+        ScanResult result = scanner.scanAllInOnePass(artifact, tempDir);
+
+        // All 10 beans should be found regardless of parallel execution order
+        assertThat(result.getBeans()).hasSize(10);
+    }
+
+    @Test
+    void testScanNoSourceDirectory() {
+        // Artifact with no matching module directory
+        Artifact artifact = createArtifact("nonexistent-module");
+        ScanResult result = scanner.scanAllInOnePass(artifact, tempDir);
+
+        assertThat(result.getBeans()).isEmpty();
+        assertThat(result.getFactories()).isEmpty();
+        assertThat(result.getConfigProperties()).isEmpty();
+        assertThat(result.getConfigClasses()).isEmpty();
+    }
+
+    @Test
+    void testScanConfigEntries() throws IOException {
+        Path moduleDir = tempDir.resolve("forage-test-config");
+        Files.createDirectories(moduleDir.resolve("src/main/java/com/example"));
+
+        writePom(moduleDir, "forage-test-config");
+
+        Files.writeString(
+                moduleDir.resolve("src/main/java/com/example/TestConfigEntries.java"),
+                """
+                package com.example;
+
+                import io.kaoto.forage.core.util.config.ConfigEntries;
+                import io.kaoto.forage.core.util.config.ConfigModule;
+                import io.kaoto.forage.core.util.config.ConfigTag;
+
+                public final class TestConfigEntries extends ConfigEntries {
+                    public static final ConfigModule API_KEY = ConfigModule.of(
+                        TestConfig.class, "forage.test.api.key",
+                        "API key for testing", "API Key", "", "string", true, ConfigTag.COMMON);
+
+                    static {
+                        initModules(TestConfigEntries.class, API_KEY);
+                    }
+                }
+                """);
+
+        Artifact artifact = createArtifact("forage-test-config");
+        ScanResult result = scanner.scanAllInOnePass(artifact, tempDir);
+
+        assertThat(result.getConfigProperties()).hasSize(1);
+        assertThat(result.getConfigProperties().get(0).getName()).isEqualTo("forage.test.api.key");
+        assertThat(result.getConfigProperties().get(0).getDescription()).isEqualTo("API key for testing");
+        assertThat(result.getConfigProperties().get(0).isRequired()).isTrue();
+    }
+
+    private void writePom(Path moduleDir, String artifactId) throws IOException {
+        Files.writeString(
+                moduleDir.resolve("pom.xml"),
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>io.kaoto.forage</groupId>
+                    <artifactId>%s</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                </project>
+                """
+                        .formatted(artifactId));
+    }
+
+    private Artifact createArtifact(String artifactId) {
+        return new DefaultArtifact(
+                "io.kaoto.forage", artifactId, "1.0-SNAPSHOT", "compile", "jar", null, new DefaultArtifactHandler());
+    }
+}


### PR DESCRIPTION
## Summary
- **Fix double POM parsing**: `extractArtifactIdFromPom` was parsing each pom.xml twice (once in `isModuleArtifactId` check, once to get the value). Merged into a single parse call.
- **Reuse DocumentBuilderFactory**: Previously created a new factory with XXE hardening per pom.xml file. Now created once and reused for all 109+ POM files.
- **Parallelize Java file scanning**: Source files are now scanned in parallel using `.parallel()` streams. JavaParser instances are per-thread via `ThreadLocal`, and `ScanResult` collections use `Collections.synchronizedList` / `ConcurrentHashMap`.

## Test plan
- [x] New `CodeScannerTest` with 6 tests covering bean scanning, factory scanning, test directory exclusion, parallel scanning of 10 files, missing source directory, and config entry extraction
- [x] All 15 existing + new tests pass
- [x] Full project build succeeds with catalog generation producing correct output (3 factories, all catalog files generated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential security vulnerability in POM file parsing by implementing XXE prevention measures.

* **Performance**
  * Improved source code scanning performance through parallel processing.

* **Tests**
  * Added comprehensive test suite validating scanning behavior, parallelism, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->