### PR TITLE
Fix #378: Rename Spring RabbitMQ properties to  forage.rabbitmq.*

### DIFF
--- a/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest.java
+++ b/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest.java
@@ -79,8 +79,8 @@ public class SpringRabbitMQHealthMetricsTest implements ForageIntegrationTest {
         Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
                 classResource("forage-spring-rabbitmq.properties.template"),
                 Map.of(
-                        "forage\\.spring\\.rabbitmq\\.port=.*",
-                        Matcher.quoteReplacement("forage.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672)),
+                        "forage\\.rabbitmq\\.port=.*",
+                        Matcher.quoteReplacement("forage.rabbitmq.port=" + rabbitmq.getMappedPort(5672)),
                         "server\\.port=.*",
                         Matcher.quoteReplacement("server.port=" + actuatorPort)),
                 afterAll);

--- a/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest.java
+++ b/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest.java
@@ -43,8 +43,8 @@ public class SpringRabbitMQNamedTest implements ForageIntegrationTest {
         Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
                 classResource("forage-spring-rabbitmq.properties.template"),
                 Map.of(
-                        "forage\\.mq1\\.spring\\.rabbitmq\\.port=.*",
-                        Matcher.quoteReplacement("forage.mq1.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672))),
+                        "forage\\.mq1\\.rabbitmq\\.port=.*",
+                        Matcher.quoteReplacement("forage.mq1.rabbitmq.port=" + rabbitmq.getMappedPort(5672))),
                 afterAll);
 
         // running jbang forage run with dynamically modified properties

--- a/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest.java
+++ b/integration-tests/messaging/src/test/java/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest.java
@@ -38,8 +38,8 @@ public class SpringRabbitMQTest implements ForageIntegrationTest {
         Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
                 classResource("forage-spring-rabbitmq.properties.template"),
                 Map.of(
-                        "forage\\.spring\\.rabbitmq\\.port=.*",
-                        Matcher.quoteReplacement("forage.spring.rabbitmq.port=" + rabbitmq.getMappedPort(5672))),
+                        "forage\\.rabbitmq\\.port=.*",
+                        Matcher.quoteReplacement("forage.rabbitmq.port=" + rabbitmq.getMappedPort(5672))),
                 afterAll);
 
         // running jbang forage run with dynamically modified properties

--- a/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest/forage-spring-rabbitmq.properties.template
+++ b/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQHealthMetricsTest/forage-spring-rabbitmq.properties.template
@@ -1,14 +1,14 @@
 # Spring RabbitMQ CachingConnectionFactory configuration
 # Connection settings for RabbitMQ broker
-forage.spring.rabbitmq.host=localhost
-forage.spring.rabbitmq.port=5672  # Overridden by test with testcontainer port
-forage.spring.rabbitmq.username=guest
-forage.spring.rabbitmq.password=guest
-forage.spring.rabbitmq.virtual.host=/
+forage.rabbitmq.host=localhost
+forage.rabbitmq.port=5672  # Overridden by test with testcontainer port
+forage.rabbitmq.username=guest
+forage.rabbitmq.password=guest
+forage.rabbitmq.virtual.host=/
 
 # Connection pooling and cache settings
-forage.spring.rabbitmq.channel.cache.size=25
-forage.spring.rabbitmq.cache.mode=CHANNEL
+forage.rabbitmq.channel.cache.size=25
+forage.rabbitmq.cache.mode=CHANNEL
 
 # Auto-declare exchanges and queues
 camel.component.spring-rabbitmq.auto-declare=true

--- a/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest/forage-spring-rabbitmq.properties.template
+++ b/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQNamedTest/forage-spring-rabbitmq.properties.template
@@ -1,10 +1,10 @@
 # Named/prefixed Spring RabbitMQ CachingConnectionFactory configuration
 # The "mq1" prefix creates a bean named "mq1" in the Camel registry
-forage.mq1.spring.rabbitmq.host=localhost
-forage.mq1.spring.rabbitmq.port=5672  # Overridden by test with testcontainer port
-forage.mq1.spring.rabbitmq.username=guest
-forage.mq1.spring.rabbitmq.password=guest
-forage.mq1.spring.rabbitmq.virtual.host=/
+forage.mq1.rabbitmq.host=localhost
+forage.mq1.rabbitmq.port=5672  # Overridden by test with testcontainer port
+forage.mq1.rabbitmq.username=guest
+forage.mq1.rabbitmq.password=guest
+forage.mq1.rabbitmq.virtual.host=/
 
 # Auto-declare exchanges and queues
 camel.component.spring-rabbitmq.auto-declare=true

--- a/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest/forage-spring-rabbitmq.properties.template
+++ b/integration-tests/messaging/src/test/resources/io/kaoto/forage/messaging/springrabbitmq/SpringRabbitMQTest/forage-spring-rabbitmq.properties.template
@@ -1,10 +1,10 @@
 # Spring RabbitMQ CachingConnectionFactory configuration
 # Connection settings for RabbitMQ broker
-forage.spring.rabbitmq.host=localhost
-forage.spring.rabbitmq.port=5672  # Overridden by test with testcontainer port
-forage.spring.rabbitmq.username=guest
-forage.spring.rabbitmq.password=guest
-forage.spring.rabbitmq.virtual.host=/
+forage.rabbitmq.host=localhost
+forage.rabbitmq.port=5672  # Overridden by test with testcontainer port
+forage.rabbitmq.username=guest
+forage.rabbitmq.password=guest
+forage.rabbitmq.virtual.host=/
 
 # Auto-declare exchanges and queues
 camel.component.spring-rabbitmq.auto-declare=true

--- a/library/messaging/forage-spring-rabbitmq-common/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/common/SpringRabbitMQConfigEntries.java
+++ b/library/messaging/forage-spring-rabbitmq-common/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/common/SpringRabbitMQConfigEntries.java
@@ -8,7 +8,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule HOST = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.host",
+            "forage.rabbitmq.host",
             "The RabbitMQ broker host",
             "Host",
             "localhost",
@@ -18,7 +18,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule PORT = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.port",
+            "forage.rabbitmq.port",
             "The RabbitMQ broker port",
             "Port",
             "5672",
@@ -28,7 +28,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule USERNAME = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.username",
+            "forage.rabbitmq.username",
             "The RabbitMQ username",
             "Username",
             "guest",
@@ -38,7 +38,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule PASSWORD = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.password",
+            "forage.rabbitmq.password",
             "The RabbitMQ password",
             "Password",
             "guest",
@@ -48,7 +48,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule VIRTUAL_HOST = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.virtual.host",
+            "forage.rabbitmq.virtual.host",
             "The RabbitMQ virtual host",
             "Virtual Host",
             "/",
@@ -58,7 +58,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule CHANNEL_CACHE_SIZE = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.channel.cache.size",
+            "forage.rabbitmq.channel.cache.size",
             "The number of channels to maintain in cache",
             "Channel Cache Size",
             "25",
@@ -68,7 +68,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule CACHE_MODE = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.cache.mode",
+            "forage.rabbitmq.cache.mode",
             "The cache mode (CHANNEL or CONNECTION)",
             "Cache Mode",
             "CHANNEL",
@@ -78,7 +78,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule CONNECTION_CACHE_SIZE = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.connection.cache.size",
+            "forage.rabbitmq.connection.cache.size",
             "The number of connections to cache (CONNECTION mode only)",
             "Connection Cache Size",
             "1",
@@ -88,7 +88,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule CHANNEL_CHECKOUT_TIMEOUT = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.channel.checkout.timeout",
+            "forage.rabbitmq.channel.checkout.timeout",
             "Timeout in milliseconds when waiting for a channel from the cache",
             "Channel Checkout Timeout",
             "30000",
@@ -98,7 +98,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule REQUESTED_HEARTBEAT = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.requested.heartbeat",
+            "forage.rabbitmq.requested.heartbeat",
             "Heartbeat interval in seconds for detecting dead connections",
             "Requested Heartbeat",
             "60",
@@ -108,7 +108,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule CONNECTION_TIMEOUT = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.connection.timeout",
+            "forage.rabbitmq.connection.timeout",
             "Connection timeout in milliseconds",
             "Connection Timeout",
             "30000",
@@ -118,7 +118,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule ADDRESSES = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.addresses",
+            "forage.rabbitmq.addresses",
             "Comma-separated list of host:port addresses for cluster failover",
             "Addresses",
             null,
@@ -128,7 +128,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule AUTOMATIC_RECOVERY_ENABLED = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.automatic.recovery.enabled",
+            "forage.rabbitmq.automatic.recovery.enabled",
             "Enable automatic connection recovery after failure",
             "Automatic Recovery",
             "true",
@@ -138,7 +138,7 @@ public final class SpringRabbitMQConfigEntries extends ConfigEntries {
 
     public static final ConfigModule NETWORK_RECOVERY_INTERVAL = ConfigModule.of(
             SpringRabbitMQConfig.class,
-            "forage.spring.rabbitmq.network.recovery.interval",
+            "forage.rabbitmq.network.recovery.interval",
             "Interval in milliseconds between recovery attempts",
             "Network Recovery Interval",
             "5000",

--- a/library/messaging/forage-spring-rabbitmq-common/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/common/SpringRabbitMQConstants.java
+++ b/library/messaging/forage-spring-rabbitmq-common/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/common/SpringRabbitMQConstants.java
@@ -13,8 +13,8 @@ public final class SpringRabbitMQConstants {
         // Utility class
     }
 
-    /** Module prefix used in property names: {@code "spring.rabbitmq"} */
-    public static final String MODULE_PREFIX = "spring.rabbitmq";
+    /** Module prefix used in property names: {@code "rabbitmq"} */
+    public static final String MODULE_PREFIX = "rabbitmq";
 
     /** Default bean name for unprefixed configurations: {@code "rabbitConnectionFactory"} */
     public static final String DEFAULT_BEAN_NAME = "rabbitConnectionFactory";

--- a/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
+++ b/library/messaging/forage-spring-rabbitmq/src/main/java/io/kaoto/forage/messaging/spring/rabbitmq/SpringRabbitMQBeanFactory.java
@@ -30,8 +30,8 @@ public class SpringRabbitMQBeanFactory implements BeanFactory {
     @Override
     public void cleanup() {
         SpringRabbitMQConfig config = new SpringRabbitMQConfig();
-        Set<String> prefixes =
-                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("spring.rabbitmq"));
+        Set<String> prefixes = ConfigStore.getInstance()
+                .readPrefixes(config, ConfigHelper.getNamedPropertyRegexp(SpringRabbitMQConstants.MODULE_PREFIX));
 
         for (String name : prefixes) {
             closeAndUnbind(name);
@@ -49,8 +49,8 @@ public class SpringRabbitMQBeanFactory implements BeanFactory {
     @Override
     public void configure() {
         SpringRabbitMQConfig config = new SpringRabbitMQConfig();
-        Set<String> prefixes =
-                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("spring.rabbitmq"));
+        Set<String> prefixes = ConfigStore.getInstance()
+                .readPrefixes(config, ConfigHelper.getNamedPropertyRegexp(SpringRabbitMQConstants.MODULE_PREFIX));
 
         if (!prefixes.isEmpty()) {
             for (String name : prefixes) {

--- a/library/messaging/forage-spring-rabbitmq/src/main/resources/forage-spring-rabbitmq.properties
+++ b/library/messaging/forage-spring-rabbitmq/src/main/resources/forage-spring-rabbitmq.properties
@@ -1,16 +1,16 @@
 # Spring RabbitMQ CachingConnectionFactory configuration
 #
-# forage.spring.rabbitmq.host=localhost
-# forage.spring.rabbitmq.port=5672
-# forage.spring.rabbitmq.username=guest
-# forage.spring.rabbitmq.password=guest
-# forage.spring.rabbitmq.virtual.host=/
-# forage.spring.rabbitmq.channel.cache.size=25
-# forage.spring.rabbitmq.cache.mode=CHANNEL
-# forage.spring.rabbitmq.connection.cache.size=1
-# forage.spring.rabbitmq.channel.checkout.timeout=30000
-# forage.spring.rabbitmq.requested.heartbeat=60
-# forage.spring.rabbitmq.connection.timeout=30000
-# forage.spring.rabbitmq.addresses=host1:5672,host2:5672
-# forage.spring.rabbitmq.automatic.recovery.enabled=true
-# forage.spring.rabbitmq.network.recovery.interval=5000
+# forage.rabbitmq.host=localhost
+# forage.rabbitmq.port=5672
+# forage.rabbitmq.username=guest
+# forage.rabbitmq.password=guest
+# forage.rabbitmq.virtual.host=/
+# forage.rabbitmq.channel.cache.size=25
+# forage.rabbitmq.cache.mode=CHANNEL
+# forage.rabbitmq.connection.cache.size=1
+# forage.rabbitmq.channel.checkout.timeout=30000
+# forage.rabbitmq.requested.heartbeat=60
+# forage.rabbitmq.connection.timeout=30000
+# forage.rabbitmq.addresses=host1:5672,host2:5672
+# forage.rabbitmq.automatic.recovery.enabled=true
+# forage.rabbitmq.network.recovery.interval=5000

--- a/library/messaging/spring-boot/forage-spring-rabbitmq-starter/src/main/java/io/kaoto/forage/springboot/messaging/springrabbitmq/ForageSpringRabbitMQAutoConfiguration.java
+++ b/library/messaging/spring-boot/forage-spring-rabbitmq-starter/src/main/java/io/kaoto/forage/springboot/messaging/springrabbitmq/ForageSpringRabbitMQAutoConfiguration.java
@@ -25,7 +25,7 @@ import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
  * Automatically creates ConnectionFactory beans from Spring RabbitMQ configuration properties,
  * supporting both single and multi-instance (prefixed) configurations.
  *
- * <p>Named/prefixed connection factories (e.g., {@code forage.mq1.spring.rabbitmq.host})
+ * <p>Named/prefixed connection factories (e.g., {@code forage.mq1.rabbitmq.host})
  * are registered dynamically by {@link ForageSpringBootModuleAdapter} using the
  * {@link SpringRabbitMQModuleDescriptor}.
  *
@@ -62,7 +62,7 @@ public class ForageSpringRabbitMQAutoConfiguration {
      * <p>This bean is only registered when:
      * <ul>
      *   <li>No "rabbitConnectionFactory" bean already exists (e.g., from the module adapter's prefix discovery)</li>
-     *   <li>The {@code forage.spring.rabbitmq.host} property is configured</li>
+     *   <li>The {@code forage.rabbitmq.host} property is configured</li>
      * </ul>
      *
      * @param forageSpringRabbitMQModuleAdapter injected to ensure the adapter runs first and discovers

--- a/website/docs/modules/spring-rabbitmq.md
+++ b/website/docs/modules/spring-rabbitmq.md
@@ -5,10 +5,10 @@ Forage creates Spring RabbitMQ `CachingConnectionFactory` beans for AMQP messagi
 ## Quick Start
 
 ```properties
-forage.spring.rabbitmq.host=localhost
-forage.spring.rabbitmq.port=5672
-forage.spring.rabbitmq.username=guest
-forage.spring.rabbitmq.password=guest
+forage.rabbitmq.host=localhost
+forage.rabbitmq.port=5672
+forage.rabbitmq.username=guest
+forage.rabbitmq.password=guest
 ```
 
 ```yaml
@@ -27,15 +27,15 @@ forage.spring.rabbitmq.password=guest
 Use prefixed configuration to create multiple named connection factories:
 
 ```properties
-forage.primary.spring.rabbitmq.host=broker1.example.com
-forage.primary.spring.rabbitmq.port=5672
-forage.primary.spring.rabbitmq.username=admin
-forage.primary.spring.rabbitmq.password=secret
+forage.primary.rabbitmq.host=broker1.example.com
+forage.primary.rabbitmq.port=5672
+forage.primary.rabbitmq.username=admin
+forage.primary.rabbitmq.password=secret
 
-forage.backup.spring.rabbitmq.host=broker2.example.com
-forage.backup.spring.rabbitmq.port=5672
-forage.backup.spring.rabbitmq.username=admin
-forage.backup.spring.rabbitmq.password=secret
+forage.backup.rabbitmq.host=broker2.example.com
+forage.backup.rabbitmq.port=5672
+forage.backup.rabbitmq.username=admin
+forage.backup.rabbitmq.password=secret
 ```
 
 ```yaml
@@ -54,9 +54,9 @@ forage.backup.spring.rabbitmq.password=secret
 Use the `addresses` property to connect to a RabbitMQ cluster. When set, it takes precedence for connection routing:
 
 ```properties
-forage.spring.rabbitmq.addresses=broker1:5672,broker2:5672,broker3:5672
-forage.spring.rabbitmq.automatic.recovery.enabled=true
-forage.spring.rabbitmq.network.recovery.interval=5000
+forage.rabbitmq.addresses=broker1:5672,broker2:5672,broker3:5672
+forage.rabbitmq.automatic.recovery.enabled=true
+forage.rabbitmq.network.recovery.interval=5000
 ```
 
 ## Health and Metrics
@@ -157,7 +157,7 @@ The `CachingConnectionFactory` supports two cache modes:
 - **CONNECTION** — caches connections and channels. Use when you need multiple connections to the broker.
 
 ```properties
-forage.spring.rabbitmq.cache.mode=CONNECTION
-forage.spring.rabbitmq.connection.cache.size=5
-forage.spring.rabbitmq.channel.cache.size=25
+forage.rabbitmq.cache.mode=CONNECTION
+forage.rabbitmq.connection.cache.size=5
+forage.rabbitmq.channel.cache.size=25
 ```


### PR DESCRIPTION
  Fixes #378

 Rename Spring RabbitMQ property prefix from forage.spring.rabbitmq.* to forage.rabbitmq.* to align
  with the established forage.<technology>.* naming convention
  - Replace hardcoded "spring.rabbitmq" strings in SpringRabbitMQBeanFactory with
  SpringRabbitMQConstants.MODULE_PREFIX
  - Update website documentation, test templates, and test regex patterns




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated RabbitMQ configuration property namespace from `forage.spring.rabbitmq.*` to `forage.rabbitmq.*` across all configuration settings (host, port, username, password, virtual host, cache settings, and connection options).

* **Documentation**
  * Updated configuration examples and references to reflect the new property naming scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->