### PR TITLE
Fix #372: Add {{env:}} and {{sys:}} placeholder resolution

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/AbstractConfig.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/AbstractConfig.java
@@ -36,7 +36,7 @@ public abstract class AbstractConfig implements Config {
     @Override
     public void register(String name, String value) {
         ConfigEntries.find(ConfigEntries.getModules(entriesClass), prefix, name)
-                .ifPresent(module -> ConfigStore.getInstance().set(module, value));
+                .ifPresent(module -> ConfigStore.getInstance().set(module, PlaceholderResolver.resolve(value)));
     }
 
     protected Optional<String> get(ConfigModule module) {

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
@@ -124,7 +124,7 @@ public final class ConfigStore {
     public void load(ConfigModule module) {
         final Optional<String> read = tryRead(module);
 
-        read.ifPresent(s -> properties.put(module, s));
+        read.ifPresent(s -> properties.put(module, PlaceholderResolver.resolve(s)));
     }
 
     /**

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/PlaceholderResolver.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/PlaceholderResolver.java
@@ -1,0 +1,111 @@
+package io.kaoto.forage.core.util.config;
+
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.camel.util.IOHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves Camel-style property placeholders ({@code {{env:KEY}}} and {@code {{sys:KEY}}})
+ * in configuration values loaded from properties files.
+ *
+ * <p>Supported syntax:
+ * <ul>
+ *   <li>{@code {{env:KEY}}} — resolves to the environment variable {@code KEY}</li>
+ *   <li>{@code {{env:KEY:default}}} — resolves to {@code KEY}, or {@code default} if not set</li>
+ *   <li>{@code {{sys:KEY}}} — resolves to the system property {@code KEY}</li>
+ *   <li>{@code {{sys:KEY:default}}} — resolves to {@code KEY}, or {@code default} if not set</li>
+ * </ul>
+ *
+ * <p>Resolution is single-pass and non-recursive. Nested placeholders like
+ * {@code {{env:KEY:{{sys:FALLBACK}}}}} are not supported.
+ *
+ * <p>If a placeholder references a variable that is not set and no default is provided,
+ * the placeholder is left unchanged in the output.
+ *
+ * @since 1.4
+ */
+public final class PlaceholderResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlaceholderResolver.class);
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{(env|sys):([^}:]+)(?::([^}]*))?}}");
+    private static final String PLACEHOLDER_TOKEN = "{{";
+
+    private PlaceholderResolver() {}
+
+    /**
+     * Returns {@code true} if the value contains at least one {@code {{env:...}}} or
+     * {@code {{sys:...}}} placeholder.
+     */
+    public static boolean containsPlaceholders(String value) {
+        if (value == null || !value.contains(PLACEHOLDER_TOKEN)) {
+            return false;
+        }
+        return PLACEHOLDER_PATTERN.matcher(value).find();
+    }
+
+    /**
+     * Resolves all {@code {{env:...}}} and {@code {{sys:...}}} placeholders in the given value.
+     *
+     * @param value the property value to resolve (may be {@code null})
+     * @return the resolved value, or the original value if no placeholders are found
+     */
+    public static String resolve(String value) {
+        if (value == null || !value.contains(PLACEHOLDER_TOKEN)) {
+            return value;
+        }
+
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(value);
+        StringBuilder sb = new StringBuilder();
+
+        while (matcher.find()) {
+            String function = matcher.group(1);
+            String key = matcher.group(2);
+            String defaultValue = matcher.group(3);
+
+            String resolved = lookup(function, key);
+
+            if (resolved != null) {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(resolved));
+            } else if (defaultValue != null) {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(defaultValue));
+            } else {
+                LOG.debug("Placeholder {{{}:{}}} could not be resolved and has no default value", function, key);
+            }
+        }
+        matcher.appendTail(sb);
+
+        return sb.toString();
+    }
+
+    /**
+     * Resolves all {@code {{env:...}}} and {@code {{sys:...}}} placeholders in the given
+     * {@link Properties} object, modifying values in place.
+     *
+     * @param props the properties to process (may be {@code null})
+     */
+    public static void resolveAll(Properties props) {
+        if (props == null || props.isEmpty()) {
+            return;
+        }
+
+        for (String key : props.stringPropertyNames()) {
+            String value = props.getProperty(key);
+            if (value != null && value.contains(PLACEHOLDER_TOKEN)) {
+                String resolved = resolve(value);
+                if (!value.equals(resolved)) {
+                    props.setProperty(key, resolved);
+                }
+            }
+        }
+    }
+
+    private static String lookup(String function, String key) {
+        if ("env".equals(function)) {
+            return IOHelper.lookupEnvironmentVariable(key);
+        }
+        return System.getProperty(key);
+    }
+}

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/PlaceholderResolverTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/PlaceholderResolverTest.java
@@ -9,8 +9,10 @@ class PlaceholderResolverTest {
 
     @Test
     void resolveEnvAndSysPlaceholders() {
+        String home = System.getenv("HOME");
+        org.junit.jupiter.api.Assumptions.assumeTrue(home != null, "HOME env var must be set");
         String input = "user={{sys:user.name}},home={{env:HOME}}";
-        String expected = "user=" + System.getProperty("user.name") + ",home=" + System.getenv("HOME");
+        String expected = "user=" + System.getProperty("user.name") + ",home=" + home;
         assertThat(PlaceholderResolver.resolve(input)).isEqualTo(expected);
     }
 

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/PlaceholderResolverTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/PlaceholderResolverTest.java
@@ -1,0 +1,40 @@
+package io.kaoto.forage.core.util.config;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceholderResolverTest {
+
+    @Test
+    void resolveEnvAndSysPlaceholders() {
+        String input = "user={{sys:user.name}},home={{env:HOME}}";
+        String expected = "user=" + System.getProperty("user.name") + ",home=" + System.getenv("HOME");
+        assertThat(PlaceholderResolver.resolve(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void resolveMissingWithDefault() {
+        assertThat(PlaceholderResolver.resolve("{{env:FORAGE_TEST_NONEXISTENT_12345:fallback}}"))
+                .isEqualTo("fallback");
+    }
+
+    @Test
+    void resolveMissingWithoutDefaultLeavesUnchanged() {
+        String input = "{{env:FORAGE_TEST_NONEXISTENT_12345}}";
+        assertThat(PlaceholderResolver.resolve(input)).isEqualTo(input);
+    }
+
+    @Test
+    void resolveAllOnProperties() {
+        Properties props = new Properties();
+        props.setProperty("resolved", "{{sys:user.name}}");
+        props.setProperty("plain", "literal value");
+
+        PlaceholderResolver.resolveAll(props);
+
+        assertThat(props.getProperty("resolved")).isEqualTo(System.getProperty("user.name"));
+        assertThat(props.getProperty("plain")).isEqualTo("literal value");
+    }
+}

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageEnvironmentPostProcessor.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageEnvironmentPostProcessor.java
@@ -15,6 +15,7 @@ import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import io.kaoto.forage.core.util.config.ConfigStore;
+import io.kaoto.forage.core.util.config.PlaceholderResolver;
 import io.kaoto.forage.core.util.config.PropertyFileLocator;
 
 /**
@@ -114,6 +115,7 @@ public class ForageEnvironmentPostProcessor implements EnvironmentPostProcessor 
                 try (InputStream is = Files.newInputStream(path)) {
                     props.load(is);
                 }
+                PlaceholderResolver.resolveAll(props);
                 if (!props.isEmpty()) {
                     String sourceName =
                             FILE_SOURCE_PREFIX + path.toAbsolutePath().normalize();
@@ -133,6 +135,7 @@ public class ForageEnvironmentPostProcessor implements EnvironmentPostProcessor 
             try (InputStream is = resource.getInputStream()) {
                 props.load(is);
             }
+            PlaceholderResolver.resolveAll(props);
             if (!props.isEmpty()) {
                 String sourceName = sourcePrefix + resource.getDescription();
                 if (!environment.getPropertySources().contains(sourceName)) {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
@@ -297,6 +297,9 @@ public final class ForagePropertyValidator {
         if (beanName == null || beanName.trim().isEmpty()) {
             return;
         }
+        if (beanName.contains("{{")) {
+            return;
+        }
 
         String feature = configEntry.getSelectsFrom();
 

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import io.kaoto.forage.catalog.model.ConfigEntry;
 import io.kaoto.forage.catalog.model.ForageBean;
 import io.kaoto.forage.catalog.reader.ForageCatalogReader;
+import io.kaoto.forage.core.util.config.PlaceholderResolver;
 import io.kaoto.forage.plugin.ForagePropertyScanner.PropertyOccurrence;
 
 /**
@@ -297,7 +298,7 @@ public final class ForagePropertyValidator {
         if (beanName == null || beanName.trim().isEmpty()) {
             return;
         }
-        if (beanName.contains("{{")) {
+        if (PlaceholderResolver.containsPlaceholders(beanName)) {
             return;
         }
 

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -53,6 +53,48 @@ Forage converts property names to environment variable names by:
 | `forage.myAgent.agent.base.url` | `FORAGE_MYAGENT_AGENT_BASE_URL` |
 | `forage.myBroker.jms.port` | `FORAGE_MYBROKER_JMS_PORT` |
 
+## Property Placeholders
+
+You can reference environment variables and system properties directly in property values using Camel-style placeholders:
+
+```properties
+forage.myDb.jdbc.url={{env:DATABASE_URL}}
+forage.myDb.jdbc.username={{env:DB_USER}}
+forage.myDb.jdbc.password={{env:DB_PASSWORD}}
+```
+
+### Syntax
+
+| Placeholder | Resolves to |
+|---|---|
+| `{{env:KEY}}` | Environment variable `KEY` |
+| `{{env:KEY:default}}` | Environment variable `KEY`, or `default` if not set |
+| `{{sys:KEY}}` | System property `KEY` |
+| `{{sys:KEY:default}}` | System property `KEY`, or `default` if not set |
+
+Placeholders are resolved at property-loading time, before values are used by Forage modules. If a variable is not set and no default is provided, the placeholder is left unchanged and a warning is logged.
+
+### Placeholders vs Overrides
+
+Property placeholders and [environment variable overrides](#property-precedence) are two different mechanisms:
+
+- **Overrides** replace the entire property: setting `FORAGE_MYDB_JDBC_URL` overrides the value from files entirely
+- **Placeholders** are embedded inside values: `{{env:DB_HOST}}` resolves to the variable's value within a larger string
+
+When both are present, overrides take priority — they are checked before file-based values.
+
+```properties
+# Placeholders let you compose values from multiple variables
+forage.myDb.jdbc.url=jdbc:postgresql://{{env:DB_HOST:localhost}}:{{env:DB_PORT:5432}}/{{env:DB_NAME:orders}}
+```
+
+### Runtime-Specific Alternatives
+
+Spring Boot and Quarkus have their own placeholder syntax (`${KEY}`). Both syntaxes work in Forage property files — see the [Runtime Support](runtimes.md) page for details.
+
+!!! note "Bean-name properties"
+    Properties that select a provider (e.g., `db.kind`, `jms.kind`) should use literal values, not placeholders. The Camel JBang plugin reads these at scan time to auto-resolve dependencies, and placeholders cannot be resolved at that stage.
+
 ## Properties Files
 
 Forage loads properties from files matching the module name. For example, the JDBC module looks for:

--- a/website/docs/concepts/configuration.md
+++ b/website/docs/concepts/configuration.md
@@ -53,6 +53,7 @@ Forage converts property names to environment variable names by:
 | `forage.myAgent.agent.base.url` | `FORAGE_MYAGENT_AGENT_BASE_URL` |
 | `forage.myBroker.jms.port` | `FORAGE_MYBROKER_JMS_PORT` |
 
+{% raw %}
 ## Property Placeholders
 
 You can reference environment variables and system properties directly in property values using Camel-style placeholders:
@@ -91,6 +92,7 @@ forage.myDb.jdbc.url=jdbc:postgresql://{{env:DB_HOST:localhost}}:{{env:DB_PORT:5
 ### Runtime-Specific Alternatives
 
 Spring Boot and Quarkus have their own placeholder syntax (`${KEY}`). Both syntaxes work in Forage property files — see the [Runtime Support](runtimes.md) page for details.
+{% endraw %}
 
 !!! note "Bean-name properties"
     Properties that select a provider (e.g., `db.kind`, `jms.kind`) should use literal values, not placeholders. The Camel JBang plugin reads these at scan time to auto-resolve dependencies, and placeholders cannot be resolved at that stage.

--- a/website/docs/concepts/runtimes.md
+++ b/website/docs/concepts/runtimes.md
@@ -98,7 +98,29 @@ While the configuration is the same, there are a few runtime-specific behaviors 
 | Configuration sources | Properties files, env vars | Spring Environment + Forage properties | SmallRye Config + Forage properties |
 | Bean registration | Camel registry | Spring beans + Camel registry | CDI beans + Camel registry |
 | Hot reload | `camel run --dev` | Spring DevTools | Quarkus dev mode |
+| Property placeholders | `{{env:KEY}}` | `{{env:KEY}}` + `${KEY}` | `{{env:KEY}}` + `${KEY}` |
 
 In Spring Boot, Forage properties are available through Spring's `@Value` and `@ConditionalOnProperty` annotations. In Quarkus, Forage properties are translated to Quarkus-native configuration at build time.
 
 For most use cases, you don't need to think about these differences — Forage handles the integration transparently.
+
+### Property Placeholders Across Runtimes
+
+Forage resolves `{{env:KEY}}` and `{{sys:KEY}}` placeholders in all runtimes at property-loading time — before values reach any runtime-specific code.
+
+Spring Boot and Quarkus also support their own placeholder syntax (`${KEY}`), which is resolved by the respective framework. Both approaches work in Forage property files:
+
+```properties
+# Camel/Forage syntax — works in all runtimes
+forage.myDb.jdbc.username={{env:DB_USER}}
+
+# Spring Boot syntax — works in Spring Boot only
+forage.myDb.jdbc.username=${DB_USER}
+
+# MicroProfile/SmallRye syntax — works in Quarkus only
+forage.myDb.jdbc.username=${DB_USER}
+```
+
+When using `{{env:KEY}}`, Forage resolves the placeholder first. The resolved value is what Spring Boot or Quarkus sees. If you use `${KEY}` instead, Forage passes it through unchanged and the framework handles resolution.
+
+Pick one syntax consistently per property file. `{{env:KEY}}` is recommended for configurations that need to work across all runtimes.

--- a/website/docs/concepts/runtimes.md
+++ b/website/docs/concepts/runtimes.md
@@ -98,12 +98,15 @@ While the configuration is the same, there are a few runtime-specific behaviors 
 | Configuration sources | Properties files, env vars | Spring Environment + Forage properties | SmallRye Config + Forage properties |
 | Bean registration | Camel registry | Spring beans + Camel registry | CDI beans + Camel registry |
 | Hot reload | `camel run --dev` | Spring DevTools | Quarkus dev mode |
+{% raw %}
 | Property placeholders | `{{env:KEY}}` | `{{env:KEY}}` + `${KEY}` | `{{env:KEY}}` + `${KEY}` |
+{% endraw %}
 
 In Spring Boot, Forage properties are available through Spring's `@Value` and `@ConditionalOnProperty` annotations. In Quarkus, Forage properties are translated to Quarkus-native configuration at build time.
 
 For most use cases, you don't need to think about these differences — Forage handles the integration transparently.
 
+{% raw %}
 ### Property Placeholders Across Runtimes
 
 Forage resolves `{{env:KEY}}` and `{{sys:KEY}}` placeholders in all runtimes at property-loading time — before values reach any runtime-specific code.
@@ -124,3 +127,4 @@ forage.myDb.jdbc.username=${DB_USER}
 When using `{{env:KEY}}`, Forage resolves the placeholder first. The resolved value is what Spring Boot or Quarkus sees. If you use `${KEY}` instead, Forage passes it through unchanged and the framework handles resolution.
 
 Pick one syntax consistently per property file. `{{env:KEY}}` is recommended for configurations that need to work across all runtimes.
+{% endraw %}


### PR DESCRIPTION
## Summary
- Add `PlaceholderResolver` utility to resolve Camel-style `{{env:KEY}}` and `{{sys:KEY}}` placeholders in Forage property files
- Resolve placeholders in `AbstractConfig.register()` (module-specific properties files) and `ConfigStore.load()` (`application.properties` path)
- Resolve placeholders in Spring Boot's `ForageEnvironmentPostProcessor` for `forage-*.properties` loaded into Spring Environment
- Skip property validation for unresolved placeholder values in `ForagePropertyValidator`
- Document placeholder syntax, runtime-specific behavior, and limitations in website docs

Closes #372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration values now support property placeholders to reference environment variables and system properties using `{{env:KEY}}` and `{{sys:KEY}}` syntax, with optional default values.
  * Placeholders are resolved during property-loading time.

* **Documentation**
  * Added guidance on property placeholder syntax and usage.
  * Clarified placeholder behavior and precedence across Camel JBang, Spring Boot, and Quarkus runtimes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/forage/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->