### PR TITLE
Fix #323: Add CXF core interface, FactoryType, and common config module

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
@@ -13,10 +13,10 @@ public enum FactoryType {
     DATA_SOURCE("javax.sql.DataSource", "forage-jdbc-common"),
 
     /** Factory that creates ConnectionFactory beans for JMS */
-    CONNECTION_FACTORY("jakarta.jms.ConnectionFactory", "forage-jms-common");
+    CONNECTION_FACTORY("jakarta.jms.ConnectionFactory", "forage-jms-common"),
 
-    /** Factory that creates ConnectionFactory beans for JMS */
-    //    CORE_FACTORIES("jakarta.jms.ConnectionFactory", "forage-jms-common");
+    /** Factory that creates CxfEndpoint beans for CXF SOAP */
+    CXF_ENDPOINT("org.apache.camel.component.cxf.jaxws.CxfEndpoint", "forage-cxf-common");
 
     private final String displayName;
 

--- a/core/forage-core-cxf/pom.xml
+++ b/core/forage-core-cxf/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>core</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-core-cxf</artifactId>
+    <name>Forage :: Core :: CXF</name>
+    <description>Core interfaces and utilities for CXF endpoint providers</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/core/forage-core-cxf/src/main/java/io/kaoto/forage/core/cxf/CxfEndpointProvider.java
+++ b/core/forage-core-cxf/src/main/java/io/kaoto/forage/core/cxf/CxfEndpointProvider.java
@@ -1,0 +1,14 @@
+package io.kaoto.forage.core.cxf;
+
+import io.kaoto.forage.core.common.BeanProvider;
+
+public interface CxfEndpointProvider extends BeanProvider<Object> {
+
+    @Override
+    default Object create() {
+        return create(null);
+    }
+
+    @Override
+    Object create(String id);
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,6 +22,7 @@
         <module>forage-core-vectordb</module>
         <module>forage-core-jdbc</module>
         <module>forage-core-jms</module>
+        <module>forage-core-cxf</module>
         <module>forage-core-jta</module>
         <module>forage-core-vertx</module>
         <module>forage-core-cloud</module>

--- a/library/cxf/forage-cxf-common/pom.xml
+++ b/library/cxf/forage-cxf-common/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-cxf-common</artifactId>
+    <name>Forage :: Library :: CXF :: Common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfCommonExportHelper.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfCommonExportHelper.java
@@ -11,6 +11,9 @@ public class CxfCommonExportHelper {
     }
 
     public static String transformCxfKindIntoProviderClass(String cxfKind) {
+        if (cxfKind == null) {
+            return "io.kaoto.forage.cxf.soap.SoapEndpointProvider";
+        }
         return CXF_KIND_TO_PROVIDER_CLASS.getOrDefault(
                 cxfKind.toLowerCase(), "io.kaoto.forage.cxf.soap.SoapEndpointProvider");
     }

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfCommonExportHelper.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfCommonExportHelper.java
@@ -1,0 +1,17 @@
+package io.kaoto.forage.cxf.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CxfCommonExportHelper {
+    private static final Map<String, String> CXF_KIND_TO_PROVIDER_CLASS = new HashMap<>();
+
+    static {
+        CXF_KIND_TO_PROVIDER_CLASS.put("soap", "io.kaoto.forage.cxf.soap.SoapEndpointProvider");
+    }
+
+    public static String transformCxfKindIntoProviderClass(String cxfKind) {
+        return CXF_KIND_TO_PROVIDER_CLASS.getOrDefault(
+                cxfKind.toLowerCase(), "io.kaoto.forage.cxf.soap.SoapEndpointProvider");
+    }
+}

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfConfig.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfConfig.java
@@ -1,0 +1,143 @@
+package io.kaoto.forage.cxf.common;
+
+import io.kaoto.forage.core.util.config.AbstractConfig;
+import io.kaoto.forage.core.util.config.MissingConfigException;
+
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.ADDRESS;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.CONTINUATION_TIMEOUT;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.CXF_KIND;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.DATA_FORMAT;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.DEFAULT_OPERATION_NAME;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.DEFAULT_OPERATION_NAMESPACE;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.LOGGING_ENABLED;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.LOGGING_SIZE_LIMIT;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.MTOM_ENABLED;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.PASSWORD;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.PORT_NAME;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.SCHEMA_VALIDATION_ENABLED;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.SERVICE_CLASS;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.SERVICE_NAME;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.SKIP_FAULT_LOGGING;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.SSL_CONTEXT_PARAMETERS;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.SYNCHRONOUS;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.USERNAME;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.WRAPPED_STYLE;
+import static io.kaoto.forage.cxf.common.CxfConfigEntries.WSDL_URL;
+
+public class CxfConfig extends AbstractConfig {
+
+    public CxfConfig() {
+        this(null);
+    }
+
+    public CxfConfig(String prefix) {
+        super(prefix, CxfConfigEntries.class);
+    }
+
+    @Override
+    public String name() {
+        return "forage-cxf";
+    }
+
+    public String cxfKind() {
+        return getRequired(CXF_KIND, "CXF kind is required but not configured");
+    }
+
+    public String address() {
+        return getRequired(ADDRESS, "CXF endpoint address is required but not configured");
+    }
+
+    public String wsdlUrl() {
+        return get(WSDL_URL).orElse(null);
+    }
+
+    public String serviceClassName() {
+        return get(SERVICE_CLASS).orElse(null);
+    }
+
+    public Class<?> loadServiceClass() {
+        String className = serviceClassName();
+        if (className == null) {
+            return null;
+        }
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new MissingConfigException("Service class not found: " + className);
+        }
+    }
+
+    public String serviceName() {
+        return get(SERVICE_NAME).orElse(null);
+    }
+
+    public String portName() {
+        return get(PORT_NAME).orElse(null);
+    }
+
+    public String dataFormat() {
+        return get(DATA_FORMAT).orElse(DATA_FORMAT.defaultValue());
+    }
+
+    public boolean loggingEnabled() {
+        return get(LOGGING_ENABLED)
+                .map(Boolean::parseBoolean)
+                .orElse(Boolean.parseBoolean(LOGGING_ENABLED.defaultValue()));
+    }
+
+    public int loggingSizeLimit() {
+        return get(LOGGING_SIZE_LIMIT)
+                .map(Integer::parseInt)
+                .orElse(Integer.parseInt(LOGGING_SIZE_LIMIT.defaultValue()));
+    }
+
+    public boolean skipFaultLogging() {
+        return get(SKIP_FAULT_LOGGING)
+                .map(Boolean::parseBoolean)
+                .orElse(Boolean.parseBoolean(SKIP_FAULT_LOGGING.defaultValue()));
+    }
+
+    public String username() {
+        return get(USERNAME).orElse(null);
+    }
+
+    public String password() {
+        return get(PASSWORD).orElse(null);
+    }
+
+    public boolean mtomEnabled() {
+        return get(MTOM_ENABLED).map(Boolean::parseBoolean).orElse(Boolean.parseBoolean(MTOM_ENABLED.defaultValue()));
+    }
+
+    public Boolean wrappedStyle() {
+        return get(WRAPPED_STYLE).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public boolean schemaValidationEnabled() {
+        return get(SCHEMA_VALIDATION_ENABLED)
+                .map(Boolean::parseBoolean)
+                .orElse(Boolean.parseBoolean(SCHEMA_VALIDATION_ENABLED.defaultValue()));
+    }
+
+    public int continuationTimeout() {
+        return get(CONTINUATION_TIMEOUT)
+                .map(Integer::parseInt)
+                .orElse(Integer.parseInt(CONTINUATION_TIMEOUT.defaultValue()));
+    }
+
+    public String defaultOperationName() {
+        return get(DEFAULT_OPERATION_NAME).orElse(null);
+    }
+
+    public String defaultOperationNamespace() {
+        return get(DEFAULT_OPERATION_NAMESPACE).orElse(null);
+    }
+
+    public boolean synchronous() {
+        return get(SYNCHRONOUS).map(Boolean::parseBoolean).orElse(Boolean.parseBoolean(SYNCHRONOUS.defaultValue()));
+    }
+
+    public String sslContextParameters() {
+        return get(SSL_CONTEXT_PARAMETERS).orElse(null);
+    }
+}

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfConfigEntries.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfConfigEntries.java
@@ -111,7 +111,7 @@ public final class CxfConfigEntries extends ConfigEntries {
             "The username for CXF endpoint authentication",
             "Username",
             null,
-            "password",
+            "string",
             false,
             ConfigTag.SECURITY);
 

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfConfigEntries.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfConfigEntries.java
@@ -1,0 +1,232 @@
+package io.kaoto.forage.cxf.common;
+
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigTag;
+
+public final class CxfConfigEntries extends ConfigEntries {
+
+    public static final ConfigModule CXF_KIND = ConfigModule.ofBeanName(
+            CxfConfig.class,
+            "forage.cxf.kind",
+            "The CXF endpoint kind/type",
+            "CXF Kind",
+            true,
+            ConfigTag.COMMON,
+            "java.lang.Object");
+
+    public static final ConfigModule ADDRESS = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.address",
+            "The CXF endpoint address URL",
+            "Address",
+            null,
+            "string",
+            true,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule WSDL_URL = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.wsdl.url",
+            "The WSDL document URL",
+            "WSDL URL",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule SERVICE_CLASS = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.service.class",
+            "The fully qualified service endpoint interface class name",
+            "Service Class",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule SERVICE_NAME = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.service.name",
+            "The service name in the WSDL",
+            "Service Name",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule PORT_NAME = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.port.name",
+            "The port name in the WSDL",
+            "Port Name",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule DATA_FORMAT = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.data.format",
+            "The CXF data format (POJO, PAYLOAD, RAW, CXF_MESSAGE)",
+            "Data Format",
+            "POJO",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule LOGGING_ENABLED = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.logging.enabled",
+            "Enable CXF message logging",
+            "Logging Enabled",
+            "false",
+            "boolean",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule LOGGING_SIZE_LIMIT = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.logging.size.limit",
+            "Maximum size of logged messages in bytes",
+            "Logging Size Limit",
+            "49152",
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule SKIP_FAULT_LOGGING = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.skip.fault.logging",
+            "Skip logging of SOAP fault messages",
+            "Skip Fault Logging",
+            "false",
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule USERNAME = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.username",
+            "The username for CXF endpoint authentication",
+            "Username",
+            null,
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule PASSWORD = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.password",
+            "The password for CXF endpoint authentication",
+            "Password",
+            null,
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule MTOM_ENABLED = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.mtom.enabled",
+            "Enable MTOM (Message Transmission Optimization Mechanism)",
+            "MTOM Enabled",
+            "false",
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule WRAPPED_STYLE = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.wrapped.style",
+            "Enable wrapped document/literal style",
+            "Wrapped Style",
+            null,
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule SCHEMA_VALIDATION_ENABLED = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.schema.validation.enabled",
+            "Enable schema validation of SOAP messages",
+            "Schema Validation",
+            "false",
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule CONTINUATION_TIMEOUT = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.continuation.timeout",
+            "Continuation timeout in milliseconds for asynchronous server operations",
+            "Continuation Timeout",
+            "30000",
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule DEFAULT_OPERATION_NAME = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.default.operation.name",
+            "The default operation name for dispatching",
+            "Default Operation Name",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule DEFAULT_OPERATION_NAMESPACE = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.default.operation.namespace",
+            "The default operation namespace for dispatching",
+            "Default Operation Namespace",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule SYNCHRONOUS = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.synchronous",
+            "Force synchronous invocation of the producer",
+            "Synchronous",
+            "false",
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule SSL_CONTEXT_PARAMETERS = ConfigModule.of(
+            CxfConfig.class,
+            "forage.cxf.ssl.context.parameters",
+            "Reference to a Camel SSLContextParameters bean by name",
+            "SSL Context Parameters",
+            null,
+            "string",
+            false,
+            ConfigTag.SECURITY);
+
+    static {
+        initModules(
+                CxfConfigEntries.class,
+                CXF_KIND,
+                ADDRESS,
+                WSDL_URL,
+                SERVICE_CLASS,
+                SERVICE_NAME,
+                PORT_NAME,
+                DATA_FORMAT,
+                LOGGING_ENABLED,
+                LOGGING_SIZE_LIMIT,
+                SKIP_FAULT_LOGGING,
+                USERNAME,
+                PASSWORD,
+                MTOM_ENABLED,
+                WRAPPED_STYLE,
+                SCHEMA_VALIDATION_ENABLED,
+                CONTINUATION_TIMEOUT,
+                DEFAULT_OPERATION_NAME,
+                DEFAULT_OPERATION_NAMESPACE,
+                SYNCHRONOUS,
+                SSL_CONTEXT_PARAMETERS);
+    }
+}

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfModuleDescriptor.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfModuleDescriptor.java
@@ -1,0 +1,42 @@
+package io.kaoto.forage.cxf.common;
+
+import io.kaoto.forage.core.common.ForageModuleDescriptor;
+import io.kaoto.forage.core.cxf.CxfEndpointProvider;
+
+public class CxfModuleDescriptor implements ForageModuleDescriptor<CxfConfig, CxfEndpointProvider> {
+
+    @Override
+    public String modulePrefix() {
+        return "cxf";
+    }
+
+    @Override
+    public CxfConfig createConfig(String prefix) {
+        return prefix == null ? new CxfConfig() : new CxfConfig(prefix);
+    }
+
+    @Override
+    public Class<CxfEndpointProvider> providerClass() {
+        return CxfEndpointProvider.class;
+    }
+
+    @Override
+    public String resolveProviderClassName(CxfConfig config) {
+        return CxfCommonExportHelper.transformCxfKindIntoProviderClass(config.cxfKind());
+    }
+
+    @Override
+    public String defaultBeanName() {
+        return "cxfEndpoint";
+    }
+
+    @Override
+    public Class<?> primaryBeanClass() {
+        return Object.class;
+    }
+
+    @Override
+    public boolean transactionEnabled(CxfConfig config) {
+        return false;
+    }
+}

--- a/library/cxf/pom.xml
+++ b/library/cxf/pom.xml
@@ -4,23 +4,16 @@
 
     <parent>
         <groupId>io.kaoto.forage</groupId>
-        <artifactId>forage</artifactId>
+        <artifactId>library</artifactId>
         <version>1.3-SNAPSHOT</version>
     </parent>
 
-    <artifactId>library</artifactId>
+    <artifactId>cxf</artifactId>
     <packaging>pom</packaging>
-    <name>Forage :: Library</name>
+    <name>Forage :: Library :: CXF</name>
 
     <modules>
-        <module>ai</module>
-        <module>cloud</module>
-        <module>common</module>
-        <module>cxf</module>
-        <module>jdbc</module>
-        <module>jms</module>
-        <module>policy</module>
-        <module>vertx</module>
+        <module>forage-cxf-common</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Summary
- Add `core/forage-core-cxf` module with `CxfEndpointProvider` interface (`BeanProvider<Object>`)
- Add `CXF_ENDPOINT` entry to `FactoryType` enum
- Add `library/cxf/forage-cxf-common` module with `CxfConfigEntries` (20 SOAP config properties), `CxfConfig`, `CxfModuleDescriptor`, and `CxfCommonExportHelper`

## Test plan
- [x] `mvn clean compile` passes from project root (all modules compile)
- [x] Spotless formatting applied automatically during compile
- [ ] CI build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache CXF SOAP endpoint support with comprehensive configuration capabilities including endpoint address, WSDL URL, service class configuration, security credentials, MTOM support, schema validation, and logging options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->