### PR TITLE
Add Spring RabbitMQ bean factory using CachingConnectionFactory

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
@@ -19,7 +19,11 @@ public enum FactoryType {
     CXF_ENDPOINT("org.apache.camel.component.cxf.jaxws.CxfEndpoint", "forage-cxf-common"),
 
     /** Factory that creates WebSearchEngine beans */
-    WEB_SEARCH_ENGINE("dev.langchain4j.web.search.WebSearchEngine", "forage-web-search");
+    WEB_SEARCH_ENGINE("dev.langchain4j.web.search.WebSearchEngine", "forage-web-search"),
+
+    /** Factory that creates Spring RabbitMQ ConnectionFactory beans */
+    SPRING_RABBITMQ_CONNECTION_FACTORY(
+            "org.springframework.amqp.rabbit.connection.ConnectionFactory", "forage-spring-rabbitmq");
 
     private final String displayName;
 

--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -433,6 +433,14 @@
             </exclusions>
         </dependency>
 
+        <!-- Messaging Modules -->
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-spring-rabbitmq</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Cloud Modules -->
         <dependency>
             <groupId>io.kaoto.forage</groupId>

--- a/library/messaging/forage-spring-rabbitmq/pom.xml
+++ b/library/messaging/forage-spring-rabbitmq/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>messaging</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-spring-rabbitmq</artifactId>
+    <name>Forage :: Library :: Messaging :: Spring RabbitMQ</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/messaging/forage-spring-rabbitmq/pom.xml
+++ b/library/messaging/forage-spring-rabbitmq/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-spring-rabbitmq</artifactId>

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
@@ -1,0 +1,111 @@
+package io.kaoto.forage.messaging.spring.rabbitmq;
+
+import java.util.Set;
+import org.apache.camel.CamelContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import io.kaoto.forage.core.annotations.FactoryType;
+import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.BeanFactory;
+import io.kaoto.forage.core.util.config.ConfigHelper;
+import io.kaoto.forage.core.util.config.ConfigStore;
+
+@ForageFactory(
+        value = "Spring RabbitMQ Connection",
+        components = {"camel-spring-rabbitmq"},
+        description = "Creates Spring RabbitMQ CachingConnectionFactory beans for AMQP messaging",
+        type = FactoryType.SPRING_RABBITMQ_CONNECTION_FACTORY,
+        autowired = true,
+        configClass = SpringRabbitMQConfig.class)
+public class SpringRabbitMQBeanFactory implements BeanFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(SpringRabbitMQBeanFactory.class);
+
+    private CamelContext camelContext;
+    private static final String DEFAULT_BEAN_NAME = "rabbitConnectionFactory";
+
+    @Override
+    public void cleanup() {
+        SpringRabbitMQConfig config = new SpringRabbitMQConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("spring.rabbitmq"));
+
+        for (String name : prefixes) {
+            camelContext.getRegistry().unbind(name);
+        }
+        camelContext.getRegistry().unbind(DEFAULT_BEAN_NAME);
+    }
+
+    @Override
+    public void configure() {
+        SpringRabbitMQConfig config = new SpringRabbitMQConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("spring.rabbitmq"));
+
+        if (!prefixes.isEmpty()) {
+            for (String name : prefixes) {
+                if (camelContext
+                                .getRegistry()
+                                .lookupByNameAndType(
+                                        name, org.springframework.amqp.rabbit.connection.ConnectionFactory.class)
+                        == null) {
+                    SpringRabbitMQConfig namedConfig = new SpringRabbitMQConfig(name);
+                    CachingConnectionFactory connectionFactory = createConnectionFactory(namedConfig);
+                    camelContext.getRegistry().bind(name, connectionFactory);
+                }
+            }
+        } else {
+            if (camelContext
+                            .getRegistry()
+                            .lookupByNameAndType(
+                                    DEFAULT_BEAN_NAME,
+                                    org.springframework.amqp.rabbit.connection.ConnectionFactory.class)
+                    == null) {
+                CachingConnectionFactory connectionFactory = createConnectionFactory(config);
+                camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, connectionFactory);
+            }
+        }
+    }
+
+    private CachingConnectionFactory createConnectionFactory(SpringRabbitMQConfig config) {
+        LOG.info(
+                "Creating CachingConnectionFactory - Host: {}, Port: {}, Username: {}, VirtualHost: {}, "
+                        + "ChannelCacheSize: {}, CacheMode: {}",
+                config.host(),
+                config.port(),
+                config.username(),
+                config.virtualHost(),
+                config.channelCacheSize(),
+                config.cacheMode());
+
+        com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = new com.rabbitmq.client.ConnectionFactory();
+        rabbitConnectionFactory.setHost(config.host());
+        rabbitConnectionFactory.setPort(config.port());
+        rabbitConnectionFactory.setUsername(config.username());
+        rabbitConnectionFactory.setPassword(config.password());
+        rabbitConnectionFactory.setVirtualHost(config.virtualHost());
+
+        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(rabbitConnectionFactory);
+        cachingConnectionFactory.setChannelCacheSize(config.channelCacheSize());
+        cachingConnectionFactory.setConnectionCacheSize(config.connectionCacheSize());
+
+        if ("CONNECTION".equalsIgnoreCase(config.cacheMode())) {
+            cachingConnectionFactory.setCacheMode(CachingConnectionFactory.CacheMode.CONNECTION);
+        } else {
+            cachingConnectionFactory.setCacheMode(CachingConnectionFactory.CacheMode.CHANNEL);
+        }
+
+        LOG.info("CachingConnectionFactory created successfully");
+        return cachingConnectionFactory;
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+}

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
@@ -49,20 +49,28 @@ public class SpringRabbitMQBeanFactory implements BeanFactory {
                                 .lookupByNameAndType(
                                         name, org.springframework.amqp.rabbit.connection.ConnectionFactory.class)
                         == null) {
-                    SpringRabbitMQConfig namedConfig = new SpringRabbitMQConfig(name);
-                    CachingConnectionFactory connectionFactory = createConnectionFactory(namedConfig);
-                    camelContext.getRegistry().bind(name, connectionFactory);
+                    try {
+                        SpringRabbitMQConfig namedConfig = new SpringRabbitMQConfig(name);
+                        CachingConnectionFactory connectionFactory = createConnectionFactory(namedConfig);
+                        camelContext.getRegistry().bind(name, connectionFactory);
+                    } catch (Exception e) {
+                        LOG.error("Failed to create RabbitMQ connection factory for: {}", name, e);
+                    }
                 }
             }
         } else {
-            if (camelContext
-                            .getRegistry()
-                            .lookupByNameAndType(
-                                    DEFAULT_BEAN_NAME,
-                                    org.springframework.amqp.rabbit.connection.ConnectionFactory.class)
-                    == null) {
-                CachingConnectionFactory connectionFactory = createConnectionFactory(config);
-                camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, connectionFactory);
+            try {
+                if (camelContext
+                                .getRegistry()
+                                .lookupByNameAndType(
+                                        DEFAULT_BEAN_NAME,
+                                        org.springframework.amqp.rabbit.connection.ConnectionFactory.class)
+                        == null) {
+                    CachingConnectionFactory connectionFactory = createConnectionFactory(config);
+                    camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, connectionFactory);
+                }
+            } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
             }
         }
     }

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
@@ -92,10 +92,19 @@ public class SpringRabbitMQBeanFactory implements BeanFactory {
         rabbitConnectionFactory.setUsername(config.username());
         rabbitConnectionFactory.setPassword(config.password());
         rabbitConnectionFactory.setVirtualHost(config.virtualHost());
+        rabbitConnectionFactory.setRequestedHeartbeat(config.requestedHeartbeat());
+        rabbitConnectionFactory.setConnectionTimeout(config.connectionTimeout());
+        rabbitConnectionFactory.setAutomaticRecoveryEnabled(config.automaticRecoveryEnabled());
+        rabbitConnectionFactory.setNetworkRecoveryInterval(config.networkRecoveryInterval());
 
         CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(rabbitConnectionFactory);
         cachingConnectionFactory.setChannelCacheSize(config.channelCacheSize());
         cachingConnectionFactory.setConnectionCacheSize(config.connectionCacheSize());
+        cachingConnectionFactory.setChannelCheckoutTimeout(config.channelCheckoutTimeout());
+
+        if (config.addresses() != null) {
+            cachingConnectionFactory.setAddresses(config.addresses());
+        }
 
         if ("CONNECTION".equalsIgnoreCase(config.cacheMode())) {
             cachingConnectionFactory.setCacheMode(CachingConnectionFactory.CacheMode.CONNECTION);

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfig.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfig.java
@@ -2,12 +2,18 @@ package io.kaoto.forage.messaging.spring.rabbitmq;
 
 import io.kaoto.forage.core.util.config.AbstractConfig;
 
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.ADDRESSES;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.AUTOMATIC_RECOVERY_ENABLED;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CACHE_MODE;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CHANNEL_CACHE_SIZE;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CHANNEL_CHECKOUT_TIMEOUT;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CONNECTION_CACHE_SIZE;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CONNECTION_TIMEOUT;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.HOST;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.NETWORK_RECOVERY_INTERVAL;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.PASSWORD;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.PORT;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.REQUESTED_HEARTBEAT;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.USERNAME;
 import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.VIRTUAL_HOST;
 
@@ -60,5 +66,39 @@ public class SpringRabbitMQConfig extends AbstractConfig {
         return get(CONNECTION_CACHE_SIZE)
                 .map(Integer::parseInt)
                 .orElse(Integer.parseInt(CONNECTION_CACHE_SIZE.defaultValue()));
+    }
+
+    public long channelCheckoutTimeout() {
+        return get(CHANNEL_CHECKOUT_TIMEOUT)
+                .map(Long::parseLong)
+                .orElse(Long.parseLong(CHANNEL_CHECKOUT_TIMEOUT.defaultValue()));
+    }
+
+    public int requestedHeartbeat() {
+        return get(REQUESTED_HEARTBEAT)
+                .map(Integer::parseInt)
+                .orElse(Integer.parseInt(REQUESTED_HEARTBEAT.defaultValue()));
+    }
+
+    public int connectionTimeout() {
+        return get(CONNECTION_TIMEOUT)
+                .map(Integer::parseInt)
+                .orElse(Integer.parseInt(CONNECTION_TIMEOUT.defaultValue()));
+    }
+
+    public String addresses() {
+        return get(ADDRESSES).orElse(null);
+    }
+
+    public boolean automaticRecoveryEnabled() {
+        return get(AUTOMATIC_RECOVERY_ENABLED)
+                .map(Boolean::parseBoolean)
+                .orElse(Boolean.parseBoolean(AUTOMATIC_RECOVERY_ENABLED.defaultValue()));
+    }
+
+    public long networkRecoveryInterval() {
+        return get(NETWORK_RECOVERY_INTERVAL)
+                .map(Long::parseLong)
+                .orElse(Long.parseLong(NETWORK_RECOVERY_INTERVAL.defaultValue()));
     }
 }

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfig.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfig.java
@@ -1,0 +1,64 @@
+package io.kaoto.forage.messaging.spring.rabbitmq;
+
+import io.kaoto.forage.core.util.config.AbstractConfig;
+
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CACHE_MODE;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CHANNEL_CACHE_SIZE;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.CONNECTION_CACHE_SIZE;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.HOST;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.PASSWORD;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.PORT;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.USERNAME;
+import static io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQConfigEntries.VIRTUAL_HOST;
+
+public class SpringRabbitMQConfig extends AbstractConfig {
+
+    public SpringRabbitMQConfig() {
+        this(null);
+    }
+
+    public SpringRabbitMQConfig(String prefix) {
+        super(prefix, SpringRabbitMQConfigEntries.class);
+    }
+
+    @Override
+    public String name() {
+        return "forage-spring-rabbitmq";
+    }
+
+    public String host() {
+        return get(HOST).orElse(HOST.defaultValue());
+    }
+
+    public int port() {
+        return get(PORT).map(Integer::parseInt).orElse(Integer.parseInt(PORT.defaultValue()));
+    }
+
+    public String username() {
+        return get(USERNAME).orElse(USERNAME.defaultValue());
+    }
+
+    public String password() {
+        return get(PASSWORD).orElse(PASSWORD.defaultValue());
+    }
+
+    public String virtualHost() {
+        return get(VIRTUAL_HOST).orElse(VIRTUAL_HOST.defaultValue());
+    }
+
+    public int channelCacheSize() {
+        return get(CHANNEL_CACHE_SIZE)
+                .map(Integer::parseInt)
+                .orElse(Integer.parseInt(CHANNEL_CACHE_SIZE.defaultValue()));
+    }
+
+    public String cacheMode() {
+        return get(CACHE_MODE).orElse(CACHE_MODE.defaultValue());
+    }
+
+    public int connectionCacheSize() {
+        return get(CONNECTION_CACHE_SIZE)
+                .map(Integer::parseInt)
+                .orElse(Integer.parseInt(CONNECTION_CACHE_SIZE.defaultValue()));
+    }
+}

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfigEntries.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfigEntries.java
@@ -86,6 +86,66 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
             false,
             ConfigTag.ADVANCED);
 
