### PR TITLE
Fix CXF named endpoints missing servlet path on Spring Boot

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/RuntimeType.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/RuntimeType.java
@@ -29,6 +29,14 @@ public enum RuntimeType {
         };
     }
 
+    public String displayName() {
+        return switch (this) {
+            case springBoot -> "Spring Boot";
+            case quarkus -> "Quarkus";
+            case main -> "Camel Main";
+        };
+    }
+
     @Override
     public String toString() {
         return runtime();

--- a/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapNamedEndpointsTest.java
+++ b/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapNamedEndpointsTest.java
@@ -1,0 +1,50 @@
+package io.kaoto.forage.cxf;
+
+import java.util.function.Consumer;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import io.kaoto.forage.integration.tests.ForageIntegrationTest;
+import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
+import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests CXF SOAP server with named endpoints (helloServer + helloClient) instead of the
+ * default unnamed cxfEndpoint bean. This validates that all named CXF beans get correct
+ * servlet path adaptation on Spring Boot and Quarkus, preventing HttpDestinationFactory
+ * errors when exporting to runtimes with embedded servlet containers.
+ */
+@CitrusSupport
+@ExtendWith(IntegrationTestSetupExtension.class)
+public class CxfSoapNamedEndpointsTest implements ForageIntegrationTest {
+
+    public static final String INTEGRATION_NAME = "cxf-soap-named-endpoints";
+
+    @Override
+    public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
+        runner.when(forageRun(INTEGRATION_NAME, "forage-cxf.properties", "cxf-soap-named-endpoints.camel.yaml")
+                .dumpIntegrationOutput(true));
+
+        return INTEGRATION_NAME;
+    }
+
+    @Test
+    @CitrusTest()
+    public void namedEndpointsServerAndClient(ForageTestCaseRunner runner) {
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .maxAttempts(8)
+                .delayBetweenAttempts(5000)
+                .waitForLogMessage("Server received SOAP request"));
+
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .maxAttempts(8)
+                .delayBetweenAttempts(5000)
+                .waitForLogMessage("Client received response"));
+    }
+}

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapNamedEndpointsTest/cxf-soap-named-endpoints.camel.yaml
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapNamedEndpointsTest/cxf-soap-named-endpoints.camel.yaml
@@ -1,0 +1,43 @@
+- route:
+    id: cxf-named-server
+    streamCache: false
+    from:
+      uri: cxf:bean:helloServer
+      steps:
+        - log:
+            message: "Server received SOAP request"
+        - setBody:
+            constant:
+              expression: >
+                <sayHelloResponse xmlns="http://example.com/hello"><greeting>Hello from named CXF server</greeting></sayHelloResponse>
+        - log:
+            message: "Server sending SOAP response"
+- route:
+    id: cxf-named-caller
+    from:
+      uri: timer
+      parameters:
+        timerName: soap-caller
+        repeatCount: 1
+        delay: 5000
+      steps:
+        - setBody:
+            constant:
+              expression: >
+                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soap:Body>
+                    <sayHello xmlns="http://example.com/hello"><name>Forage</name></sayHello>
+                  </soap:Body>
+                </soap:Envelope>
+        - setHeader:
+            name: CamelHttpMethod
+            constant:
+              expression: POST
+        - setHeader:
+            name: Content-Type
+            constant:
+              expression: text/xml
+        - to:
+            uri: "http://localhost:8080/services/hello"
+        - log:
+            message: "Client received response: ${body}"

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapNamedEndpointsTest/forage-cxf.properties
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapNamedEndpointsTest/forage-cxf.properties
@@ -1,0 +1,8 @@
+# Server endpoint (named bean)
+forage.helloServer.cxf.address=http://localhost:8080/services/hello
+forage.helloServer.cxf.data.format=PAYLOAD
+
+# Client endpoint (named bean) — not used for calling; the test caller
+# uses raw HTTP so we only need the server endpoint to start successfully.
+forage.helloClient.cxf.address=http://localhost:8080/services/hello
+forage.helloClient.cxf.data.format=PAYLOAD

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageSpringBootModuleAdapter.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageSpringBootModuleAdapter.java
@@ -3,6 +3,7 @@ package io.kaoto.forage.springboot.common;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -38,10 +39,21 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
 
     private final ForageModuleDescriptor<C, P> descriptor;
     private final Environment environment;
