### PR TITLE
fix #364: Runtime filtering for integration test suites

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -67,12 +67,39 @@ Every test is executed trice times (for each different runtime).
 You do not need to take care of runtimes when writing an integration tests.
 (Implementation, taking care of runtimes, is located in `io.kaoto.forage.integration.tests.ForageTestCaseRunner`).
 
-When you run the integration test via IDE or via cmd, the test runs `<plain Camel>` runtime.
-To select runtime, export `INTEGRATION_TEST_RUNTIME` property as an environmental property.
+When you run the integration test via IDE or via cmd, all three runtimes are tested by default.
+To select a specific runtime, export `INTEGRATION_TEST_RUNTIME` environment variable.
 
-Example:
+**Supported INTEGRATION_TEST_RUNTIME values:**
+- `main` - Plain Camel Main runtime (alias: `camel-main`)
+- `quarkus` - Quarkus runtime
+- `spring-boot` - Spring Boot runtime
+
+**Note:** If `INTEGRATION_TEST_RUNTIME` is not set, all three runtimes will be tested (default behavior).
+
+**Examples:**
+
+Run tests with only Quarkus runtime:
 ```bash
 export INTEGRATION_TEST_RUNTIME=quarkus
+mvn clean verify -f integration-tests/jdbc -Dit.test=JdbcTest
+```
+
+Run tests with only Spring Boot runtime:
+```bash
+export INTEGRATION_TEST_RUNTIME=spring-boot
+mvn clean verify -f integration-tests/jdbc -Dit.test=JdbcTest
+```
+
+Run tests with only plain Camel Main runtime:
+```bash
+export INTEGRATION_TEST_RUNTIME=main
+mvn clean verify -f integration-tests/jdbc -Dit.test=JdbcTest
+```
+
+Run tests with all runtimes (default behavior):
+```bash
+unset INTEGRATION_TEST_RUNTIME
 mvn clean verify -f integration-tests/jdbc -Dit.test=JdbcTest
 ```
 

--- a/integration-tests/common/pom.xml
+++ b/integration-tests/common/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>camel-jbang-plugin-forage</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/PlainSuite.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/PlainSuite.java
@@ -2,6 +2,7 @@ package io.kaoto.forage.integration.tests.suites;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.common.RuntimeType;
 
 import org.junit.platform.suite.api.AfterSuite;
 import org.junit.platform.suite.api.BeforeSuite;
@@ -23,6 +24,6 @@ public class PlainSuite {
 
     @BeforeSuite
     public static void beforeSuite() {
-        TestSuiteHelper.beforeSuite("<plain>", LOG);
+        TestSuiteHelper.beforeSuite(RuntimeType.main, LOG);
     }
 }

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/QuarkusSuite.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/QuarkusSuite.java
@@ -2,6 +2,7 @@ package io.kaoto.forage.integration.tests.suites;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.common.RuntimeType;
 
 import org.junit.platform.suite.api.AfterSuite;
 import org.junit.platform.suite.api.BeforeSuite;
@@ -23,6 +24,6 @@ public class QuarkusSuite {
 
     @BeforeSuite
     public static void beforeSuite() {
-        TestSuiteHelper.beforeSuite("quarkus", LOG);
+        TestSuiteHelper.beforeSuite(RuntimeType.quarkus, LOG);
     }
 }

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/SpringBootSuite.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/SpringBootSuite.java
@@ -2,6 +2,7 @@ package io.kaoto.forage.integration.tests.suites;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.common.RuntimeType;
 
 import org.junit.platform.suite.api.AfterSuite;
 import org.junit.platform.suite.api.BeforeSuite;
@@ -23,6 +24,6 @@ public class SpringBootSuite {
 
     @BeforeSuite
     public static void beforeSuite() {
-        TestSuiteHelper.beforeSuite("spring-boot", LOG);
+        TestSuiteHelper.beforeSuite(RuntimeType.springBoot, LOG);
     }
 }

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/TestSuiteHelper.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/suites/TestSuiteHelper.java
@@ -1,6 +1,7 @@
 package io.kaoto.forage.integration.tests.suites;
 
 import org.slf4j.Logger;
