### PR TITLE
Add web search engine bean factories for Tavily and Google Custom Search

### DIFF
--- a/core/forage-core-ai/src/main/java/io/kaoto/forage/core/ai/WebSearchEngineProvider.java
+++ b/core/forage-core-ai/src/main/java/io/kaoto/forage/core/ai/WebSearchEngineProvider.java
@@ -1,0 +1,9 @@
+package io.kaoto.forage.core.ai;
+
+import io.kaoto.forage.core.common.BeanProvider;
+import dev.langchain4j.web.search.WebSearchEngine;
+
+/**
+ * Provider interface for creating web search engine instances
+ */
+public interface WebSearchEngineProvider extends BeanProvider<WebSearchEngine> {}

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
@@ -16,7 +16,10 @@ public enum FactoryType {
     CONNECTION_FACTORY("jakarta.jms.ConnectionFactory", "forage-jms-common"),
 
     /** Factory that creates CxfEndpoint beans for CXF SOAP */
-    CXF_ENDPOINT("org.apache.camel.component.cxf.jaxws.CxfEndpoint", "forage-cxf-common");
+    CXF_ENDPOINT("org.apache.camel.component.cxf.jaxws.CxfEndpoint", "forage-cxf-common"),
+
+    /** Factory that creates WebSearchEngine beans */
+    WEB_SEARCH_ENGINE("dev.langchain4j.web.search.WebSearchEngine", "forage-web-search");
 
     private final String displayName;
 

--- a/library/ai/web-search/forage-web-search-google-custom/pom.xml
+++ b/library/ai/web-search/forage-web-search-google-custom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>web-search</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-web-search-google-custom</artifactId>

--- a/library/ai/web-search/forage-web-search-google-custom/pom.xml
+++ b/library/ai/web-search/forage-web-search-google-custom/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>web-search</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-web-search-google-custom</artifactId>
+    <name>Forage :: Library :: AI :: Web Search :: Google Custom Search</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-web-search-engine-google-custom</artifactId>
+            <version>${langchain4j-beta.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/web-search/forage-web-search-google-custom/src/main/java/io/kaoto/forage/websearch/google/GoogleCustomSearchConfig.java
+++ b/library/ai/web-search/forage-web-search-google-custom/src/main/java/io/kaoto/forage/websearch/google/GoogleCustomSearchConfig.java
@@ -1,0 +1,61 @@
+package io.kaoto.forage.websearch.google;
+
+import java.time.Duration;
+import io.kaoto.forage.core.util.config.AbstractConfig;
+
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.API_KEY;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.CSI;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.INCLUDE_IMAGES;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.LOG_REQUESTS;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.LOG_RESPONSES;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.MAX_RETRIES;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.SITE_RESTRICT;
+import static io.kaoto.forage.websearch.google.GoogleCustomSearchConfigEntries.TIMEOUT;
+
+public class GoogleCustomSearchConfig extends AbstractConfig {
+
+    public GoogleCustomSearchConfig() {
+        this(null);
+    }
+
+    public GoogleCustomSearchConfig(String prefix) {
+        super(prefix, GoogleCustomSearchConfigEntries.class);
+    }
+
+    @Override
+    public String name() {
+        return "forage-web-search-google-custom";
+    }
+
+    public String apiKey() {
+        return getRequired(API_KEY, "Missing Google Custom Search API key");
+    }
+
+    public String csi() {
+        return getRequired(CSI, "Missing Google Custom Search Engine ID (CSI)");
+    }
+
+    public Boolean siteRestrict() {
+        return get(SITE_RESTRICT).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public Boolean includeImages() {
+        return get(INCLUDE_IMAGES).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public Duration timeout() {
+        return get(TIMEOUT).map(Duration::parse).orElse(null);
+    }
+
+    public Integer maxRetries() {
+        return get(MAX_RETRIES).map(Integer::parseInt).orElse(null);
+    }
+
+    public Boolean logRequests() {
+        return get(LOG_REQUESTS).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public Boolean logResponses() {
+        return get(LOG_RESPONSES).map(Boolean::parseBoolean).orElse(null);
+    }
+}

--- a/library/ai/web-search/forage-web-search-google-custom/src/main/java/io/kaoto/forage/websearch/google/GoogleCustomSearchConfigEntries.java
+++ b/library/ai/web-search/forage-web-search-google-custom/src/main/java/io/kaoto/forage/websearch/google/GoogleCustomSearchConfigEntries.java
@@ -1,0 +1,93 @@
+package io.kaoto.forage.websearch.google;
+
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigTag;
+
+public final class GoogleCustomSearchConfigEntries extends ConfigEntries {
+    public static final ConfigModule API_KEY = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.api.key",
+            "Google API key for Custom Search API",
+            "API Key",
+            null,
+            "password",
+            true,
+            ConfigTag.SECURITY);
+    public static final ConfigModule CSI = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.csi",
+            "Custom Search Engine ID (Programmable Search Engine)",
+            "Custom Search ID",
+            null,
+            "string",
+            true,
+            ConfigTag.COMMON);
+    public static final ConfigModule SITE_RESTRICT = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.site.restrict",
+            "Restrict search to sites specified in the Custom Search Engine",
+            "Site Restrict",
+            null,
+            "boolean",
+            false,
+            ConfigTag.COMMON);
+    public static final ConfigModule INCLUDE_IMAGES = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.include.images",
+            "Include public images in search results",
+            "Include Images",
+            null,
+            "boolean",
+            false,
+            ConfigTag.COMMON);
+    public static final ConfigModule TIMEOUT = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.timeout",
+            "Request timeout duration (ISO-8601, e.g. PT60S)",
+            "Timeout",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule MAX_RETRIES = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.max.retries",
+            "Maximum number of retry attempts for failed requests",
+            "Max Retries",
+            null,
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule LOG_REQUESTS = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.log.requests",
+            "Enable request logging",
+            "Log Requests",
+            null,
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule LOG_RESPONSES = ConfigModule.of(
+            GoogleCustomSearchConfig.class,
+            "forage.google.custom.search.log.responses",
+            "Enable response logging",
+            "Log Responses",
+            null,
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    static {
+        initModules(
+                GoogleCustomSearchConfigEntries.class,
+                API_KEY,
+                CSI,
+                SITE_RESTRICT,
+                INCLUDE_IMAGES,
+                TIMEOUT,
+                MAX_RETRIES,
+                LOG_REQUESTS,
+                LOG_RESPONSES);
+    }
+}

--- a/library/ai/web-search/forage-web-search-google-custom/src/main/java/io/kaoto/forage/websearch/google/GoogleCustomSearchProvider.java
+++ b/library/ai/web-search/forage-web-search-google-custom/src/main/java/io/kaoto/forage/websearch/google/GoogleCustomSearchProvider.java
@@ -1,0 +1,59 @@
+package io.kaoto.forage.websearch.google;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.ai.WebSearchEngineProvider;
+import io.kaoto.forage.core.annotations.ForageBean;
+import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.google.customsearch.GoogleCustomWebSearchEngine;
+
+@ForageBean(
+        value = "google-custom-search",
+        components = {"camel-langchain4j-web-search"},
+        feature = "Web Search Engine",
+        description = "Google Custom Search engine via Programmable Search Engine")
+public class GoogleCustomSearchProvider implements WebSearchEngineProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(GoogleCustomSearchProvider.class);
+
+    @Override
+    public WebSearchEngine create(String id) {
+        GoogleCustomSearchConfig config = new GoogleCustomSearchConfig(id);
+
+        LOG.trace(
+                "Creating Google Custom Search engine with configuration: siteRestrict={}, includeImages={}, maxRetries={}, logRequests={}, logResponses={}",
+                config.siteRestrict(),
+                config.includeImages(),
+                config.maxRetries(),
+                config.logRequests(),
+                config.logResponses());
+
+        GoogleCustomWebSearchEngine.GoogleCustomWebSearchEngineBuilder builder =
+                GoogleCustomWebSearchEngine.builder().apiKey(config.apiKey()).csi(config.csi());
+
+        if (config.siteRestrict() != null) {
+            builder.siteRestrict(config.siteRestrict());
+        }
+
+        if (config.includeImages() != null) {
+            builder.includeImages(config.includeImages());
+        }
+
+        if (config.timeout() != null) {
+            builder.timeout(config.timeout());
+        }
+
+        if (config.maxRetries() != null) {
+            builder.maxRetries(config.maxRetries());
+        }
+
+        if (config.logRequests() != null) {
+            builder.logRequests(config.logRequests());
+        }
+
+        if (config.logResponses() != null) {
+            builder.logResponses(config.logResponses());
+        }
+
+        return builder.build();
+    }
+}

--- a/library/ai/web-search/forage-web-search-google-custom/src/main/resources/META-INF/services/io.kaoto.forage.core.ai.WebSearchEngineProvider
+++ b/library/ai/web-search/forage-web-search-google-custom/src/main/resources/META-INF/services/io.kaoto.forage.core.ai.WebSearchEngineProvider
@@ -1,0 +1,1 @@
+io.kaoto.forage.websearch.google.GoogleCustomSearchProvider

--- a/library/ai/web-search/forage-web-search-tavily/pom.xml
+++ b/library/ai/web-search/forage-web-search-tavily/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>web-search</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-web-search-tavily</artifactId>
+    <name>Forage :: Library :: AI :: Web Search :: Tavily</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-web-search-engine-tavily</artifactId>
+            <version>${langchain4j-beta.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/web-search/forage-web-search-tavily/pom.xml
+++ b/library/ai/web-search/forage-web-search-tavily/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>web-search</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-web-search-tavily</artifactId>

--- a/library/ai/web-search/forage-web-search-tavily/src/main/java/io/kaoto/forage/websearch/tavily/TavilyConfig.java
+++ b/library/ai/web-search/forage-web-search-tavily/src/main/java/io/kaoto/forage/websearch/tavily/TavilyConfig.java
@@ -1,0 +1,69 @@
+package io.kaoto.forage.websearch.tavily;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import io.kaoto.forage.core.util.config.AbstractConfig;
+
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.API_KEY;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.BASE_URL;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.EXCLUDE_DOMAINS;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.INCLUDE_ANSWER;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.INCLUDE_DOMAINS;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.INCLUDE_RAW_CONTENT;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.SEARCH_DEPTH;
+import static io.kaoto.forage.websearch.tavily.TavilyConfigEntries.TIMEOUT;
+
+public class TavilyConfig extends AbstractConfig {
+
+    public TavilyConfig() {
+        this(null);
+    }
+
+    public TavilyConfig(String prefix) {
+        super(prefix, TavilyConfigEntries.class);
+    }
+
+    @Override
+    public String name() {
+        return "forage-web-search-tavily";
+    }
+
+    public String apiKey() {
+        return getRequired(API_KEY, "Missing Tavily API key");
+    }
+
+    public String baseUrl() {
+        return get(BASE_URL).orElse(BASE_URL.defaultValue());
+    }
+
+    public Duration timeout() {
+        return get(TIMEOUT).map(Duration::parse).orElse(null);
+    }
+
+    public String searchDepth() {
+        return get(SEARCH_DEPTH).orElse(null);
+    }
+
+    public Boolean includeAnswer() {
+        return get(INCLUDE_ANSWER).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public Boolean includeRawContent() {
+        return get(INCLUDE_RAW_CONTENT).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public List<String> includeDomains() {
+        return get(INCLUDE_DOMAINS)
+                .map(s -> Arrays.asList(s.split(",")))
+                .map(list -> list.stream().map(String::trim).toList())
+                .orElse(null);
+    }
+
+    public List<String> excludeDomains() {
+        return get(EXCLUDE_DOMAINS)
+                .map(s -> Arrays.asList(s.split(",")))
+                .map(list -> list.stream().map(String::trim).toList())
+                .orElse(null);
+    }
+}

--- a/library/ai/web-search/forage-web-search-tavily/src/main/java/io/kaoto/forage/websearch/tavily/TavilyConfigEntries.java
+++ b/library/ai/web-search/forage-web-search-tavily/src/main/java/io/kaoto/forage/websearch/tavily/TavilyConfigEntries.java
@@ -1,0 +1,93 @@
+package io.kaoto.forage.websearch.tavily;
+
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigTag;
+
+public final class TavilyConfigEntries extends ConfigEntries {
+    public static final ConfigModule API_KEY = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.api.key",
+            "Tavily API key for authentication",
+            "API Key",
+            null,
+            "password",
+            true,
+            ConfigTag.SECURITY);
+    public static final ConfigModule BASE_URL = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.base.url",
+            "Custom base URL for Tavily API",
+            "Base URL",
+            "https://api.tavily.com/",
+            "string",
+            false,
+            ConfigTag.COMMON);
+    public static final ConfigModule TIMEOUT = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.timeout",
+            "Request timeout duration (ISO-8601, e.g. PT10S)",
+            "Timeout",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule SEARCH_DEPTH = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.search.depth",
+            "Search depth (basic or advanced)",
+            "Search Depth",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+    public static final ConfigModule INCLUDE_ANSWER = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.include.answer",
+            "Include a generated answer in search results",
+            "Include Answer",
+            null,
+            "boolean",
+            false,
+            ConfigTag.COMMON);
+    public static final ConfigModule INCLUDE_RAW_CONTENT = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.include.raw.content",
+            "Include raw HTML content in search results",
+            "Include Raw Content",
+            null,
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule INCLUDE_DOMAINS = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.include.domains",
+            "Comma-separated list of domains to include in search",
+            "Include Domains",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule EXCLUDE_DOMAINS = ConfigModule.of(
+            TavilyConfig.class,
+            "forage.tavily.exclude.domains",
+            "Comma-separated list of domains to exclude from search",
+            "Exclude Domains",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+
+    static {
+        initModules(
+                TavilyConfigEntries.class,
+                API_KEY,
+                BASE_URL,
+                TIMEOUT,
+                SEARCH_DEPTH,
+                INCLUDE_ANSWER,
+                INCLUDE_RAW_CONTENT,
+                INCLUDE_DOMAINS,
+                EXCLUDE_DOMAINS);
+    }
+}

--- a/library/ai/web-search/forage-web-search-tavily/src/main/java/io/kaoto/forage/websearch/tavily/TavilyProvider.java
+++ b/library/ai/web-search/forage-web-search-tavily/src/main/java/io/kaoto/forage/websearch/tavily/TavilyProvider.java
@@ -1,0 +1,62 @@
+package io.kaoto.forage.websearch.tavily;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.ai.WebSearchEngineProvider;
+import io.kaoto.forage.core.annotations.ForageBean;
+import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.tavily.TavilyWebSearchEngine;
+
+@ForageBean(
+        value = "tavily",
+        components = {"camel-langchain4j-web-search"},
+        feature = "Web Search Engine",
+        description = "Tavily AI-powered web search engine")
+public class TavilyProvider implements WebSearchEngineProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(TavilyProvider.class);
+
+    @Override
+    public WebSearchEngine create(String id) {
+        TavilyConfig config = new TavilyConfig(id);
+
+        LOG.trace(
+                "Creating Tavily web search engine with configuration: baseUrl={}, searchDepth={}, includeAnswer={}, includeRawContent={}",
+                config.baseUrl(),
+                config.searchDepth(),
+                config.includeAnswer(),
+                config.includeRawContent());
+
+        TavilyWebSearchEngine.TavilyWebSearchEngineBuilder builder =
+                TavilyWebSearchEngine.builder().apiKey(config.apiKey());
+
+        if (config.baseUrl() != null) {
+            builder.baseUrl(config.baseUrl());
+        }
+
+        if (config.timeout() != null) {
+            builder.timeout(config.timeout());
+        }
+
+        if (config.searchDepth() != null) {
+            builder.searchDepth(config.searchDepth());
+        }
+
+        if (config.includeAnswer() != null) {
+            builder.includeAnswer(config.includeAnswer());
+        }
+
+        if (config.includeRawContent() != null) {
+            builder.includeRawContent(config.includeRawContent());
+        }
+
+        if (config.includeDomains() != null) {
+            builder.includeDomains(config.includeDomains());
+        }
+
+        if (config.excludeDomains() != null) {
+            builder.excludeDomains(config.excludeDomains());
+        }
+
+        return builder.build();
+    }
+}

--- a/library/ai/web-search/forage-web-search-tavily/src/main/resources/META-INF/services/io.kaoto.forage.core.ai.WebSearchEngineProvider
+++ b/library/ai/web-search/forage-web-search-tavily/src/main/resources/META-INF/services/io.kaoto.forage.core.ai.WebSearchEngineProvider
@@ -1,0 +1,1 @@
+io.kaoto.forage.websearch.tavily.TavilyProvider

--- a/library/ai/web-search/forage-web-search/pom.xml
+++ b/library/ai/web-search/forage-web-search/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>web-search</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-web-search</artifactId>
+    <name>Forage :: Library :: AI :: Web Search :: Bean Factory</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/web-search/forage-web-search/pom.xml
+++ b/library/ai/web-search/forage-web-search/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>web-search</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-web-search</artifactId>

--- a/library/ai/web-search/forage-web-search/src/main/java/io/kaoto/forage/websearch/WebSearchBeanFactory.java
+++ b/library/ai/web-search/forage-web-search/src/main/java/io/kaoto/forage/websearch/WebSearchBeanFactory.java
@@ -1,0 +1,72 @@
+package io.kaoto.forage.websearch;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import org.apache.camel.CamelContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.ai.WebSearchEngineProvider;
+import io.kaoto.forage.core.annotations.FactoryType;
+import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.BeanFactory;
+import io.kaoto.forage.core.util.config.ConfigStore;
+import dev.langchain4j.web.search.WebSearchEngine;
+
+@ForageFactory(
+        value = "WebSearch",
+        components = {"camel-langchain4j-web-search"},
+        description = "Creates web search engine beans for LangChain4j integration",
+        type = FactoryType.WEB_SEARCH_ENGINE,
+        autowired = true)
+public class WebSearchBeanFactory implements BeanFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(WebSearchBeanFactory.class);
+    static final String DEFAULT_BEAN_NAME = "web-search-engine";
+
+    private CamelContext camelContext;
+
+    @Override
+    public void cleanup() {
+        camelContext.getRegistry().unbind(DEFAULT_BEAN_NAME);
+    }
+
+    @Override
+    public void configure() {
+        if (camelContext.getRegistry().lookupByNameAndType(DEFAULT_BEAN_NAME, WebSearchEngine.class) != null) {
+            LOG.debug("WebSearchEngine bean already registered, skipping");
+            return;
+        }
+
+        List<ServiceLoader.Provider<WebSearchEngineProvider>> providers = findProviders(WebSearchEngineProvider.class);
+        if (providers.isEmpty()) {
+            LOG.debug("No WebSearchEngineProvider found, skipping web search engine registration");
+            return;
+        }
+
+        ServiceLoader.Provider<WebSearchEngineProvider> provider = providers.get(0);
+        if (providers.size() > 1) {
+            LOG.info(
+                    "Multiple WebSearchEngineProvider implementations found, using: {}",
+                    provider.type().getName());
+        }
+
+        try {
+            WebSearchEngine engine = provider.get().create();
+            camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, engine);
+            LOG.info("Registered WebSearchEngine bean with name: {}", DEFAULT_BEAN_NAME);
+        } catch (Exception e) {
+            LOG.warn("Failed to create web search engine: {}", e.getMessage());
+            LOG.debug("Web search engine creation exception details", e);
+        }
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+        ConfigStore.getInstance().setClassLoader(camelContext.getApplicationContextClassLoader());
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+}