+    private UnaryOperator<Object> beanCustomizer;
 
     public ForageSpringBootModuleAdapter(ForageModuleDescriptor<C, P> descriptor, Environment environment) {
         this.descriptor = descriptor;
         this.environment = environment;
+    }
+
+    /**
+     * Sets an optional customizer applied to every primary bean after creation.
+     * Use this to apply runtime-specific configuration that the generic provider
+     * cannot set (e.g., servlet container paths for CXF endpoints).
+     */
+    public ForageSpringBootModuleAdapter<C, P> withBeanCustomizer(UnaryOperator<Object> customizer) {
+        this.beanCustomizer = customizer;
+        return this;
     }
 
     @Override
@@ -191,6 +203,10 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
                     "No " + descriptor.modulePrefix() + " provider found for class: " + providerClassName);
         }
 
-        return provider.get().create(name);
+        Object bean = provider.get().create(name);
+        if (beanCustomizer != null) {
+            bean = beanCustomizer.apply(bean);
+        }
+        return bean;
     }
 }

--- a/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfRecorder.java
+++ b/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfRecorder.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
+import io.kaoto.forage.core.common.RuntimeType;
 import io.kaoto.forage.core.common.ServiceLoaderHelper;
 import io.kaoto.forage.core.cxf.CxfEndpointProvider;
 import io.kaoto.forage.core.util.config.ConfigStore;
