### PR TITLE
Fix #326: Add plain Camel CXF BeanFactory

### DIFF
--- a/library/cxf/forage-cxf/pom.xml
+++ b/library/cxf/forage-cxf/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-cxf</artifactId>
+    <name>Forage :: Library :: CXF :: Forage CXF</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-support</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/cxf/forage-cxf/src/main/java/io/kaoto/forage/cxf/CxfBeanFactory.java
+++ b/library/cxf/forage-cxf/src/main/java/io/kaoto/forage/cxf/CxfBeanFactory.java
@@ -1,0 +1,118 @@
+package io.kaoto.forage.cxf;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelContextAware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.annotations.FactoryType;
+import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.BeanFactory;
+import io.kaoto.forage.core.common.ServiceLoaderHelper;
+import io.kaoto.forage.core.cxf.CxfEndpointProvider;
+import io.kaoto.forage.core.util.config.ConfigHelper;
+import io.kaoto.forage.core.util.config.ConfigStore;
+import io.kaoto.forage.cxf.common.CxfCommonExportHelper;
+import io.kaoto.forage.cxf.common.CxfConfig;
+
+@ForageFactory(
+        value = "CXF Web Service",
+        components = {"camel-cxf"},
+        description = "Creates CXF SOAP endpoint beans for web service integration",
+        type = FactoryType.CXF_ENDPOINT,
+        autowired = true,
+        configClass = CxfConfig.class)
+public class CxfBeanFactory implements BeanFactory {
+    private final Logger LOG = LoggerFactory.getLogger(CxfBeanFactory.class);
+
+    private CamelContext camelContext;
+    private static final String DEFAULT_BEAN_NAME = "cxfEndpoint";
+
+    @Override
+    public void cleanup() {
+        CxfConfig config = new CxfConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("cxf"));
+
+        for (String name : prefixes) {
+            camelContext.getRegistry().unbind(name);
+        }
+        camelContext.getRegistry().unbind(DEFAULT_BEAN_NAME);
+    }
+
+    @Override
+    public void configure() {
+        CxfConfig config = new CxfConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("cxf"));
+
+        if (!prefixes.isEmpty()) {
+            for (String name : prefixes) {
+                try {
+                    if (camelContext.getRegistry().lookupByName(name) == null) {
+                        CxfConfig cxfConfig = new CxfConfig(name);
+                        Object endpoint = newCxfEndpoint(cxfConfig, name);
+                        if (endpoint != null) {
+                            applyCamelContext(endpoint);
+                            camelContext.getRegistry().bind(name, endpoint);
+                        }
+                    }
+                } catch (Exception ex) {
+                    LOG.error("Failed to configure CXF endpoint '{}': {}", name, ex.getMessage(), ex);
+                }
+            }
+        } else {
+            try {
+                if (camelContext.getRegistry().lookupByName(DEFAULT_BEAN_NAME) == null) {
+                    CxfConfig cxfConfig = new CxfConfig();
+                    Object endpoint = newCxfEndpoint(cxfConfig, DEFAULT_BEAN_NAME);
+                    if (endpoint != null) {
+                        applyCamelContext(endpoint);
+                        camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, endpoint);
+                    } else {
+                        throw new IllegalArgumentException(
+                                "No matching CxfEndpointProvider found for configured cxf.kind");
+                    }
+                }
+            } catch (Exception ex) {
+                LOG.error(ex.getMessage(), ex);
+            }
+        }
+    }
+
+    private Object newCxfEndpoint(CxfConfig cxfConfig, String name) {
+        final String providerClass = CxfCommonExportHelper.transformCxfKindIntoProviderClass(cxfConfig.cxfKind());
+        LOG.info("Creating CXF endpoint of type {}", providerClass);
+
+        final List<ServiceLoader.Provider<CxfEndpointProvider>> providers = findProviders(CxfEndpointProvider.class);
+
+        final ServiceLoader.Provider<CxfEndpointProvider> provider =
+                ServiceLoaderHelper.findProviderByClassName(providers, providerClass);
+
+        if (provider == null) {
+            LOG.warn("CXF endpoint {} has no provider for {}", name, providerClass);
+            return null;
+        }
+
+        return provider.get().create(name);
+    }
+
+    // setCamelContext() applies deferred properties — all config must be set before this call
+    private void applyCamelContext(Object endpoint) {
+        if (endpoint instanceof CamelContextAware contextAware) {
+            contextAware.setCamelContext(camelContext);
+        }
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+}

--- a/library/cxf/forage-cxf/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
+++ b/library/cxf/forage-cxf/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
@@ -1,0 +1,1 @@
+io.kaoto.forage.cxf.CxfBeanFactory

--- a/library/cxf/pom.xml
+++ b/library/cxf/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>forage-cxf-common</module>
         <module>forage-cxf-soap</module>
+        <module>forage-cxf</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Summary
- Add `forage-cxf` module with `CxfBeanFactory` that wires CXF SOAP endpoint providers into a running Camel context
- Supports single-endpoint (default `cxfEndpoint` bean name) and multi-instance prefixed configuration
- Calls `setCamelContext()` after provider creates the endpoint to apply deferred CXF properties
- Registers via ServiceLoader for automatic discovery

## Test plan
- [ ] Verify `mvn -DskipTests install` passes in `library/cxf/forage-cxf`
- [ ] Verify ServiceLoader file is present in the built jar
- [ ] Test single CXF endpoint configuration via `forage-cxf.properties`
- [ ] Test multi-instance CXF endpoint configuration with prefixed properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Apache CXF SOAP endpoint support, enabling configuration of web services with customizable addressing, WSDL URLs, service/port names, authentication, logging, binary attachment handling (MTOM), XML schema validation, continuation timeout management, and default operation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->