### PR TITLE
Fix #329: Add CXF integration tests

### DIFF
--- a/integration-tests/cxf/pom.xml
+++ b/integration-tests/cxf/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>integration-tests</artifactId>
+        <version>1.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>integration-tests-cxf</artifactId>
+    <name>Forage :: Integration Tests :: CXF</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>integration-tests-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.citrusframework.mvn</groupId>
+                <artifactId>citrus-maven-plugin</artifactId>
+                <version>${citrus.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>virtualDependencies</id>
+            <activation>
+                <property>
+                    <name>!noVirtualDependencies</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- The following dependencies guarantee that this module is built after them. -->
+                <dependency>
+                    <groupId>io.kaoto.forage</groupId>
+                    <artifactId>forage-quarkus-cxf-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapServerTest.java
+++ b/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapServerTest.java
@@ -1,0 +1,55 @@
+package io.kaoto.forage.cxf;
+
+import java.util.Collections;
+import java.util.function.Consumer;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.integration.tests.ForageIntegrationTest;
+import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
+import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@CitrusSupport
+@ExtendWith(IntegrationTestSetupExtension.class)
+public class CxfSoapServerTest implements ForageIntegrationTest {
+    private static final Logger LOG = LoggerFactory.getLogger(CxfSoapServerTest.class);
+
+    public static final String INTEGRATION_NAME = "cxf-soap-server";
+
+    @Override
+    public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
+        var builder = forageRun(INTEGRATION_NAME, "forage-cxf.properties", "route-server.camel.yaml")
+                .dumpIntegrationOutput(true);
+
+        String runtime = System.getProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY);
+        if ("quarkus".equals(runtime)) {
+            builder.withEnvs(Collections.singletonMap("FORAGE_CXF_ADDRESS", "/hello"));
+        }
+
+        runner.when(builder);
+
+        return INTEGRATION_NAME;
+    }
+
+    @Test
+    @CitrusTest()
+    public void soapServerCall(ForageTestCaseRunner runner) {
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .maxAttempts(8)
+                .delayBetweenAttempts(5000)
+                .waitForLogMessage("Server received request"));
+
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .maxAttempts(8)
+                .delayBetweenAttempts(5000)
+                .waitForLogMessage("Hello from CXF server"));
+    }
+}

