### PR TITLE
Fix #365: Remove unnecessary ForageConnectionFactory wrapper

### DIFF
--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/ForageConnectionFactory.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/ForageConnectionFactory.java
@@ -1,5 +1,0 @@
-package io.kaoto.forage.jms.common;
-
-import jakarta.jms.ConnectionFactory;
-
-public record ForageConnectionFactory(ConnectionFactory connectionFactory) {}

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -25,7 +25,6 @@ import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.jms.common.ConnectionFactoryCommonExportHelper;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
-import io.kaoto.forage.jms.common.ForageConnectionFactory;
 
 @ForageFactory(
         value = "JMS Connection",
@@ -130,8 +129,12 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
             for (String name : prefixes) {
                 if (camelContext.getRegistry().lookupByNameAndType(name, ConnectionFactory.class) == null) {
                     ConnectionFactoryConfig cfConfig = new ConnectionFactoryConfig(name);
-                    ForageConnectionFactory forageConnectionFactory = newConnectionFactory(cfConfig, name);
-                    camelContext.getRegistry().bind(name, forageConnectionFactory.connectionFactory());
+                    ConnectionFactory connectionFactory = newConnectionFactory(cfConfig, name);
+                    if (connectionFactory != null) {
+                        camelContext.getRegistry().bind(name, connectionFactory);
+                    } else {
+                        LOG.warn("Skipping binding for '{}' because ConnectionFactory creation returned null", name);
+                    }
                 }
             }
         } else {
@@ -141,11 +144,8 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
                     final List<ServiceLoader.Provider<ConnectionFactoryProvider>> providers =
                             findProviders(ConnectionFactoryProvider.class);
                     if (providers.size() == 1) {
-                        ForageConnectionFactory forageConnectionFactory =
-                                doCreateConnectionFactory(providers.get(0), null);
-                        camelContext
-                                .getRegistry()
-                                .bind(DEFAULT_CONNECTION_FACTORY, forageConnectionFactory.connectionFactory());
+                        ConnectionFactory connectionFactory = doCreateConnectionFactory(providers.get(0), null);
+                        camelContext.getRegistry().bind(DEFAULT_CONNECTION_FACTORY, connectionFactory);
                     } else {
                         throw new IllegalArgumentException(
                                 "No ConnectionFactory implementation is present in the classpath");
@@ -157,7 +157,7 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         }
     }
 
-    private synchronized ForageConnectionFactory newConnectionFactory(
+    private synchronized ConnectionFactory newConnectionFactory(
             ConnectionFactoryConfig connectionFactoryConfig, String name) {
         final String connectionFactoryProviderClass =
                 ConnectionFactoryCommonExportHelper.transformJmsKindIntoProviderClass(
@@ -178,10 +178,10 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         return doCreateConnectionFactory(connectionFactoryProvider, name);
     }
 
-    private ForageConnectionFactory doCreateConnectionFactory(
+    private ConnectionFactory doCreateConnectionFactory(
             ServiceLoader.Provider<ConnectionFactoryProvider> provider, String name) {
         final ConnectionFactoryProvider connectionFactoryProvider = provider.get();
-        return new ForageConnectionFactory(connectionFactoryProvider.create(name));
+        return connectionFactoryProvider.create(name);
     }
 
     @Override


### PR DESCRIPTION
fixes https://github.com/KaotoIO/forage/issues/365

The ForageConnectionFactory wrapper was unnecessary. It was a simple record that wrapped ConnectionFactory, which was immediately unwrapped at every usage point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified JMS connection handling by removing an internal wrapper layer. The system now registers JMS connection factories directly, reducing unnecessary abstraction complexity while maintaining compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->