@@ -41,7 +42,7 @@ public class ForageCxfRecorder {
             String cxfServletPath = ConfigProvider.getConfig()
                     .getOptionalValue("quarkus.cxf.path", String.class)
                     .orElse(DEFAULT_CXF_SERVLET_PATH);
-            forageCxfEndpoint.setQuarkusCxfServletPath(cxfServletPath);
+            forageCxfEndpoint.setServletContainerCxfPath(cxfServletPath, RuntimeType.quarkus);
         }
         if (endpoint != null) {
             return new RuntimeValue<>(endpoint);

--- a/library/cxf/forage-cxf-soap/src/main/java/io/kaoto/forage/cxf/soap/ForageCxfEndpoint.java
+++ b/library/cxf/forage-cxf-soap/src/main/java/io/kaoto/forage/cxf/soap/ForageCxfEndpoint.java
@@ -15,6 +15,7 @@ import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.transport.http.HTTPConduitConfigurer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.common.RuntimeType;
 
 public class ForageCxfEndpoint extends CxfEndpoint {
 
@@ -23,16 +24,11 @@ public class ForageCxfEndpoint extends CxfEndpoint {
     private String sslContextParametersBeanName;
     private final AtomicBoolean sslConfigured = new AtomicBoolean(false);
     private String cxfServletPath;
-    private String runtimeName;
+    private RuntimeType runtimeType;
 
-    public void setQuarkusCxfServletPath(String path) {
+    public void setServletContainerCxfPath(String path, RuntimeType runtimeType) {
         this.cxfServletPath = path;
-        this.runtimeName = "Quarkus";
-    }
-
-    public void setSpringBootCxfServletPath(String path) {
-        this.cxfServletPath = path;
-        this.runtimeName = "Spring Boot";
+        this.runtimeType = runtimeType;
     }
 
     public void setSslContextParametersBeanName(String beanName) {
@@ -94,7 +90,7 @@ public class ForageCxfEndpoint extends CxfEndpoint {
                 "Absolute CXF address '{}' detected on {} server endpoint; "
                         + "adapting to relative path '{}' (CXF servlet root: '{}')",
                 address,
-                runtimeName,
+                runtimeType.displayName(),
                 relativePath,
                 servletPath);
 

--- a/library/cxf/spring-boot/forage-cxf-starter/src/main/java/io/kaoto/forage/springboot/cxf/ForageCxfAutoConfiguration.java
+++ b/library/cxf/spring-boot/forage-cxf-starter/src/main/java/io/kaoto/forage/springboot/cxf/ForageCxfAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.core.env.Environment;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.RuntimeType;
 import io.kaoto.forage.core.cxf.CxfEndpointProvider;
 import io.kaoto.forage.cxf.common.CxfCommonExportHelper;
 import io.kaoto.forage.cxf.common.CxfConfig;
@@ -32,10 +33,18 @@ public class ForageCxfAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(ForageCxfAutoConfiguration.class);
 
+    private static final String DEFAULT_CXF_SERVLET_PATH = "/services";
+
     @Bean
     static ForageSpringBootModuleAdapter<CxfConfig, CxfEndpointProvider> forageCxfModuleAdapter(
             Environment environment) {
-        return new ForageSpringBootModuleAdapter<>(new CxfModuleDescriptor(), environment);
+        String cxfPath = environment.getProperty("cxf.path", DEFAULT_CXF_SERVLET_PATH);
+        return new ForageSpringBootModuleAdapter<>(new CxfModuleDescriptor(), environment).withBeanCustomizer(bean -> {
+            if (bean instanceof ForageCxfEndpoint endpoint) {
+                endpoint.setServletContainerCxfPath(cxfPath, RuntimeType.springBoot);
+            }
+            return bean;
+        });
     }
 
     @Bean("cxfEndpoint")
@@ -46,7 +55,7 @@ public class ForageCxfAutoConfiguration {
         String kind = config.cxfKind();
         String providerClassName = CxfCommonExportHelper.transformCxfKindIntoProviderClass(kind);
 
-        String cxfServletPath = environment.getProperty("cxf.path", "/services");
+        String cxfPath = environment.getProperty("cxf.path", DEFAULT_CXF_SERVLET_PATH);
 
         List<ServiceLoader.Provider<CxfEndpointProvider>> providers =
                 ServiceLoader.load(CxfEndpointProvider.class).stream().toList();
@@ -56,7 +65,7 @@ public class ForageCxfAutoConfiguration {
                 log.info("Creating default CXF endpoint using provider: {}", providerClassName);
                 Object endpoint = provider.get().create(null);
                 if (endpoint instanceof ForageCxfEndpoint forageCxfEndpoint) {
-                    forageCxfEndpoint.setSpringBootCxfServletPath(cxfServletPath);
+                    forageCxfEndpoint.setServletContainerCxfPath(cxfPath, RuntimeType.springBoot);
                 }
                 log.info("Registered default CXF endpoint bean");
                 return endpoint;


### PR DESCRIPTION
## Summary

- Named CXF beans (e.g., `helloServer`, `helloClient`) created via `ForageSpringBootModuleAdapter` were not getting the servlet container path set, causing `HttpDestinationFactory` errors on Spring Boot exports
- Add `withBeanCustomizer()` to `ForageSpringBootModuleAdapter` so the CXF auto-configuration can set the servlet path at creation time for all beans — not just the default `@Bean` method
- Unify `setQuarkusCxfServletPath` and `setSpringBootCxfServletPath` into a single `setServletContainerCxfPath(String, RuntimeType)` method
- Add `RuntimeType.displayName()` for human-readable log messages
- Add integration test covering the named endpoints scenario (server + client with contract-first WSDL)

## Test plan

- [x] CXF integration tests pass (PlainSuite: 3/3 passed)
- [x] forage-examples CXF export tests pass (all 24 export tests green, including the previously failing `cxf/soap-server` Spring Boot export)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CXF SOAP named endpoints support enabling client-server communication.
  * Added human-friendly display names for runtime types.
  * Enhanced Spring Boot module adapter with bean customization capabilities.

* **Tests**
  * Added integration test for CXF SOAP named endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/355)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->