### PR TITLE
docs: automate version management in docs and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      currentDevelopmentVersion:
-        description: 'The current development version'
+      releaseVersion:
+        description: 'The version to release (e.g. 1.3)'
         required: true
       nextDevelopmentVersion:
-        description: 'The next development version'
+        description: 'The next development version (e.g. 1.4)'
         required: true
 
 jobs:
@@ -58,7 +58,14 @@ jobs:
           echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
           ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           
-          mvn -DskipTests -Darguments="-DskipTests" -Pdist -B --no-transfer-progress --file pom.xml -Dtag=v${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
+          mvn -DskipTests -Darguments="-DskipTests" -Pdist -B --no-transfer-progress --file pom.xml -Dtag=v${{ github.event.inputs.releaseVersion }} -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
+
+      - name: Update docs version
+        run: |
+          sed -i 's/forage_version: ".*"/forage_version: "${{ github.event.inputs.releaseVersion }}"/' website/mkdocs.yml
+          git add website/mkdocs.yml
+          git commit -m "docs: update stable version to ${{ github.event.inputs.releaseVersion }}"
+          git push
 
       # Create a release
 
@@ -66,7 +73,7 @@ jobs:
         uses: jreleaser/release-action@v2
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.releaseVersion }}
 
       # Persist logs
 

--- a/website/docs/getting-started/snapshot.md
+++ b/website/docs/getting-started/snapshot.md
@@ -3,14 +3,14 @@
 !!! warning "Development Builds"
     Snapshot builds are published from the `main` branch every two days. They may contain breaking changes, incomplete features, or bugs. Use the [stable release](index.md) for production.
 
-The latest snapshot version is **1.4-SNAPSHOT**, published to the Maven Central Portal Snapshots repository.
+The latest snapshot version is **{{ forage_snapshot_version }}**, published to the Maven Central Portal Snapshots repository.
 
 ## Install the Snapshot Plugin
 
 ```bash
 camel plugin add forage \
   --repos=https://central.sonatype.com/repository/maven-snapshots/ \
-  --gav io.kaoto.forage:camel-jbang-plugin-forage:1.4-SNAPSHOT
+  --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_snapshot_version }}
 ```
 
 Verify it installed correctly:
@@ -85,6 +85,6 @@ Then use the snapshot version in your dependencies:
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-jdbc-postgresql</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>{{ forage_snapshot_version }}</version>
 </dependency>
 ```

--- a/website/macros/forage_catalog.py
+++ b/website/macros/forage_catalog.py
@@ -12,8 +12,9 @@ Usage in Markdown:
 
 Version variables (automatically extracted from pom.xml):
 
-    {{ forage_version }}    -> e.g. "1.1-SNAPSHOT"
-    {{ camel_version }}     -> e.g. "4.18.0"
+    {{ forage_version }}          -> e.g. "1.3" (overridden by mkdocs.yml for stable docs)
+    {{ forage_snapshot_version }} -> e.g. "1.4-SNAPSHOT" (always from pom.xml)
+    {{ camel_version }}           -> e.g. "4.18.0"
 """
 
 import json
@@ -45,6 +46,7 @@ def _load_versions():
     ver = root.find("m:version", POM_NS)
     if ver is not None:
         versions["forage_version"] = ver.text
+        versions["forage_snapshot_version"] = ver.text
     props = root.find("m:properties", POM_NS)
     if props is not None:
         camel_ver = props.find("m:camel.version", POM_NS)

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -44,7 +44,7 @@ theme:
     - toc.follow
 
 extra:
-  forage_version: "1.1"
+  forage_version: "1.3"
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
## Summary
- Update stable docs version from `1.1` to `1.3` in `mkdocs.yml`
- Add `forage_snapshot_version` macro variable (always from `pom.xml`) so snapshot docs stay in sync automatically
- Replace hardcoded `1.4-SNAPSHOT` in snapshot page with `{{ forage_snapshot_version }}`
- Rename `currentDevelopmentVersion` to `releaseVersion` in the release workflow for clarity
- Add "Update docs version" step to the release workflow so `mkdocs.yml` is updated automatically on each release