### PR TITLE
Fix #367: Fix integration tests to use properties files instead of environment variables

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/PropertiesTemplateHelper.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/PropertiesTemplateHelper.java
@@ -1,0 +1,97 @@
+package io.kaoto.forage.integration.tests;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import org.citrusframework.spi.Resource;
+import org.citrusframework.spi.Resources;
+
+/**
+ * Helper class for creating temporary properties files from templates for integration tests.
+ * <p>
+ * Integration tests should use properties files with placeholder values replaced by testcontainer
+ * connection details, rather than using environment variables. This ensures tests validate
+ * the same configuration loading mechanism (ConfigSourceFactory) that end users experience.
+ */
+public final class PropertiesTemplateHelper {
+
+    private PropertiesTemplateHelper() {
+        // Utility class
+    }
+
+    /**
+     * Load a properties template, apply replacements, and write to a temporary file.
+     *
+     * @param templateResource the .properties.template file from test resources
+     * @param replacements map of regex patterns to replacement values (use Matcher.quoteReplacement for values)
+     * @param afterAll cleanup callback to register temp file deletion
+     * @return FileSystemResource pointing to the temp properties file
+     */
+    public static Resource createFromTemplate(
+            Resource templateResource, Map<String, String> replacements, Consumer<AutoCloseable> afterAll) {
+        try {
+            // Load template content
+            String template;
+            try (var inputStream = templateResource.getInputStream()) {
+                template = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            }
+
+            // Apply all replacements
+            String propertiesContent = template;
+            for (Map.Entry<String, String> entry : replacements.entrySet()) {
+                propertiesContent = propertiesContent.replaceAll(entry.getKey(), entry.getValue());
+            }
+
+            // Extract filename from template (remove .template suffix)
+            String templateFileName = templateResource.getFile().getName();
+            String propertiesFileName = templateFileName.replace(".template", "");
+
+            // Write to temp directory with proper name
+            Path tempDir = Files.createTempDirectory("forage-test-");
+            Path tempPropertiesFile = tempDir.resolve(propertiesFileName);
+            Files.writeString(tempPropertiesFile, propertiesContent, StandardCharsets.UTF_8);
+
+            // Register cleanup to delete temp file and directory
+            afterAll.accept(() -> {
+                try {
+                    Files.deleteIfExists(tempPropertiesFile);
+                    Files.deleteIfExists(tempDir);
+                } catch (java.nio.file.DirectoryNotEmptyException e) {
+                    // Ignore - temp directory will be cleaned up by OS
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+
+            // Return FileSystemResource
+            return Resources.create(tempPropertiesFile.toFile());
+
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to prepare properties from template: " + templateResource.getLocation(), e);
+        }
+    }
+
+    /**
+     * Convenience method for single property replacement.
+     *
+     * @param templateResource the .properties.template file from test resources
+     * @param propertyPattern regex pattern matching the property to replace
+     * @param replacementValue the replacement value (will be quoted for regex safety)
+     * @param afterAll cleanup callback
+     * @return FileSystemResource pointing to the temp properties file
+     */
+    public static Resource createFromTemplate(
+            Resource templateResource,
+            String propertyPattern,
+            String replacementValue,
+            Consumer<AutoCloseable> afterAll) {
+        return createFromTemplate(
+                templateResource, Map.of(propertyPattern, Matcher.quoteReplacement(replacementValue)), afterAll);
+    }
+}

--- a/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapTest.java
+++ b/integration-tests/cxf/src/test/java/io/kaoto/forage/cxf/CxfSoapTest.java
@@ -1,15 +1,17 @@
 package io.kaoto.forage.cxf;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.spi.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -115,13 +117,23 @@ public class CxfSoapTest implements ForageIntegrationTest {
 
         String wireMockUrl = "http://localhost:" + wireMock.port();
 
-        Map<String, String> envs = new HashMap<>();
-        envs.put("FORAGE_CXF_ADDRESS", wireMockUrl + "/ws/hello");
-        envs.put("FORAGE_CXF_WSDL_URL", wireMockUrl + "/ws/hello?wsdl");
+        // Load template properties and replace testcontainer-specific values
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-cxf.properties.template"),
+                Map.of(
+                        "forage\\.cxf\\.address=.*",
+                        Matcher.quoteReplacement("forage.cxf.address=" + wireMockUrl + "/ws/hello"),
+                        "forage\\.cxf\\.wsdl\\.url=.*",
+                        Matcher.quoteReplacement("forage.cxf.wsdl.url=" + wireMockUrl + "/ws/hello?wsdl")),
+                afterAll);
 
-        runner.when(forageRun(INTEGRATION_NAME, "forage-cxf.properties", "cxf-soap-client.camel.yaml")
-                .dumpIntegrationOutput(true)
-                .withEnvs(envs));
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("cxf-soap-client.camel.yaml"))
+                .dumpIntegrationOutput(true));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/forage-cxf.properties
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/forage-cxf.properties
@@ -1,6 +1,0 @@
-forage.cxf.address=http://localhost:8080/ws/hello
-forage.cxf.wsdl.url=http://localhost:8080/ws/hello?wsdl
-forage.cxf.service.name={http://example.com/hello}HelloService
-forage.cxf.port.name={http://example.com/hello}HelloPort
-forage.cxf.data.format=PAYLOAD
-forage.cxf.logging.enabled=true

--- a/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/forage-cxf.properties.template
+++ b/integration-tests/cxf/src/test/resources/io/kaoto/forage/cxf/CxfSoapTest/forage-cxf.properties.template
@@ -1,0 +1,6 @@
+forage.cxf.address=http://localhost:8080/ws/hello  # Overridden by test with WireMock URL
+forage.cxf.wsdl.url=http://localhost:8080/ws/hello?wsdl  # Overridden by test with WireMock URL
+forage.cxf.service.name={http://example.com/hello}HelloService
+forage.cxf.port.name={http://example.com/hello}HelloPort
+forage.cxf.data.format=PAYLOAD
+forage.cxf.logging.enabled=true

--- a/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/JdbcTest.java
+++ b/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/JdbcTest.java
@@ -6,8 +6,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import org.citrusframework.GherkinTestActionRunner;
 import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.annotations.CitrusTest;
@@ -24,6 +25,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -68,13 +70,22 @@ public class JdbcTest implements ForageIntegrationTest {
 
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
-        // running jbang forage run with required resources and required runtime
-        runner.when(forageRun(INTEGRATION_NAME, "forage-datasource-factory.properties", "jdbc-routes.camel.yaml")
+        // Load template properties and replace testcontainer-specific values
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-datasource-factory.properties.template"),
+                Map.of("forage\\.jdbc\\.url=.*", Matcher.quoteReplacement("forage.jdbc.url=" + postgres.getJdbcUrl())),
+                afterAll);
+
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("jdbc-routes.camel.yaml"))
                 .addResource(classResource("MyAggregationStrategy.java"))
                 .dumpIntegrationOutput(true)
                 // required if more test are using the same route
-                .autoRemove(false)
-                .withEnvs(Collections.singletonMap("FORAGE_JDBC_URL", postgres.getJdbcUrl())));
+                .autoRemove(false));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/MultiTest.java
+++ b/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/MultiTest.java
@@ -2,8 +2,10 @@ package io.kaoto.forage.jdbc;
 
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.spi.Resource;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -13,6 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,12 +49,25 @@ public class MultiTest implements ForageIntegrationTest {
 
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
-        runner.when(forageRun("route", "forage-datasource-factory.properties", "route.camel.yaml")
+        // Load template properties and replace testcontainer-specific values
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-datasource-factory.properties.template"),
+                Map.of(
+                        "forage\\.ds1\\.jdbc\\.url=.*",
+                        Matcher.quoteReplacement("forage.ds1.jdbc.url=" + postgres.getJdbcUrl()),
+                        "forage\\.ds2\\.jdbc\\.url=.*",
+                        Matcher.quoteReplacement("forage.ds2.jdbc.url=" + mysql.getJdbcUrl())),
+                afterAll);
+
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName("route")
+                .addResource(dynamicProperties)
+                .addResource(classResource("route.camel.yaml"))
                 // required if more test are using the same route
                 .autoRemove(false)
-                .dumpIntegrationOutput(true)
-                .withEnvs(Map.of(
-                        "FORAGE_DS1_JDBC_URL", postgres.getJdbcUrl(), "FORAGE_DS2_JDBC_URL", mysql.getJdbcUrl())));
+                .dumpIntegrationOutput(true));
 
         return "route";
     }

--- a/integration-tests/jdbc/src/test/resources/io/kaoto/forage/jdbc/JdbcTest/forage-datasource-factory.properties.template
+++ b/integration-tests/jdbc/src/test/resources/io/kaoto/forage/jdbc/JdbcTest/forage-datasource-factory.properties.template
@@ -1,7 +1,7 @@
 # PostgreSQL JDBC Configuration
 # Database connection settings
 forage.jdbc.db.kind=postgresql
-#forage.jdbc.url is configured dynamically in the test
+forage.jdbc.url=jdbc:postgresql://localhost:5432/postgresql  # Overridden by test with testcontainer URL
 forage.jdbc.username=test
 forage.jdbc.password=test
 

--- a/integration-tests/jdbc/src/test/resources/io/kaoto/forage/jdbc/MultiTest/forage-datasource-factory.properties.template
+++ b/integration-tests/jdbc/src/test/resources/io/kaoto/forage/jdbc/MultiTest/forage-datasource-factory.properties.template
@@ -1,7 +1,7 @@
 # PostgreSQL JDBC Configuration
 # Database connection settings
 forage.ds1.jdbc.db.kind=postgresql
-#ds1.forage.jdbc.url=jdbc:postgresql://localhost:5432/postgres
+forage.ds1.jdbc.url=jdbc:postgresql://localhost:5432/postgres  # Overridden by test with testcontainer URL
 forage.ds1.jdbc.username=test
 forage.ds1.jdbc.password=test
 
@@ -20,7 +20,7 @@ forage.ds1.jdbc.transaction.timeout.seconds=30
 # MySQL JDBC Configuration
 # Database connection settings
 forage.ds2.jdbc.db.kind=mysql
-#ds2.forage.jdbc.url=jdbc:mysql://localhost:3306/test
+forage.ds2.jdbc.url=jdbc:mysql://localhost:3306/test  # Overridden by test with testcontainer URL
 forage.ds2.jdbc.username=test
 forage.ds2.jdbc.password=test
 

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
@@ -1,9 +1,11 @@
 package io.kaoto.forage.jms;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.spi.Resource;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +16,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,11 +40,22 @@ public class JmsArtemisTest implements ForageIntegrationTest {
 
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
-        // running jbang forage run with required resources and required runtime
-        runner.when(forageRun(INTEGRATION_NAME, "forage-connectionfactory.properties", "route-artemis.camel.yaml")
-                .dumpIntegrationOutput(true)
-                .withEnvs(Collections.singletonMap(
-                        "FORAGE_JMS_BROKER_URL", "tcp://" + artemis.getHost() + ":" + artemis.getMappedPort(61616))));
+        // Load template properties and replace testcontainer-specific values
+        String brokerUrl = "tcp://" + artemis.getHost() + ":" + artemis.getMappedPort(61616);
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-connectionfactory.properties.template"),
+                Map.of(
+                        "forage\\.jms\\.broker\\.url=.*",
+                        Matcher.quoteReplacement("forage.jms.broker.url=" + brokerUrl)),
+                afterAll);
+
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("route-artemis.camel.yaml"))
+                .dumpIntegrationOutput(true));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
@@ -1,10 +1,11 @@
 package io.kaoto.forage.jms;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.spi.Resource;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -77,18 +79,23 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
         destinations.createQueue("DLQ");
         destinations.createQueue("DLQ2");
 
