### PR TITLE
Fix #324: Add CXF SOAP endpoint provider

### DIFF
--- a/library/cxf/forage-cxf-soap/pom.xml
+++ b/library/cxf/forage-cxf-soap/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-cxf-soap</artifactId>
+    <name>Forage :: Library :: CXF :: SOAP</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-cxf-soap</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/cxf/forage-cxf-soap/src/main/java/io/kaoto/forage/cxf/soap/SoapEndpointProvider.java
+++ b/library/cxf/forage-cxf-soap/src/main/java/io/kaoto/forage/cxf/soap/SoapEndpointProvider.java
@@ -1,0 +1,70 @@
+package io.kaoto.forage.cxf.soap;
+
+import org.apache.camel.component.cxf.common.DataFormat;
+import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
+import io.kaoto.forage.core.annotations.ForageBean;
+import io.kaoto.forage.core.cxf.CxfEndpointProvider;
+import io.kaoto.forage.cxf.common.CxfConfig;
+
+@ForageBean(
+        value = "soap",
+        components = {"camel-cxf"},
+        description = "Apache CXF SOAP (JAX-WS) endpoint",
+        feature = "org.apache.camel.component.cxf.jaxws.CxfEndpoint")
+public class SoapEndpointProvider implements CxfEndpointProvider {
+
+    @Override
+    public Object create(String id) {
+        CxfConfig config = new CxfConfig(id);
+        CxfEndpoint endpoint = new CxfEndpoint();
+
+        endpoint.setAddress(config.address());
+        endpoint.setDataFormat(DataFormat.valueOf(config.dataFormat()));
+
+        if (config.wsdlUrl() != null) {
+            endpoint.setWsdlURL(config.wsdlUrl());
+        }
+
+        Class<?> serviceClass = config.loadServiceClass();
+        if (serviceClass != null) {
+            endpoint.setServiceClass(serviceClass);
+        }
+
+        if (config.serviceName() != null) {
+            endpoint.setServiceName(config.serviceName());
+        }
+        if (config.portName() != null) {
+            endpoint.setPortName(config.portName());
+        }
+
+        endpoint.setLoggingFeatureEnabled(config.loggingEnabled());
+        endpoint.setLoggingSizeLimit(config.loggingSizeLimit());
+        endpoint.setSkipFaultLogging(config.skipFaultLogging());
+
+        if (config.username() != null) {
+            endpoint.setUsername(config.username());
+        }
+        if (config.password() != null) {
+            endpoint.setPassword(config.password());
+        }
+
+        endpoint.setMtomEnabled(config.mtomEnabled());
+
+        if (config.wrappedStyle() != null) {
+            endpoint.setWrappedStyle(config.wrappedStyle());
+        }
+
+        endpoint.setSchemaValidationEnabled(config.schemaValidationEnabled());
+        endpoint.setContinuationTimeout(config.continuationTimeout());
+        endpoint.setSynchronous(config.synchronous());
+
+        if (config.defaultOperationName() != null) {
+            endpoint.setDefaultOperationName(config.defaultOperationName());
+        }
+        if (config.defaultOperationNamespace() != null) {
+            endpoint.setDefaultOperationNamespace(config.defaultOperationNamespace());
+        }
+
+        return endpoint;
+    }
+}

--- a/library/cxf/forage-cxf-soap/src/main/resources/META-INF/services/io.kaoto.forage.core.cxf.CxfEndpointProvider
+++ b/library/cxf/forage-cxf-soap/src/main/resources/META-INF/services/io.kaoto.forage.core.cxf.CxfEndpointProvider
@@ -1,0 +1,1 @@
+io.kaoto.forage.cxf.soap.SoapEndpointProvider

--- a/library/cxf/pom.xml
+++ b/library/cxf/pom.xml
@@ -14,6 +14,7 @@
 
     <modules>
         <module>forage-cxf-common</module>
+        <module>forage-cxf-soap</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Summary
- Add `forage-cxf-soap` module with `SoapEndpointProvider` implementing `CxfEndpointProvider`
- Provider creates and configures a `CxfEndpoint` from `CxfConfig` properties (address, WSDL, service class, data format, logging, auth, MTOM, schema validation, etc.)
- SSL context parameters skipped — requires `CamelContext` resolution, left for the BeanFactory

## Test plan
- [ ] `mvn compile -f library/cxf/forage-cxf-soap` compiles successfully
- [ ] `mvn spotless:check -f library/cxf/forage-cxf-soap` passes formatting
- [ ] ServiceLoader file correctly registers the provider

Closes #324