### PR TITLE
docs: add snapshot builds documentation

### DIFF
--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -107,3 +107,4 @@ When you're ready to deploy, export to Spring Boot or Quarkus:
 - Explore the [Core Concepts](../concepts/index.md) to understand how Forage works
 - Browse working [Examples](../examples/index.md) covering JDBC, JMS, transactions, and AI agents
 - See all available [Modules](../modules/index.md) for a full list of supported technologies
+- Try the latest development features with [Snapshot Builds](snapshot.md)

--- a/website/docs/getting-started/snapshot.md
+++ b/website/docs/getting-started/snapshot.md
@@ -1,0 +1,90 @@
+# Snapshot Builds
+
+!!! warning "Development Builds"
+    Snapshot builds are published from the `main` branch every two days. They may contain breaking changes, incomplete features, or bugs. Use the [stable release](index.md) for production.
+
+The latest snapshot version is **1.4-SNAPSHOT**, published to the Maven Central Portal Snapshots repository.
+
+## Install the Snapshot Plugin
+
+```bash
+camel plugin add forage \
+  --repos=https://central.sonatype.com/repository/maven-snapshots/ \
+  --gav io.kaoto.forage:camel-jbang-plugin-forage:1.4-SNAPSHOT
+```
+
+Verify it installed correctly:
+
+```bash
+camel forage --help
+```
+
+## Running Routes
+
+When running routes with a snapshot version of Forage, you need to tell Camel where to download snapshot dependencies. Use the `--repos` flag:
+
+```bash
+camel run --repos=https://central.sonatype.com/repository/maven-snapshots/ *
+```
+
+Alternatively, add the repository to your `application.properties` so you don't need the flag every time:
+
+```properties
+camel.jbang.repos=https://central.sonatype.com/repository/maven-snapshots/
+```
+
+Then run as usual:
+
+```bash
+camel run *
+```
+
+## Exporting to Production
+
+The `--repos` flag also works with `camel export`:
+
+=== "Spring Boot"
+
+    ```bash
+    camel export --runtime=spring-boot \
+      --repos=https://central.sonatype.com/repository/maven-snapshots/ \
+      --directory=./my-app
+    ```
+
+=== "Quarkus"
+
+    ```bash
+    camel export --runtime=quarkus \
+      --repos=https://central.sonatype.com/repository/maven-snapshots/ \
+      --directory=./my-app
+    ```
+
+## Using Snapshots in a Maven Project
+
+If you are using Forage as a Maven dependency (without Camel JBang), add the snapshot repository to your `pom.xml`:
+
+```xml
+<repositories>
+    <repository>
+        <name>Central Portal Snapshots</name>
+        <id>central-portal-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+```
+
+Then use the snapshot version in your dependencies:
+
+```xml
+<dependency>
+    <groupId>io.kaoto.forage</groupId>
+    <artifactId>forage-jdbc-postgresql</artifactId>
+    <version>1.4-SNAPSHOT</version>
+</dependency>
+```

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -82,7 +82,9 @@ plugins:
 
 nav:
   - Home: index.md
-  - Getting Started: getting-started/index.md
+  - Getting Started:
+      - getting-started/index.md
+      - Snapshot Builds: getting-started/snapshot.md
   - Core Concepts:
       - concepts/index.md
       - Bean Providers: concepts/bean-providers.md


### PR DESCRIPTION
## Summary
- Add a new "Snapshot Builds" page under Getting Started documenting how to consume SNAPSHOT artifacts from the Central Portal Snapshots repository
- Covers Camel JBang plugin install with `--repos`, running routes, `camel.jbang.repos` property, export, and direct Maven POM usage
- Update mkdocs.yml navigation and Getting Started page with a link to the new page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated getting started guide with reference to snapshot builds
* Added new snapshot builds documentation covering plugin installation, repository configuration, and Maven project setup for accessing latest development features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->