-        // running jbang forage run with required resources and required runtime
-        runner.when(forageRun(INTEGRATION_NAME, "forage-connectionfactory.properties", "route-ibm.camel.yaml")
-                .dumpIntegrationOutput(true)
-                //                .withArg("--jvm-debug", "5005")
-                .withEnvs(Collections.singletonMap(
-                        "FORAGE_JMS_BROKER_URL",
-                        "mq://%s:%d/%s/%s"
-                                .formatted(
-                                        ibmmq.getHost(),
-                                        ibmmq.getMappedPort(1414),
-                                        MESSAGING_CHANNEL,
-                                        QUEUE_MANAGER_NAME))));
+        // Load template properties and replace testcontainer-specific values
+        String brokerUrl = "mq://%s:%d/%s/%s"
+                .formatted(ibmmq.getHost(), ibmmq.getMappedPort(1414), MESSAGING_CHANNEL, QUEUE_MANAGER_NAME);
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-connectionfactory.properties.template"),
+                Map.of(
+                        "forage\\.jms\\.broker\\.url=.*",
+                        Matcher.quoteReplacement("forage.jms.broker.url=" + brokerUrl)),
+                afterAll);
+
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("route-ibm.camel.yaml"))
+                .dumpIntegrationOutput(true));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/forage-connectionfactory.properties.template
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/forage-connectionfactory.properties.template
@@ -1,8 +1,8 @@
-# IbmMQ JMS Configuration with XA Transactions
-forage.jms.kind=ibmmq
-forage.jms.broker.url=mq://localhost:1414/DEV.APP.SVRCONN/QM1
-forage.jms.username=app
-forage.jms.password=passw0rd
+# ActiveMQ Artemis JMS Configuration with XA Transactions
+forage.jms.kind=artemis
+forage.jms.broker.url=tcp://localhost:61616  # Overridden by test with testcontainer URL
+forage.jms.username=artemis
+forage.jms.password=artemis
 
 # Connection pool settings
 forage.jms.pool.enabled=true