+    public static final ConfigModule CHANNEL_CHECKOUT_TIMEOUT = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.channel.checkout.timeout",
+            "Timeout in milliseconds when waiting for a channel from the cache",
+            "Channel Checkout Timeout",
+            "30000",
+            "long",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule REQUESTED_HEARTBEAT = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.requested.heartbeat",
+            "Heartbeat interval in seconds for detecting dead connections",
+            "Requested Heartbeat",
+            "60",
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule CONNECTION_TIMEOUT = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.connection.timeout",
+            "Connection timeout in milliseconds",
+            "Connection Timeout",
+            "30000",
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule ADDRESSES = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.addresses",
+            "Comma-separated list of host:port addresses for cluster failover",
+            "Addresses",
+            null,
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule AUTOMATIC_RECOVERY_ENABLED = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.automatic.recovery.enabled",
+            "Enable automatic connection recovery after failure",
+            "Automatic Recovery",
+            "true",
+            "boolean",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule NETWORK_RECOVERY_INTERVAL = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.network.recovery.interval",
+            "Interval in milliseconds between recovery attempts",
+            "Network Recovery Interval",
+            "5000",
+            "long",
+            false,
+            ConfigTag.ADVANCED);
+
     static {
         initModules(
                 SpringRabbitMQConfigEntries.class,
@@ -96,6 +156,12 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
                 VIRTUAL_HOST,
                 CHANNEL_CACHE_SIZE,
                 CACHE_MODE,
-                CONNECTION_CACHE_SIZE);
+                CONNECTION_CACHE_SIZE,
+                CHANNEL_CHECKOUT_TIMEOUT,
+                REQUESTED_HEARTBEAT,
+                CONNECTION_TIMEOUT,
+                ADDRESSES,
+                AUTOMATIC_RECOVERY_ENABLED,
+                NETWORK_RECOVERY_INTERVAL);
     }
 }

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfigEntries.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQConfigEntries.java
@@ -1,0 +1,101 @@
+package io.kaoto.forage.messaging.spring.rabbitmq;
+
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigTag;
+
+public final class SpringRabbitMQConfigEntries extends ConfigEntries {
+
+    public static final ConfigModule HOST = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.host",
+            "The RabbitMQ broker host",
+            "Host",
+            "localhost",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule PORT = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.port",
+            "The RabbitMQ broker port",
+            "Port",
+            "5672",
+            "integer",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule USERNAME = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.username",
+            "The RabbitMQ username",
+            "Username",
+            "guest",
+            "string",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule PASSWORD = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.password",
+            "The RabbitMQ password",
+            "Password",
+            "guest",
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule VIRTUAL_HOST = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.virtual.host",
+            "The RabbitMQ virtual host",
+            "Virtual Host",
+            "/",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule CHANNEL_CACHE_SIZE = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.channel.cache.size",
+            "The number of channels to maintain in cache",
+            "Channel Cache Size",
+            "25",
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule CACHE_MODE = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.cache.mode",
+            "The cache mode (CHANNEL or CONNECTION)",
+            "Cache Mode",
+            "CHANNEL",
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule CONNECTION_CACHE_SIZE = ConfigModule.of(
+            SpringRabbitMQConfig.class,
+            "forage.spring.rabbitmq.connection.cache.size",
+            "The number of connections to cache (CONNECTION mode only)",
+            "Connection Cache Size",
+            "1",
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+
+    static {
+        initModules(
+                SpringRabbitMQConfigEntries.class,
+                HOST,
+                PORT,
+                USERNAME,
+                PASSWORD,
+                VIRTUAL_HOST,
+                CHANNEL_CACHE_SIZE,
+                CACHE_MODE,
+                CONNECTION_CACHE_SIZE);
+    }
+}

--- a/library/messaging/forage-spring-rabbitmq/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
+++ b/library/messaging/forage-spring-rabbitmq/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
@@ -1,0 +1,1 @@
+io.kaoto.forage.messaging.spring.rabbitmq.SpringRabbitMQBeanFactory

--- a/library/messaging/forage-spring-rabbitmq/src/main/resources/forage-spring-rabbitmq.properties
+++ b/library/messaging/forage-spring-rabbitmq/src/main/resources/forage-spring-rabbitmq.properties
@@ -8,3 +8,9 @@
 # forage.spring.rabbitmq.channel.cache.size=25
 # forage.spring.rabbitmq.cache.mode=CHANNEL
 # forage.spring.rabbitmq.connection.cache.size=1
+# forage.spring.rabbitmq.channel.checkout.timeout=30000
+# forage.spring.rabbitmq.requested.heartbeat=60
+# forage.spring.rabbitmq.connection.timeout=30000
+# forage.spring.rabbitmq.addresses=host1:5672,host2:5672
+# forage.spring.rabbitmq.automatic.recovery.enabled=true
+# forage.spring.rabbitmq.network.recovery.interval=5000

--- a/library/messaging/forage-spring-rabbitmq/src/main/resources/forage-spring-rabbitmq.properties
+++ b/library/messaging/forage-spring-rabbitmq/src/main/resources/forage-spring-rabbitmq.properties
@@ -1,0 +1,10 @@
+# Spring RabbitMQ CachingConnectionFactory configuration
+#
+# forage.spring.rabbitmq.host=localhost
+# forage.spring.rabbitmq.port=5672
+# forage.spring.rabbitmq.username=guest
+# forage.spring.rabbitmq.password=guest
+# forage.spring.rabbitmq.virtual.host=/
+# forage.spring.rabbitmq.channel.cache.size=25
+# forage.spring.rabbitmq.cache.mode=CHANNEL
+# forage.spring.rabbitmq.connection.cache.size=1

--- a/library/messaging/pom.xml
+++ b/library/messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>messaging</artifactId>

--- a/library/messaging/pom.xml
+++ b/library/messaging/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>library</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>messaging</artifactId>
+    <packaging>pom</packaging>
+    <name>Forage :: Library :: Messaging</name>
+
+    <modules>
+        <module>forage-spring-rabbitmq</module>
+    </modules>
+
+</project>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -19,6 +19,7 @@
         <module>cxf</module>
         <module>jdbc</module>
         <module>jms</module>
+        <module>messaging</module>
         <module>policy</module>
         <module>security</module>
         <module>vertx</module>

--- a/website/docs/modules/index.md
+++ b/website/docs/modules/index.md
@@ -14,6 +14,7 @@ Forage provides ready-to-use bean factories for a wide range of Apache Camel com
 
 - [JDBC](jdbc.md) — Datasource providers with connection pooling
 - [JMS](jms.md) — Connection factories for message brokers
+- [Spring RabbitMQ](spring-rabbitmq.md) — CachingConnectionFactory for AMQP messaging
 
 ## Integration
 

--- a/website/docs/modules/spring-rabbitmq.md
+++ b/website/docs/modules/spring-rabbitmq.md
@@ -1,0 +1,63 @@
+# Spring RabbitMQ
+
+Forage creates Spring RabbitMQ `CachingConnectionFactory` beans for AMQP messaging with the `camel-spring-rabbitmq` component.
+
+## Quick Start
+
+```properties
+forage.spring.rabbitmq.host=localhost
+forage.spring.rabbitmq.port=5672
+forage.spring.rabbitmq.username=guest
+forage.spring.rabbitmq.password=guest
+```
+
+```yaml
+- to:
+    uri: spring-rabbitmq:orders
+    parameters:
+      connectionFactory: "#rabbitConnectionFactory"
+```
+
+## Properties
+
+{{ forage_properties("Spring RabbitMQ Connection") }}
+
+## Multiple Brokers
+
+Use prefixed configuration to create multiple named connection factories:
+
+```properties
+forage.primary.spring.rabbitmq.host=broker1.example.com
+forage.primary.spring.rabbitmq.port=5672
+forage.primary.spring.rabbitmq.username=admin
+forage.primary.spring.rabbitmq.password=secret
+
+forage.backup.spring.rabbitmq.host=broker2.example.com
+forage.backup.spring.rabbitmq.port=5672
+forage.backup.spring.rabbitmq.username=admin
+forage.backup.spring.rabbitmq.password=secret
+```
+
+```yaml
+- to:
+    uri: spring-rabbitmq:orders
+    parameters:
+      connectionFactory: "#primary"
+- to:
+    uri: spring-rabbitmq:notifications
+    parameters:
+      connectionFactory: "#backup"
+```
+
+## Cache Modes
+
+The `CachingConnectionFactory` supports two cache modes:
+
+- **CHANNEL** (default) — caches channels within a single connection. Suitable for most use cases.
+- **CONNECTION** — caches connections and channels. Use when you need multiple connections to the broker.
+
+```properties
+forage.spring.rabbitmq.cache.mode=CONNECTION
+forage.spring.rabbitmq.connection.cache.size=5
+forage.spring.rabbitmq.channel.cache.size=25
+```

--- a/website/docs/modules/spring-rabbitmq.md
+++ b/website/docs/modules/spring-rabbitmq.md
@@ -49,6 +49,16 @@ forage.backup.spring.rabbitmq.password=secret
       connectionFactory: "#backup"
 ```
 
+## Cluster Failover
+
+Use the `addresses` property to connect to a RabbitMQ cluster. When set, it takes precedence for connection routing:
+
+```properties
+forage.spring.rabbitmq.addresses=broker1:5672,broker2:5672,broker3:5672
+forage.spring.rabbitmq.automatic.recovery.enabled=true
+forage.spring.rabbitmq.network.recovery.interval=5000
+```
+
 ## Cache Modes
 
 The `CachingConnectionFactory` supports two cache modes:

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
           - Chat Memory: modules/ai/chat-memory.md
       - JDBC: modules/jdbc.md
       - JMS: modules/jms.md
+      - Spring RabbitMQ: modules/spring-rabbitmq.md
       - CXF: modules/cxf.md
   - Guides:
       - guides/index.md


### PR DESCRIPTION
## Summary
- Add new `forage-spring-rabbitmq` module under `library/messaging/` providing a bean factory for Spring RabbitMQ `CachingConnectionFactory`
- Configuration supports host, port, credentials, virtual host, channel/connection cache settings
- Add `SPRING_RABBITMQ_CONNECTION_FACTORY` entry to `FactoryType` enum for catalog integration

## Test plan
- [ ] Verify `mvn -DskipTests install -f library/messaging/forage-spring-rabbitmq` builds successfully
- [ ] Verify `mvn spotless:check -f library/messaging/forage-spring-rabbitmq` passes
- [ ] Test with a Camel route using `camel-spring-rabbitmq` component against a RabbitMQ broker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spring RabbitMQ connection factory support for RabbitMQ brokers
  * Configurable connection parameters: host, port, username, password, virtual host
  * Advanced cache options to tune connection and channel pooling
  * Support for multiple simultaneous RabbitMQ connections via configurable prefixes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/345)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->