--- a/library/ai/web-search/forage-web-search/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
+++ b/library/ai/web-search/forage-web-search/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
@@ -1,0 +1,1 @@
+io.kaoto.forage.websearch.WebSearchBeanFactory

--- a/library/ai/web-search/pom.xml
+++ b/library/ai/web-search/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>web-search</artifactId>

--- a/library/ai/web-search/pom.xml
+++ b/library/ai/web-search/pom.xml
@@ -4,22 +4,18 @@
 
     <parent>
         <groupId>io.kaoto.forage</groupId>
-        <artifactId>library</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <artifactId>ai</artifactId>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>ai</artifactId>
+    <artifactId>web-search</artifactId>
     <packaging>pom</packaging>
-    <name>Forage :: Library :: AI</name>
+    <name>Forage :: Library :: AI :: Web Search</name>
 
     <modules>
-        <module>agents</module>
-        <module>chat-memory</module>
-        <module>guardrails</module>
-        <module>models</module>
-        <module>rag</module>
-        <module>vector-dbs</module>
-        <module>web-search</module>
+        <module>forage-web-search</module>
+        <module>forage-web-search-tavily</module>
+        <module>forage-web-search-google-custom</module>
     </modules>
 
 </project>

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
@@ -86,9 +86,7 @@ public class ForagePlugin implements Plugin {
         if (existing != null && existing.contains(SHIBBOLETH_REPO)) {
             return;
         }
-        String repos = existing == null || existing.isBlank()
-                ? SHIBBOLETH_REPO
-                : existing + "," + SHIBBOLETH_REPO;
+        String repos = existing == null || existing.isBlank() ? SHIBBOLETH_REPO : existing + "," + SHIBBOLETH_REPO;
         main.setRepositories(repos);
     }
 


### PR DESCRIPTION
## Summary

- Add `WebSearchEngineProvider` interface in `forage-core-ai` and `WEB_SEARCH_ENGINE` factory type
- Add `forage-web-search` BeanFactory module that discovers providers via ServiceLoader and binds a `WebSearchEngine` to the Camel registry
- Add `forage-web-search-tavily` provider with configurable API key, base URL, timeout, search depth, and domain filtering
- Add `forage-web-search-google-custom` provider with configurable API key, CSI, site restrict, image inclusion, retries, and logging

## Test plan

- [ ] Verify all web-search modules compile: `mvn clean compile -f library/ai/web-search`
- [ ] Verify formatting: `mvn spotless:check -f library/ai/web-search`
- [ ] Validate Tavily provider with a live API key
- [ ] Validate Google Custom Search provider with a live API key and CSI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced web search engine integration framework supporting multiple providers. Google Custom Search and Tavily search engines are now available with comprehensive configuration options including API credentials, request timeouts, maximum retries, domain filtering, image search settings, search depth configuration, content preferences, and diagnostic logging capabilities.

* **Chores**
  * Code maintainability improvements in repository configuration handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->