@@ -17,3 +17,5 @@ forage.jms.transaction.enabled=true
 forage.jms.transaction.timeout.seconds=30
 forage.jms.transaction.node.id=node1
 forage.jms.transaction.enable.recovery=true
+forage.jms.transaction.object.store.directory=tx-object-store
+forage.jms.transaction.object.store.type=file-system

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/forage-connectionfactory.properties.template
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/forage-connectionfactory.properties.template
@@ -1,8 +1,8 @@
-# ActiveMQ Artemis JMS Configuration with XA Transactions
-forage.jms.kind=artemis
-forage.jms.broker.url=tcp://localhost:61616
-forage.jms.username=artemis
-forage.jms.password=artemis
+# IbmMQ JMS Configuration with XA Transactions
+forage.jms.kind=ibmmq
+forage.jms.broker.url=mq://localhost:1414/DEV.APP.SVRCONN/QM1  # Overridden by test with testcontainer URL
+forage.jms.username=app
+forage.jms.password=passw0rd
 
 # Connection pool settings
 forage.jms.pool.enabled=true
@@ -17,5 +17,3 @@ forage.jms.transaction.enabled=true
 forage.jms.transaction.timeout.seconds=30
 forage.jms.transaction.node.id=node1
 forage.jms.transaction.enable.recovery=true