--- a/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapTest.java
+++ b/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapTest.java
@@ -1,0 +1,134 @@
+package io.kaoto.forage.cxf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.integration.tests.ForageIntegrationTest;
+import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
+import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@CitrusSupport
+@ExtendWith(IntegrationTestSetupExtension.class)
+public class CxfSoapTest implements ForageIntegrationTest {
+    private static final Logger LOG = LoggerFactory.getLogger(CxfSoapTest.class);
+
+    public static final String INTEGRATION_NAME = "cxf-soap-client";
+
+    static WireMockServer wireMock;
+
+    private static final String SOAP_RESPONSE =
+            """
+            <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+              <soap:Body>
+                <sayHelloResponse xmlns="http://example.com/hello">
+                  <greeting>Hello Forage from CXF</greeting>
+                </sayHelloResponse>
+              </soap:Body>
+            </soap:Envelope>""";
+
+    private static final String WSDL =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+                         xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                         xmlns:tns="http://example.com/hello"
+                         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                         name="HelloService"
+                         targetNamespace="http://example.com/hello">
+              <types>
+                <xsd:schema targetNamespace="http://example.com/hello">
+                  <xsd:element name="sayHello">
+                    <xsd:complexType>
+                      <xsd:sequence>
+                        <xsd:element name="name" type="xsd:string"/>
+                      </xsd:sequence>
+                    </xsd:complexType>
+                  </xsd:element>
+                  <xsd:element name="sayHelloResponse">
+                    <xsd:complexType>
+                      <xsd:sequence>
+                        <xsd:element name="greeting" type="xsd:string"/>
+                      </xsd:sequence>
+                    </xsd:complexType>
+                  </xsd:element>
+                </xsd:schema>
+              </types>
+              <message name="SayHelloRequest">
+                <part name="parameters" element="tns:sayHello"/>
+              </message>
+              <message name="SayHelloResponse">
+                <part name="parameters" element="tns:sayHelloResponse"/>
+              </message>
+              <portType name="HelloPortType">
+                <operation name="sayHello">
+                  <input message="tns:SayHelloRequest"/>
+                  <output message="tns:SayHelloResponse"/>
+                </operation>
+              </portType>
+              <binding name="HelloBinding" type="tns:HelloPortType">
+                <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+                <operation name="sayHello">
+                  <soap:operation soapAction="sayHello"/>
+                  <input><soap:body use="literal"/></input>
+                  <output><soap:body use="literal"/></output>
+                </operation>
+              </binding>
+              <service name="HelloService">
+                <port name="HelloPort" binding="tns:HelloBinding">
+                  <soap:address location="http://localhost:8080/ws/hello"/>
+                </port>
+              </service>
+            </definitions>""";
+
+    @Override
+    public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
+        wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+        afterAll.accept(() -> wireMock.stop());
+
+        wireMock.stubFor(get(urlMatching("/ws/hello\\?wsdl"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(WSDL)));
+
+        wireMock.stubFor(post(urlEqualTo("/ws/hello"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(SOAP_RESPONSE)));
+
+        String wireMockUrl = "http://localhost:" + wireMock.port();
+
+        Map<String, String> envs = new HashMap<>();
+        envs.put("FORAGE_CXF_ADDRESS", wireMockUrl + "/ws/hello");
+        envs.put("FORAGE_CXF_WSDL_URL", wireMockUrl + "/ws/hello?wsdl");
+
+        runner.when(forageRun(INTEGRATION_NAME, "forage-cxf.properties", "route.camel.yaml")
+                .dumpIntegrationOutput(true)
+                .withEnvs(envs));
+
+        return INTEGRATION_NAME;
+    }
+
+    @Test
+    @CitrusTest()
+    public void soapClientCall(ForageTestCaseRunner runner) {
+        runner.then(camel().jbang().verify().integration(INTEGRATION_NAME).waitForLogMessage("Hello Forage from CXF"));
+    }
+}

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapServerTest/forage-cxf.properties
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapServerTest/forage-cxf.properties
@@ -1,0 +1,4 @@
+forage.cxf.kind=soap
+forage.cxf.address=http://localhost:8080/services/hello
+forage.cxf.data.format=PAYLOAD
+forage.cxf.logging.enabled=false

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapServerTest/route-server.camel.yaml
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapServerTest/route-server.camel.yaml
@@ -1,0 +1,43 @@
+- route:
+    id: cxf-soap-server
+    streamCaching: false
+    from:
+      uri: cxf:bean:cxfEndpoint
+      steps:
+        - log:
+            message: "Server received request"
+        - setBody:
+            constant:
+              expression: >
+                <sayHelloResponse xmlns="http://example.com/hello"><greeting>Hello from CXF server</greeting></sayHelloResponse>
+        - log:
+            message: "Server sending response"
+- route:
+    id: cxf-soap-caller
+    from:
+      uri: timer
+      parameters:
+        timerName: soap-caller
+        repeatCount: 1
+        delay: 5000
+      steps:
+        - setBody:
+            constant:
+              expression: >
+                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soap:Body>
+                    <sayHello xmlns="http://example.com/hello"><name>Forage</name></sayHello>
+                  </soap:Body>
+                </soap:Envelope>
+        - setHeader:
+            name: CamelHttpMethod
+            constant:
+              expression: POST
+        - setHeader:
+            name: Content-Type
+            constant:
+              expression: text/xml
+        - to:
+            uri: "http://localhost:8080/services/hello"
+        - log:
+            message: "Server response: ${body}"

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/forage-cxf.properties
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/forage-cxf.properties
@@ -1,0 +1,7 @@
+forage.cxf.kind=soap
+forage.cxf.address=http://localhost:8080/ws/hello
+forage.cxf.wsdl.url=http://localhost:8080/ws/hello?wsdl
+forage.cxf.service.name={http://example.com/hello}HelloService
+forage.cxf.port.name={http://example.com/hello}HelloPort
+forage.cxf.data.format=PAYLOAD
+forage.cxf.logging.enabled=true

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/route.camel.yaml
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/route.camel.yaml
@@ -1,0 +1,25 @@
+- route:
+    id: cxf-soap-client
+    from:
+      uri: timer
+      parameters:
+        timerName: soap-caller
+        repeatCount: 1
+        period: 5000
+      steps:
+        - setBody:
+            constant:
+              expression: >
+                <sayHello xmlns="http://example.com/hello"><name>Forage</name></sayHello>
+        - setHeader:
+            name: operationName
+            constant:
+              expression: sayHello
+        - setHeader:
+            name: operationNamespace
+            constant:
+              expression: "http://example.com/hello"
+        - to:
+            uri: cxf:bean:cxfEndpoint
+        - log:
+            message: "SOAP response: ${body}"

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -38,6 +38,7 @@
         <module>common</module>
         <module>jdbc</module>
         <module>jms</module>
+        <module>cxf</module>
     </modules>
 
     <build>

--- a/library/cxf/camel-quarkus/deployment/pom.xml
+++ b/library/cxf/camel-quarkus/deployment/pom.xml
@@ -47,6 +47,12 @@
             <artifactId>smallrye-config</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.quarkiverse.cxf</groupId>
+            <artifactId>quarkus-cxf-deployment</artifactId>
+            <version>${quarkiverse-cxf.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
+++ b/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
@@ -18,6 +18,7 @@ import io.kaoto.forage.cxf.common.CxfConfig;
 import io.kaoto.forage.cxf.common.CxfConfigEntries;
 import io.kaoto.forage.cxf.common.CxfModuleDescriptor;
 import io.kaoto.forage.quarkus.cxf.ForageCxfRecorder;
+import io.quarkiverse.cxf.deployment.CxfRouteRegistrationRequestorBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -45,6 +46,11 @@ public class ForageCxfProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    CxfRouteRegistrationRequestorBuildItem requestCxfRouteRegistration() {
+        return new CxfRouteRegistrationRequestorBuildItem(FEATURE);
     }
 
     @BuildStep

--- a/library/cxf/forage-cxf-soap/pom.xml
+++ b/library/cxf/forage-cxf-soap/pom.xml
@@ -33,6 +33,12 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-soap</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http-undertow</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/cxf/forage-cxf/src/main/java/io/kaoto/forage/cxf/CxfBeanFactory.java
+++ b/library/cxf/forage-cxf/src/main/java/io/kaoto/forage/cxf/CxfBeanFactory.java
@@ -67,7 +67,7 @@ public class CxfBeanFactory implements BeanFactory {
             try {
                 if (camelContext.getRegistry().lookupByName(DEFAULT_BEAN_NAME) == null) {
                     CxfConfig cxfConfig = new CxfConfig();
-                    Object endpoint = newCxfEndpoint(cxfConfig, DEFAULT_BEAN_NAME);
+                    Object endpoint = newCxfEndpoint(cxfConfig, null);
                     if (endpoint != null) {
                         applyCamelContext(endpoint);
                         camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, endpoint);
@@ -92,7 +92,7 @@ public class CxfBeanFactory implements BeanFactory {
                 ServiceLoaderHelper.findProviderByClassName(providers, providerClass);
 
         if (provider == null) {
-            LOG.warn("CXF endpoint {} has no provider for {}", name, providerClass);
+            LOG.warn("CXF endpoint '{}' has no provider for {}", name != null ? name : DEFAULT_BEAN_NAME, providerClass);
             return null;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <azure.messaging.eventhubs.version>5.21.3</azure.messaging.eventhubs.version>
         <camel-quarkus.version>3.33.0</camel-quarkus.version>
         <cxf.version>4.1.5</cxf.version>
+        <quarkiverse-cxf.version>3.33.0</quarkiverse-cxf.version>
+        <wiremock.version>3.13.0</wiremock.version>
         <citrus.version>4.10.0</citrus.version>
         <groovy.version>4.0.30</groovy.version>
         <ibmmq-client.version>9.4.5.0</ibmmq-client.version>


### PR DESCRIPTION
## Summary
- Add Citrus-based integration tests for CXF SOAP **client** and **server** modes
- Tests run on all three runtimes: plain Camel, Spring Boot, and Quarkus
- Fix CXF module bugs discovered during testing:
  - `CxfBeanFactory`: pass `null` as config prefix in default case (was passing bean name, causing property lookup failures in plain Camel)
  - `forage-cxf-soap`: add `cxf-rt-transports-http-undertow` dependency for CXF server HTTP transport
  - `ForageCxfProcessor`: register `CxfRouteRegistrationRequestorBuildItem` so `quarkus-cxf` mounts the Vert.x HTTP handler

### Client test (`CxfSoapTest`)
- Embedded WireMock serves WSDL and canned SOAP response
- CXF endpoint calls WireMock in PAYLOAD mode
- Verifies response parsed correctly

### Server test (`CxfSoapServerTest`)
- CXF endpoint hosts a SOAP service
- Timer route calls it via HTTP and verifies response
- Quarkus uses relative address (`/hello`) for `quarkus-cxf` Vert.x transport compatibility

## Test plan
- [x] `mvn verify -f integration-tests/cxf` — 6/6 tests pass (2 tests x 3 runtimes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CXF SOAP integration support enabling SOAP-based message handling and integration with SOAP services.
  * Integrated Undertow HTTP transport for enhanced CXF connectivity options.

* **Tests**
  * Added comprehensive CXF SOAP client and server integration test suites to validate SOAP message exchange and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->