+import io.kaoto.forage.core.common.RuntimeType;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
 import io.kaoto.forage.plugin.ExportHelper;
 
@@ -14,9 +15,9 @@ class TestSuiteHelper {
         System.clearProperty("citrus.camel.jbang.version");
     }
 
-    public static void beforeSuite(String runtimeValue, Logger log) {
-        if (!runtimeValue.startsWith("<")) {
-            System.setProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY, runtimeValue);
+    public static void beforeSuite(RuntimeType runtime, Logger log) {
+        if (runtime != RuntimeType.main) {
+            System.setProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY, runtime.runtime());
         } else {
             System.clearProperty(IntegrationTestSetupExtension.RUNTIME_PROPERTY);
         }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -58,7 +58,7 @@
                         <dependency>io.kaoto.forage:integration-tests-common</dependency>
                     </dependenciesToScan>
                     <includes>
-                        <include>**/*Suite</include>
+                        <include>${suite.includes}</include>
                     </includes>
                     <systemPropertyVariables>
                         <citrus.camel.jbang.work.dir>${project.build.directory}/.run</citrus.camel.jbang.work.dir>
@@ -109,6 +109,11 @@
         </plugins>
     </build>
 
+    <properties>
+        <!-- Default: run all suites when INTEGRATION_TEST_RUNTIME is not set -->
+        <suite.includes>**/*Suite</suite.includes>
+    </properties>
+
     <profiles>
         <profile>
             <id>skip-test-container-config-generation</id>
@@ -119,6 +124,56 @@
             </activation>
             <properties>
                 <skip-test-containers-config-generation>true</skip-test-containers-config-generation>
+            </properties>
+        </profile>
+
+        <!-- Runtime filtering profiles -->
+        <profile>
+            <id>runtime-main</id>
+            <activation>
+                <property>
+                    <name>env.INTEGRATION_TEST_RUNTIME</name>
+                    <value>main</value>
+                </property>
+            </activation>
+            <properties>
+                <suite.includes>**/PlainSuite.class</suite.includes>
+            </properties>
+        </profile>
+        <profile>
+            <id>runtime-camel-main</id>
+            <activation>
+                <property>
+                    <name>env.INTEGRATION_TEST_RUNTIME</name>
+                    <value>camel-main</value>
+                </property>
+            </activation>
+            <properties>
+                <suite.includes>**/PlainSuite.class</suite.includes>
+            </properties>
+        </profile>
+        <profile>
+            <id>runtime-quarkus</id>
+            <activation>
+                <property>
+                    <name>env.INTEGRATION_TEST_RUNTIME</name>
+                    <value>quarkus</value>
+                </property>
+            </activation>
+            <properties>
+                <suite.includes>**/QuarkusSuite.class</suite.includes>
+            </properties>
+        </profile>
+        <profile>
+            <id>runtime-spring-boot</id>
+            <activation>
+                <property>
+                    <name>env.INTEGRATION_TEST_RUNTIME</name>
+                    <value>spring-boot</value>
+                </property>
+            </activation>
+            <properties>
+                <suite.includes>**/SpringBootSuite.class</suite.includes>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Adds `INTEGRATION_TEST_RUNTIME` environment variable support to run tests with a specific runtime (camel-main, quarkus, or spring-boot), reducing execution time by 3x when targeting one runtime instead of all three.

When not set, all runtimes are tested (default/backward compatible).

Fixes https://github.com/KaotoIO/forage/issues/364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration test documentation to clarify runtime selection behavior. Tests now default to exercising all three runtimes (Camel Main, Quarkus, Spring Boot), with support for targeting specific runtimes using the `INTEGRATION_TEST_RUNTIME` environment variable.

* **Tests**
  * Enhanced integration test infrastructure with configurable runtime-specific test filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->