### PR TITLE
Fix #327: Add Spring Boot CXF starter

### DIFF
--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -342,6 +342,23 @@
             </exclusions>
         </dependency>
 
+        <!-- CXF Modules -->
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-soap</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Cloud Modules -->
         <dependency>
             <groupId>io.kaoto.forage</groupId>

--- a/library/cxf/pom.xml
+++ b/library/cxf/pom.xml
@@ -16,6 +16,7 @@
         <module>forage-cxf-common</module>
         <module>forage-cxf-soap</module>
         <module>forage-cxf</module>
+        <module>spring-boot</module>
     </modules>
 
 </project>

--- a/library/cxf/spring-boot/forage-cxf-starter/pom.xml
+++ b/library/cxf/spring-boot/forage-cxf-starter/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf-spring-boot</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-cxf-starter</artifactId>
+    <name>Forage :: Library :: CXF :: Spring Boot :: CXF Starter</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-spring-boot-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/cxf/spring-boot/forage-cxf-starter/pom.xml
+++ b/library/cxf/spring-boot/forage-cxf-starter/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-cxf-soap-starter</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/library/cxf/spring-boot/forage-cxf-starter/src/main/java/io/kaoto/forage/springboot/cxf/ForageCxfAutoConfiguration.java
+++ b/library/cxf/spring-boot/forage-cxf-starter/src/main/java/io/kaoto/forage/springboot/cxf/ForageCxfAutoConfiguration.java
@@ -1,0 +1,75 @@
+package io.kaoto.forage.springboot.cxf;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import io.kaoto.forage.core.annotations.FactoryType;
+import io.kaoto.forage.core.annotations.FactoryVariant;
+import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.cxf.CxfEndpointProvider;
+import io.kaoto.forage.cxf.common.CxfCommonExportHelper;
+import io.kaoto.forage.cxf.common.CxfConfig;
+import io.kaoto.forage.cxf.common.CxfModuleDescriptor;
+import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
+
+/**
+ * Auto-configuration for Forage CXF endpoint creation using ServiceLoader discovery.
+ * Automatically creates CXF endpoint beans from configuration properties,
+ * supporting both single and multi-instance (prefixed) configurations.
+ *
+ * <p>Named/prefixed endpoints (e.g., {@code forage.billing.cxf.address}) are registered
+ * dynamically by {@link ForageSpringBootModuleAdapter} using the {@link CxfModuleDescriptor}.
+ */
+@ForageFactory(
+        value = "CXF (Spring Boot)",
+        variant = FactoryVariant.SPRING_BOOT,
+        components = {"camel-cxf"},
+        description = "Auto-configured CXF SOAP endpoint for Spring Boot",
+        type = FactoryType.CXF_ENDPOINT,
+        autowired = true,
+        configClass = CxfConfig.class)
+@Configuration
+public class ForageCxfAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(ForageCxfAutoConfiguration.class);
+
+    @Bean
+    static ForageSpringBootModuleAdapter<CxfConfig, CxfEndpointProvider> forageCxfModuleAdapter(
+            Environment environment) {
+        return new ForageSpringBootModuleAdapter<>(new CxfModuleDescriptor(), environment);
+    }
+
+    @Bean("cxfEndpoint")
+    @ConditionalOnMissingBean(name = "cxfEndpoint")
+    @ConditionalOnProperty(prefix = "forage.cxf", name = "kind")
+    public Object forageDefaultCxfEndpoint() {
+        CxfConfig config = new CxfConfig();
+        String kind = config.cxfKind();
+        String providerClassName = CxfCommonExportHelper.transformCxfKindIntoProviderClass(kind);
+
+        List<ServiceLoader.Provider<CxfEndpointProvider>> providers =
+                ServiceLoader.load(CxfEndpointProvider.class).stream().toList();
+
+        for (ServiceLoader.Provider<CxfEndpointProvider> provider : providers) {
+            if (provider.type().getName().equals(providerClassName)) {
+                log.info("Creating default CXF endpoint using provider: {}", providerClassName);
+                Object endpoint = provider.get().create(null);
+                log.info("Registered default CXF endpoint bean");
+                return endpoint;
+            }
+        }
+
+        String available = providers.stream()
+                .map(p -> p.type().getName())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("none");
+        throw new IllegalStateException("No CxfEndpointProvider found for kind '" + kind + "' (expected "
+                + providerClassName + "). Available providers: " + available);
+    }
+}

--- a/library/cxf/spring-boot/forage-cxf-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/library/cxf/spring-boot/forage-cxf-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.kaoto.forage.springboot.cxf.ForageCxfAutoConfiguration

--- a/library/cxf/spring-boot/pom.xml
+++ b/library/cxf/spring-boot/pom.xml
@@ -20,6 +20,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel-spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/library/cxf/spring-boot/pom.xml
+++ b/library/cxf/spring-boot/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cxf-spring-boot</artifactId>
+    <packaging>pom</packaging>
+    <name>Forage :: Library :: CXF :: Spring Boot</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>forage-cxf-starter</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <smallrye.version>3.16.0</smallrye.version>
         <spotless.version>3.2.1</spotless.version>
         <palantir-format.version>2.71.0</palantir-format.version>
+        <camel-spring-boot.version>${camel.version}</camel-spring-boot.version>
         <spring-boot.version>3.5.14</spring-boot.version>
         <spring.version>6.2.17</spring.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>


### PR DESCRIPTION
## Summary
- Adds `forage-cxf-starter` Spring Boot auto-configuration module for CXF SOAP endpoints
- Follows the established JMS/JDBC starter pattern with `ForageSpringBootModuleAdapter` and fallback bean
- Uses existing `CxfModuleDescriptor` and `SoapEndpointProvider` — plain `CxfEndpoint` works in Spring Boot as demonstrated by the official camel-spring-boot-examples

## Test plan
- [x] Module compiles successfully (`mvn -DskipTests install`)
- [x] Full CXF reactor builds (all 6 modules)
- [x] Spotless formatting passes
- [ ] Integration test with Spring Boot runtime