-forage.jms.transaction.object.store.directory=tx-object-store
-forage.jms.transaction.object.store.type=file-system

--- a/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest.java
+++ b/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest.java
@@ -1,22 +1,18 @@
 package io.kaoto.forage.messaging.springrabbitmq;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
-import org.citrusframework.spi.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -28,6 +24,7 @@ import io.kaoto.forage.integration.tests.DisableOnQuarkus;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 import io.kaoto.forage.integration.tests.RuntimeConditionExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -74,56 +71,30 @@ public class SpringRabbitMQHealthMetricsTest implements ForageIntegrationTest {
 
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
-        try {
-            // Find an unused random port for actuator endpoints
-            actuatorPort = findAvailablePort();
-            LOG.info("Using random port {} for actuator endpoints", actuatorPort);
+        // Find an unused random port for actuator endpoints
+        actuatorPort = findAvailablePort();
+        LOG.info("Using random port {} for actuator endpoints", actuatorPort);
 
-            Resource templateProperties = classResource("forage-spring-rabbitmq.properties.template");
-            String template;
-            try (var inputStream = templateProperties.getInputStream()) {
-                template = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-            }
+        // Load template properties and replace testcontainer-specific values
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-spring-rabbitmq.properties.template"),
+                Map.of(
+                        "forage\\.spring\\.rabbitmq\\.port=.*",
+                        Matcher.quoteReplacement("forage.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672)),
+                        "server\\.port=.*",
+                        Matcher.quoteReplacement("server.port=" + actuatorPort)),
+                afterAll);
 
-            // Replace connection details with testcontainer values and set actuator port
-            String propertiesContent = template.replaceAll(
-                            "forage\\.spring\\.rabbitmq\\.port=.*",
-                            Matcher.quoteReplacement("forage.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672)))
-                    .replaceAll("server\\.port=.*", Matcher.quoteReplacement("server.port=" + actuatorPort));
-
-            // Write to temp directory with proper name so it gets discovered by config system
-            Path tempDir = Files.createTempDirectory("forage-test-");
-            Path tempPropertiesFile = tempDir.resolve("forage-spring-rabbitmq.properties");
-            Files.writeString(tempPropertiesFile, propertiesContent, StandardCharsets.UTF_8);
-
-            // Register cleanup to delete temp file and directory
-            afterAll.accept(() -> {
-                try {
-                    Files.deleteIfExists(tempPropertiesFile);
-                    Files.deleteIfExists(tempDir);
-                } catch (java.nio.file.DirectoryNotEmptyException e) {
-                    // Ignore - temp directory will be cleaned up by OS
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
-
-            Resource dynamicProperties = Resources.create(tempPropertiesFile.toFile());
-
-            // Start Spring Boot application with actuator and metrics
-            runner.when(camel().jbang()
-                    .custom("forage", "run")
-                    .processName(INTEGRATION_NAME)
-                    .addResource(dynamicProperties)
-                    .addResource(classResource("route.camel.yaml"))
-                    .withArg("--dep", "org.springframework.boot:spring-boot-starter-web")
-                    .withArg("--dep", "org.springframework.boot:spring-boot-starter-actuator")
-                    .withArg("--dep", "io.micrometer:micrometer-core")
-                    .dumpIntegrationOutput(true));
-
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to prepare forage-spring-rabbitmq.properties", e);
-        }
+        // Start Spring Boot application with actuator and metrics
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("route.camel.yaml"))
+                .withArg("--dep", "org.springframework.boot:spring-boot-starter-web")
+                .withArg("--dep", "org.springframework.boot:spring-boot-starter-actuator")
+                .withArg("--dep", "io.micrometer:micrometer-core")
+                .dumpIntegrationOutput(true));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest.java
+++ b/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest.java
@@ -1,16 +1,11 @@
 package io.kaoto.forage.messaging.springrabbitmq;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
-import org.citrusframework.spi.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -20,6 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,49 +39,21 @@ public class SpringRabbitMQNamedTest implements ForageIntegrationTest {
 
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
-        // Load template properties file and replace testcontainer-specific values
-        try {
-            Resource templateProperties = classResource("forage-spring-rabbitmq.properties.template");
-            String template;
-            try (var inputStream = templateProperties.getInputStream()) {
-                template = new String(templateProperties.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            }
+        // Load template properties and replace testcontainer-specific values
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-spring-rabbitmq.properties.template"),
+                Map.of(
+                        "forage\\.mq1\\.spring\\.rabbitmq\\.port=.*",
+                        Matcher.quoteReplacement("forage.mq1.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672))),
+                afterAll);
 
-            // Replace connection details with testcontainer values
-            String propertiesContent = template.replaceAll(
-                    "forage\\.mq1\\.spring\\.rabbitmq\\.port=.*",
-                    Matcher.quoteReplacement("forage.mq1.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672)));
-
-            // Write to temp directory with proper name so it gets discovered by config system
-            Path tempDir = Files.createTempDirectory("forage-test-");
-            Path tempPropertiesFile = tempDir.resolve("forage-spring-rabbitmq.properties");
-            Files.writeString(tempPropertiesFile, propertiesContent, StandardCharsets.UTF_8);
-
-            // Register cleanup to delete temp file and directory
-            afterAll.accept(() -> {
-                try {
-                    Files.deleteIfExists(tempPropertiesFile);
-                    Files.deleteIfExists(tempDir);
-                } catch (java.nio.file.DirectoryNotEmptyException e) {
-                    // Ignore - temp directory will be cleaned up by OS
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
-
-            Resource dynamicProperties = Resources.create(tempPropertiesFile.toFile());
-
-            // running jbang forage run with dynamically modified properties
-            runner.when(camel().jbang()
-                    .custom("forage", "run")
-                    .processName(INTEGRATION_NAME)
-                    .addResource(dynamicProperties)
-                    .addResource(classResource("route.camel.yaml"))
-                    .dumpIntegrationOutput(true));
-
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to prepare forage-spring-rabbitmq.properties", e);
-        }
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("route.camel.yaml"))
+                .dumpIntegrationOutput(true));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest.java
+++ b/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest.java
@@ -1,16 +1,11 @@
 package io.kaoto.forage.messaging.springrabbitmq;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
-import org.citrusframework.spi.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -20,6 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.kaoto.forage.integration.tests.ForageIntegrationTest;
 import io.kaoto.forage.integration.tests.ForageTestCaseRunner;
 import io.kaoto.forage.integration.tests.IntegrationTestSetupExtension;
+import io.kaoto.forage.integration.tests.PropertiesTemplateHelper;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,49 +34,21 @@ public class SpringRabbitMQTest implements ForageIntegrationTest {
 
     @Override
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
-        // Load template properties file and replace testcontainer-specific values
-        try {
-            Resource templateProperties = classResource("forage-spring-rabbitmq.properties.template");
-            String template;
-            try (var inputStream = templateProperties.getInputStream()) {
-                template = new String(templateProperties.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            }
+        // Load template properties and replace testcontainer-specific values
+        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-spring-rabbitmq.properties.template"),
+                Map.of(
+                        "forage\\.spring\\.rabbitmq\\.port=.*",
+                        Matcher.quoteReplacement("forage.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672))),
+                afterAll);
 
-            // Replace connection details with testcontainer values
-            String propertiesContent = template.replaceAll(
-                    "forage\\.spring\\.rabbitmq\\.port=.*",
-                    Matcher.quoteReplacement("forage.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672)));
-
-            // Write to temp directory with proper name so it gets discovered by config system
-            Path tempDir = Files.createTempDirectory("forage-test-");
-            Path tempPropertiesFile = tempDir.resolve("forage-spring-rabbitmq.properties");
-            Files.writeString(tempPropertiesFile, propertiesContent, StandardCharsets.UTF_8);
-
-            // Register cleanup to delete temp file and directory
-            afterAll.accept(() -> {
-                try {
-                    Files.deleteIfExists(tempPropertiesFile);
-                    Files.deleteIfExists(tempDir);
-                } catch (java.nio.file.DirectoryNotEmptyException e) {
-                    // Ignore - temp directory will be cleaned up by OS
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            });
-
-            Resource dynamicProperties = Resources.create(tempPropertiesFile.toFile());
-
-            // running jbang forage run with dynamically modified properties
-            runner.when(camel().jbang()
-                    .custom("forage", "run")
-                    .processName(INTEGRATION_NAME)
-                    .addResource(dynamicProperties)
-                    .addResource(classResource("route.camel.yaml"))
-                    .dumpIntegrationOutput(true));
-
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to prepare forage-spring-rabbitmq.properties", e);
-        }
+        // running jbang forage run with dynamically modified properties
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(INTEGRATION_NAME)
+                .addResource(dynamicProperties)
+                .addResource(classResource("route.camel.yaml"))
+                .dumpIntegrationOutput(true));
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest/forage-spring-rabbitmq.properties.template
+++ b/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest/forage-spring-rabbitmq.properties.template
@@ -1,7 +1,7 @@
 # Spring RabbitMQ CachingConnectionFactory configuration
-# Connection settings for RabbitMQ broker (overridden by test)
+# Connection settings for RabbitMQ broker
 forage.spring.rabbitmq.host=localhost
-forage.spring.rabbitmq.port=5672
+forage.spring.rabbitmq.port=5672  # Overridden by test with testcontainer port
 forage.spring.rabbitmq.username=guest
 forage.spring.rabbitmq.password=guest
 forage.spring.rabbitmq.virtual.host=/
@@ -21,5 +21,5 @@ management.health.rabbit.enabled=true
 # Enable RabbitMQ metrics
 management.metrics.enable.rabbitmq=true
 
-# Server port (will be replaced with random port by test)
-server.port=0
+# Server port
+server.port=0  # Overridden by test with random available port

--- a/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest/forage-spring-rabbitmq.properties.template
+++ b/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest/forage-spring-rabbitmq.properties.template
@@ -1,7 +1,7 @@
 # Named/prefixed Spring RabbitMQ CachingConnectionFactory configuration
 # The "mq1" prefix creates a bean named "mq1" in the Camel registry
 forage.mq1.spring.rabbitmq.host=localhost
-forage.mq1.spring.rabbitmq.port=5672
+forage.mq1.spring.rabbitmq.port=5672  # Overridden by test with testcontainer port
 forage.mq1.spring.rabbitmq.username=guest
 forage.mq1.spring.rabbitmq.password=guest
 forage.mq1.spring.rabbitmq.virtual.host=/

--- a/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest/forage-spring-rabbitmq.properties.template
+++ b/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest/forage-spring-rabbitmq.properties.template
@@ -1,7 +1,7 @@
 # Spring RabbitMQ CachingConnectionFactory configuration
-# Connection settings for RabbitMQ broker (overridden by environment variables in test)
+# Connection settings for RabbitMQ broker
 forage.spring.rabbitmq.host=localhost
-forage.spring.rabbitmq.port=5672
+forage.spring.rabbitmq.port=5672  # Overridden by test with testcontainer port
 forage.spring.rabbitmq.username=guest
 forage.spring.rabbitmq.password=guest
 forage.spring.rabbitmq.virtual.host=/


### PR DESCRIPTION
## Summary

Fixes integration tests to use properties file templates instead of environment variables for testcontainer connection details. This ensures tests validate the same `ConfigSourceFactory` mechanism that end users experience.

### Problem

Integration tests were setting testcontainer connection details via environment variables (`FORAGE_JMS_BROKER_URL`, `FORAGE_JDBC_URL`, etc.), which bypassed the actual properties file loading mechanism that real users experience. This meant tests could pass even when properties file loading was broken.

### Solution

- Created `PropertiesTemplateHelper` utility class in `integration-tests-common` to standardize the template-to-temp-file pattern
- Renamed existing `.properties` files to `.properties.template` with placeholder values
- Added inline comments documenting which properties are overridden by tests
- Updated 8 integration test classes to use the helper instead of environment variables:
  - JDBC: `JdbcTest`, `MultiTest`
  - JMS: `JmsArtemisTest`, `JmsIbmMqTest`
  - CXF: `CxfSoapTest`
  - Messaging: `SpringRabbitMQTest`, `SpringRabbitMQNamedTest`, `SpringRabbitMQHealthMetricsTest`
- Removed all `.withEnvs()` calls from test code

### Test Plan

- ✅ All integration tests compile successfully
- ✅ Code formatted with Spotless
- ✅ Self-reviewed - no issues found
- Tests will run via CI on PR

Fixes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration tests (JDBC, JMS, CXF, RabbitMQ) to use dynamic property templates for configuration instead of environment variables.

* **Refactor**
  * Added a test utility that generates temporary property files from templates with dynamic value substitution, supporting safer regex-based replacements and automatic cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->