### PR TITLE
Fix #328: Add Quarkus CXF integration

### DIFF
--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -420,6 +420,18 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-quarkus-cxf-deployment</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-core-deployment</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Cloud Modules -->
         <dependency>

--- a/library/cxf/camel-quarkus/deployment/pom.xml
+++ b/library/cxf/camel-quarkus/deployment/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf-camel-quarkus</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-quarkus-cxf-deployment</artifactId>
+    <name>Forage :: Library :: CXF :: Quarkus :: Deployment</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core-deployment</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-quarkus-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfBuildItem.java
+++ b/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfBuildItem.java
@@ -1,0 +1,29 @@
+package io.kaoto.forage.quarkus.cxf.deployment;
+
+import io.kaoto.forage.cxf.common.CxfConfig;
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class ForageCxfBuildItem extends MultiBuildItem {
+
+    private final String name;
+    private final String prefix;
+    private final CxfConfig config;
+
+    public ForageCxfBuildItem(String name, String prefix, CxfConfig config) {
+        this.name = name;
+        this.prefix = prefix;
+        this.config = config;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public CxfConfig getConfig() {
+        return config;
+    }
+}

--- a/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
+++ b/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
@@ -1,0 +1,122 @@
+package io.kaoto.forage.quarkus.cxf.deployment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
+import org.jboss.logging.Logger;
+import io.kaoto.forage.core.annotations.FactoryType;
+import io.kaoto.forage.core.annotations.FactoryVariant;
+import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigEntry;
+import io.kaoto.forage.core.util.config.ConfigHelper;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigStore;
+import io.kaoto.forage.cxf.common.CxfConfig;
+import io.kaoto.forage.cxf.common.CxfConfigEntries;
+import io.kaoto.forage.cxf.common.CxfModuleDescriptor;
+import io.kaoto.forage.quarkus.cxf.ForageCxfRecorder;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+
+@ForageFactory(
+        value = "CXF (Quarkus)",
+        variant = FactoryVariant.QUARKUS,
+        components = {"camel-cxf"},
+        description = "Native CXF SOAP endpoint for Quarkus with compile-time optimization",
+        type = FactoryType.CXF_ENDPOINT,
+        autowired = true,
+        configClass = CxfConfig.class,
+        runtimeDependencies = {"mvn:org.apache.camel.quarkus:camel-quarkus-cxf-soap"})
+public class ForageCxfProcessor {
+
+    private static final Logger LOG = Logger.getLogger(ForageCxfProcessor.class);
+    private static final String FEATURE = "forage-cxf";
+    private static final CxfModuleDescriptor DESCRIPTOR = new CxfModuleDescriptor();
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    void discoverCxfEndpoints(
+            BuildProducer<ForageCxfBuildItem> cxfEndpoints, BuildProducer<SystemPropertyBuildItem> systemProperties) {
+
+        CxfConfig defaultConfig = DESCRIPTOR.createConfig(null);
+        Set<String> named = ConfigStore.getInstance()
+                .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+
+        if (!named.isEmpty()) {
+            for (String name : named) {
+                CxfConfig config = DESCRIPTOR.createConfig(name);
+                cxfEndpoints.produce(new ForageCxfBuildItem(name, name, config));
+                propagateConfigAsSystemProperties(name, systemProperties);
+            }
+        } else {
+            Set<String> defaultPrefixes = ConfigStore.getInstance()
+                    .readPrefixes(defaultConfig, ConfigHelper.getDefaultPropertyRegexp(DESCRIPTOR.modulePrefix()));
+            if (!defaultPrefixes.isEmpty()) {
+                cxfEndpoints.produce(new ForageCxfBuildItem(DESCRIPTOR.defaultBeanName(), null, defaultConfig));
+                propagateConfigAsSystemProperties(null, systemProperties);
+            } else {
+                LOG.debug("No Forage CXF configuration found, skipping CXF endpoint discovery");
+            }
+        }
+    }
+
+    private void propagateConfigAsSystemProperties(
+            String prefix, BuildProducer<SystemPropertyBuildItem> systemProperties) {
+
+        Map<ConfigModule, ConfigEntry> modules = ConfigEntries.getModules(CxfConfigEntries.class);
+        for (ConfigModule module : modules.keySet()) {
+            ConfigModule resolved = prefix != null ? module.asNamed(prefix) : module;
+            Optional<String> value = ConfigStore.getInstance().get(resolved);
+            if (value.isPresent()) {
+                String propertyName = resolved.propertyName();
+                LOG.debugf("Propagating %s=%s as system property", propertyName, value.get());
+                systemProperties.produce(new SystemPropertyBuildItem(propertyName, value.get()));
+            }
+        }
+    }
+
+    @BuildStep
+    @Record(value = ExecutionTime.RUNTIME_INIT)
+    void registerCxfEndpoints(
+            ForageCxfRecorder recorder,
+            List<ForageCxfBuildItem> cxfEndpoints,
+            BuildProducer<CamelRuntimeBeanBuildItem> beans) {
+
+        for (ForageCxfBuildItem item : cxfEndpoints) {
+            LOG.infof("Registering CXF endpoint bean '%s'", item.getName());
+            RuntimeValue<Object> endpoint = recorder.createCxfEndpoint(item.getPrefix());
+            if (endpoint != null) {
+                beans.produce(new CamelRuntimeBeanBuildItem(item.getName(), Object.class.getName(), endpoint));
+            }
+        }
+    }
+
+    @BuildStep
+    void registerReflectiveClasses(
+            List<ForageCxfBuildItem> cxfEndpoints, BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+
+        for (ForageCxfBuildItem item : cxfEndpoints) {
+            String serviceClassName = item.getConfig().serviceClassName();
+            if (serviceClassName != null) {
+                LOG.infof("Registering CXF service class for reflection: %s", serviceClassName);
+                reflectiveClasses.produce(ReflectiveClassBuildItem.builder(serviceClassName)
+                        .methods()
+                        .fields()
+                        .build());
+            }
+        }
+    }
+}

--- a/library/cxf/camel-quarkus/pom.xml
+++ b/library/cxf/camel-quarkus/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf</artifactId>
+        <version>1.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>cxf-camel-quarkus</artifactId>
+    <packaging>pom</packaging>
+    <name>Forage :: Library :: CXF :: Camel Quarkus</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/library/cxf/camel-quarkus/runtime/pom.xml
+++ b/library/cxf/camel-quarkus/runtime/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>cxf-camel-quarkus</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-quarkus-cxf</artifactId>
+    <name>Forage :: Library :: CXF :: Quarkus :: Runtime</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-core</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-cxf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-cxf-soap</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfConfigSourceFactory.java
+++ b/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfConfigSourceFactory.java
@@ -1,0 +1,15 @@
+package io.kaoto.forage.quarkus.cxf;
+
+import io.kaoto.forage.core.common.ForageModuleDescriptor;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
+import io.kaoto.forage.core.cxf.CxfEndpointProvider;
+import io.kaoto.forage.cxf.common.CxfConfig;
+import io.kaoto.forage.cxf.common.CxfModuleDescriptor;
+
+public class ForageCxfConfigSourceFactory extends ForageQuarkusConfigSourceAdapter<CxfConfig> {
+
+    @Override
+    protected ForageModuleDescriptor<CxfConfig, CxfEndpointProvider> descriptor() {
+        return new CxfModuleDescriptor();
+    }
+}

--- a/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfRecorder.java
+++ b/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfRecorder.java
@@ -1,0 +1,42 @@
+package io.kaoto.forage.quarkus.cxf;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import org.jboss.logging.Logger;
+import io.kaoto.forage.core.common.ServiceLoaderHelper;
+import io.kaoto.forage.core.cxf.CxfEndpointProvider;
+import io.kaoto.forage.core.util.config.ConfigStore;
+import io.kaoto.forage.cxf.common.CxfCommonExportHelper;
+import io.kaoto.forage.cxf.common.CxfConfig;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class ForageCxfRecorder {
+
+    private static final Logger LOG = Logger.getLogger(ForageCxfRecorder.class);
+
+    public RuntimeValue<Object> createCxfEndpoint(String id) {
+        ConfigStore.getInstance().setClassLoader(Thread.currentThread().getContextClassLoader());
+        CxfConfig config = id == null ? new CxfConfig() : new CxfConfig(id);
+        String providerClass = CxfCommonExportHelper.transformCxfKindIntoProviderClass(config.cxfKind());
+        LOG.infof("Creating CXF endpoint of type %s for id '%s'", providerClass, id);
+
+        List<ServiceLoader.Provider<CxfEndpointProvider>> providers =
+                ServiceLoader.load(CxfEndpointProvider.class).stream().toList();
+
+        ServiceLoader.Provider<CxfEndpointProvider> provider =
+                ServiceLoaderHelper.findProviderByClassName(providers, providerClass);
+
+        if (provider == null) {
+            LOG.warnf("No CXF endpoint provider found for class %s", providerClass);
+            return null;
+        }
+
+        Object endpoint = provider.get().create(id);
+        if (endpoint != null) {
+            return new RuntimeValue<>(endpoint);
+        }
+        return null;
+    }
+}

--- a/library/cxf/camel-quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceFactory
+++ b/library/cxf/camel-quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceFactory
@@ -1,0 +1,1 @@
+io.kaoto.forage.quarkus.cxf.ForageCxfConfigSourceFactory

--- a/library/cxf/pom.xml
+++ b/library/cxf/pom.xml
@@ -17,6 +17,7 @@
         <module>forage-cxf-soap</module>
         <module>forage-cxf</module>
         <module>spring-boot</module>
+        <module>camel-quarkus</module>
     </modules>
 
 </project>

--- a/library/cxf/spring-boot/forage-cxf-starter/pom.xml
+++ b/library/cxf/spring-boot/forage-cxf-starter/pom.xml
@@ -28,6 +28,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http-undertow</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/library/cxf/spring-boot/forage-cxf-starter/src/main/java/io/kaoto/forage/springboot/cxf/ForageCxfAutoConfiguration.java
+++ b/library/cxf/spring-boot/forage-cxf-starter/src/main/java/io/kaoto/forage/springboot/cxf/ForageCxfAutoConfiguration.java
@@ -18,14 +18,6 @@ import io.kaoto.forage.cxf.common.CxfConfig;
 import io.kaoto.forage.cxf.common.CxfModuleDescriptor;
 import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
 
-/**
- * Auto-configuration for Forage CXF endpoint creation using ServiceLoader discovery.
- * Automatically creates CXF endpoint beans from configuration properties,
- * supporting both single and multi-instance (prefixed) configurations.
- *
- * <p>Named/prefixed endpoints (e.g., {@code forage.billing.cxf.address}) are registered
- * dynamically by {@link ForageSpringBootModuleAdapter} using the {@link CxfModuleDescriptor}.
- */
 @ForageFactory(
         value = "CXF (Spring Boot)",
         variant = FactoryVariant.SPRING_BOOT,

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <azure.identity.version>1.18.2</azure.identity.version>
         <azure.messaging.eventhubs.version>5.21.3</azure.messaging.eventhubs.version>
         <camel-quarkus.version>3.33.0</camel-quarkus.version>
+        <cxf.version>4.1.5</cxf.version>
         <citrus.version>4.10.0</citrus.version>
         <groovy.version>4.0.30</groovy.version>
         <ibmmq-client.version>9.4.5.0</ibmmq-client.version>


### PR DESCRIPTION
## Summary
- Add Quarkus runtime and deployment modules for CXF SOAP subsystem (`library/cxf/camel-quarkus/`)
- `ForageCxfProcessor` with build steps: feature registration, CXF endpoint discovery, bean registration via `CamelRuntimeBeanBuildItem`, `ReflectiveClassBuildItem` for native image, and `SystemPropertyBuildItem` for config propagation
- `ForageCxfRecorder` creates CXF endpoints at runtime via ServiceLoader
- `ForageCxfConfigSourceFactory` for SmallRye Config integration
- Added `forage-quarkus-cxf-deployment` to `forage-catalog/pom.xml`

Closes #328

## Test plan
- [x] Full build passes (`mvn clean install -DskipTests`)
- [x] Spotless formatting passes
- [x] Quarkus extension metadata generated (`quarkus-build-steps.list`)
- [x] CXF Quarkus variant appears in generated catalog JSON
- [x] `camel forage config read` detects CXF beans (default and named)
- [x] `camel forage config write` reports correct dependencies for all runtimes
- [x] `camel forage run` starts CXF SOAP endpoint on Undertow (plain Camel)
- [x] `camel forage export --runtime=quarkus` + `java -jar` starts CXF endpoint successfully
- [x] `camel forage export --runtime=spring-boot` exports with correct `forage-cxf-starter` dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Apache CXF support for Quarkus runtime environments.
  * Enabled automatic endpoint configuration discovery and native image support.

* **Chores**
  * Added new Maven modules and dependencies for CXF integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->