### PR TITLE
Fix #383: Support application-{profile}.properties in ForagePropertyScanner

### DIFF
--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
@@ -78,7 +78,22 @@ public class ForagePlugin implements Plugin {
 
     private void beforeRun(KameletMain main, List<String> files) {
         resolveConfigDir(files);
+        propagateProfile(main);
         addShibbolethRepo(main);
+    }
+
+    // JVM-global side effect: sets camel.main.profile so ForagePropertyScanner can resolve the
+    // active profile. Safe because camel run/export each run in their own JVM process — no cleanup
+    // needed. Consistent with how forage.config.dir is handled in resolveConfigDir.
+    private static void propagateProfile(KameletMain main) {
+        if (System.getProperty("camel.main.profile") != null) {
+            return;
+        }
+        String profile = main.getProfile();
+        if (profile != null) {
+            LOG.debug("Propagating camel.main.profile={} from KameletMain", profile);
+            System.setProperty("camel.main.profile", profile);
+        }
     }
 
     private static void addShibbolethRepo(KameletMain main) {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyScanner.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyScanner.java
@@ -24,6 +24,8 @@ import io.kaoto.forage.catalog.reader.ForageCatalogReader;
 public final class ForagePropertyScanner {
 
     private static final Pattern FORAGE_PROPERTY_PATTERN = Pattern.compile("^forage\\.(.+)$");
+    private static final String PROFILE_PROPERTY = "camel.main.profile";
+    private static final String PROFILE_ENV_VAR = "CAMEL_MAIN_PROFILE";
 
     private ForagePropertyScanner() {}
 
@@ -80,39 +82,39 @@ public final class ForagePropertyScanner {
 
         Map<String, Map<String, List<PropertyOccurrence>>> result = new HashMap<>();
 
-        List<File> propertiesFiles = findPropertiesFiles(directory, catalog);
-        for (File file : propertiesFiles) {
+        // Load application properties with profile override semantics (like Camel does):
+        // scan base first, then profile file — profile occurrences replace base ones per property key
+        File applicationPropsFile = loadApplicationProperties(directory);
+        Properties baseProps = null;
+        if (applicationPropsFile != null) {
+            baseProps = new Properties();
+            try (FileInputStream fis = new FileInputStream(applicationPropsFile)) {
+                baseProps.load(fis);
+            }
+            collectForageProperties(baseProps, applicationPropsFile, catalog, trackUnknown, result);
+        }
+
+        String profile = resolveProfile(baseProps);
+        if (profile != null) {
+            File profileFile = new File(directory, "application-" + profile + ".properties");
+            if (profileFile.isFile()) {
+                Properties profileProps = new Properties();
+                try (FileInputStream fis = new FileInputStream(profileFile)) {
+                    profileProps.load(fis);
+                }
+                // Profile properties override base: replace matching occurrences
+                overrideForageProperties(profileProps, profileFile, catalog, trackUnknown, result);
+            }
+        }
+
+        // Load forage-specific and catalog-named properties files independently
+        List<File> nonAppFiles = findNonApplicationPropertiesFiles(directory, catalog);
+        for (File file : nonAppFiles) {
             Properties props = new Properties();
             try (FileInputStream fis = new FileInputStream(file)) {
                 props.load(fis);
             }
-
-            for (String key : props.stringPropertyNames()) {
-                Matcher matcher = FORAGE_PROPERTY_PATTERN.matcher(key);
-                if (!matcher.matches()) {
-                    continue;
-                }
-
-                String remainder = matcher.group(1);
-                ParseResult parsed = parsePropertyKey(remainder, catalog);
-
-                String value = props.getProperty(key);
-                PropertyOccurrence occurrence = new PropertyOccurrence(file, key, value);
-
-                if (parsed == null) {
-                    // Property starts with "forage." but doesn't match any known pattern
-                    if (trackUnknown) {
-                        result.computeIfAbsent("__unknown__", k -> new HashMap<>())
-                                .computeIfAbsent(remainder, k -> new ArrayList<>())
-                                .add(occurrence);
-                    }
-                    continue;
-                }
-
-                result.computeIfAbsent(parsed.factoryTypeKey, k -> new HashMap<>())
-                        .computeIfAbsent(parsed.propertyName, k -> new ArrayList<>())
-                        .add(occurrence);
-            }
+            collectForageProperties(props, file, catalog, trackUnknown, result);
         }
 
         return result;
@@ -132,14 +134,121 @@ public final class ForagePropertyScanner {
         return scanPropertiesWithFileTracking(directory, catalog, true);
     }
 
-    private static List<File> findPropertiesFiles(File dir, ForageCatalogReader catalog) throws IOException {
-        Set<String> targetFileNames = new java.util.HashSet<>();
-        targetFileNames.add("application.properties");
+    private static void collectForageProperties(
+            Properties props,
+            File sourceFile,
+            ForageCatalogReader catalog,
+            boolean trackUnknown,
+            Map<String, Map<String, List<PropertyOccurrence>>> result) {
+
+        for (String key : props.stringPropertyNames()) {
+            Matcher matcher = FORAGE_PROPERTY_PATTERN.matcher(key);
+            if (!matcher.matches()) {
+                continue;
+            }
+
+            String remainder = matcher.group(1);
+            ParseResult parsed = parsePropertyKey(remainder, catalog);
+
+            String value = props.getProperty(key);
+            PropertyOccurrence occurrence = new PropertyOccurrence(sourceFile, key, value);
+
+            if (parsed == null) {
+                if (trackUnknown) {
+                    result.computeIfAbsent("__unknown__", k -> new HashMap<>())
+                            .computeIfAbsent(remainder, k -> new ArrayList<>())
+                            .add(occurrence);
+                }
+                continue;
+            }
+
+            result.computeIfAbsent(parsed.factoryTypeKey, k -> new HashMap<>())
+                    .computeIfAbsent(parsed.propertyName, k -> new ArrayList<>())
+                    .add(occurrence);
+        }
+    }
+
+    private static void overrideForageProperties(
+            Properties profileProps,
+            File profileFile,
+            ForageCatalogReader catalog,
+            boolean trackUnknown,
+            Map<String, Map<String, List<PropertyOccurrence>>> result) {
+
+        for (String key : profileProps.stringPropertyNames()) {
+            Matcher matcher = FORAGE_PROPERTY_PATTERN.matcher(key);
+            if (!matcher.matches()) {
+                continue;
+            }
+
+            String remainder = matcher.group(1);
+            ParseResult parsed = parsePropertyKey(remainder, catalog);
+
+            String value = profileProps.getProperty(key);
+            PropertyOccurrence occurrence = new PropertyOccurrence(profileFile, key, value);
+
+            if (parsed == null) {
+                if (trackUnknown) {
+                    replaceBaseOccurrence("__unknown__", remainder, key, occurrence, result);
+                }
+                continue;
+            }
+
+            replaceBaseOccurrence(parsed.factoryTypeKey, parsed.propertyName, key, occurrence, result);
+        }
+    }
+
+    // Override is only called after collectForageProperties has processed application.properties,
+    // and before non-application files (forage-*.properties) are scanned. This ordering guarantees
+    // that removeIf only removes base application.properties occurrences, never forage-*.properties ones.
+    private static void replaceBaseOccurrence(
+            String groupKey,
+            String propertyName,
+            String fullPropertyName,
+            PropertyOccurrence occurrence,
+            Map<String, Map<String, List<PropertyOccurrence>>> result) {
+
+        Map<String, List<PropertyOccurrence>> groupMap = result.computeIfAbsent(groupKey, k -> new HashMap<>());
+        List<PropertyOccurrence> occurrences = groupMap.get(propertyName);
+        if (occurrences != null) {
+            occurrences.removeIf(o -> o.fullPropertyName().equals(fullPropertyName));
+        }
+        groupMap.computeIfAbsent(propertyName, k -> new ArrayList<>()).add(occurrence);
+    }
+
+    private static File loadApplicationProperties(File dir) {
+        File file = new File(dir, "application.properties");
+        return file.isFile() ? file : null;
+    }
+
+    static String resolveProfile(Properties applicationProps) {
+        String profile = resolveProfileFromEnvironment();
+        if (profile != null) {
+            return profile;
+        }
+
+        if (applicationProps != null) {
+            profile = applicationProps.getProperty(PROFILE_PROPERTY);
+        }
+        return profile;
+    }
+
+    private static String resolveProfileFromEnvironment() {
+        String profile = System.getProperty(PROFILE_PROPERTY);
+        if (profile != null) {
+            return profile;
+        }
+        return System.getenv(PROFILE_ENV_VAR);
+    }
+
+    private static List<File> findNonApplicationPropertiesFiles(File dir, ForageCatalogReader catalog)
+            throws IOException {
+        Set<String> catalogFileNames = new java.util.HashSet<>();
 
         for (ForageCatalogReader.FactoryMetadata metadata : catalog.getAllFactories()) {
             String propsFile = metadata.propertiesFileName();
             if (propsFile != null && !propsFile.isEmpty()) {
-                targetFileNames.add(propsFile);
+                catalogFileNames.add(propsFile);
             }
         }
 
@@ -147,7 +256,7 @@ public final class ForagePropertyScanner {
             return paths.filter(Files::isRegularFile)
                     .filter(p -> {
                         String fileName = p.getFileName().toString();
-                        return targetFileNames.contains(fileName)
+                        return catalogFileNames.contains(fileName)
                                 || (fileName.startsWith("forage-") && fileName.endsWith(".properties"));
                     })
                     .map(Path::toFile)

--- a/tooling/camel-jbang-plugin-forage/src/test/java/io/kaoto/forage/plugin/ForagePropertyScannerTest.java
+++ b/tooling/camel-jbang-plugin-forage/src/test/java/io/kaoto/forage/plugin/ForagePropertyScannerTest.java
@@ -1,0 +1,151 @@
+package io.kaoto.forage.plugin;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import io.kaoto.forage.catalog.reader.ForageCatalogReader;
+import io.kaoto.forage.plugin.ForagePropertyScanner.PropertyOccurrence;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ForagePropertyScannerTest {
+
+    @TempDir
+    File tempDir;
+
+    private String originalProfile;
+    private ForageCatalogReader catalog;
+
+    @BeforeEach
+    void setUp() {
+        originalProfile = System.getProperty("camel.main.profile");
+        System.clearProperty("camel.main.profile");
+        catalog = ForageCatalogReader.getInstance();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (originalProfile != null) {
+            System.setProperty("camel.main.profile", originalProfile);
+        } else {
+            System.clearProperty("camel.main.profile");
+        }
+    }
+
+    @Test
+    void profilePropertiesDiscoveredViaSysProp() throws Exception {
+        writeFile("application-dev.properties", "forage.jdbc.db.kind=postgresql\n");
+        System.setProperty("camel.main.profile", "dev");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("postgresql");
+    }
+
+    @Test
+    void profileOverridesBase() throws Exception {
+        writeFile("application.properties", "forage.jdbc.db.kind=h2\n");
+        writeFile("application-dev.properties", "forage.jdbc.db.kind=postgresql\n");
+        System.setProperty("camel.main.profile", "dev");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("postgresql");
+    }
+
+    @Test
+    void profileOverridesBaseWithCorrectFileAttribution() throws Exception {
+        writeFile("application.properties", "forage.jdbc.db.kind=h2\nforage.jdbc.url=jdbc:h2:mem:test\n");
+        writeFile("application-dev.properties", "forage.jdbc.db.kind=postgresql\n");
+        System.setProperty("camel.main.profile", "dev");
+
+        Map<String, Map<String, List<PropertyOccurrence>>> result =
+                ForagePropertyScanner.scanPropertiesWithFileTracking(tempDir, catalog, false);
+
+        List<PropertyOccurrence> kindOccurrences = result.get("jdbc").get("db.kind");
+        assertThat(kindOccurrences).hasSize(1);
+        assertThat(kindOccurrences.get(0).value()).isEqualTo("postgresql");
+        assertThat(kindOccurrences.get(0).file().getName()).isEqualTo("application-dev.properties");
+
+        List<PropertyOccurrence> urlOccurrences = result.get("jdbc").get("url");
+        assertThat(urlOccurrences).hasSize(1);
+        assertThat(urlOccurrences.get(0).value()).isEqualTo("jdbc:h2:mem:test");
+        assertThat(urlOccurrences.get(0).file().getName()).isEqualTo("application.properties");
+    }
+
+    @Test
+    void profileFileOnlyWithoutApplicationProperties() throws Exception {
+        writeFile("application-dev.properties", "forage.jdbc.db.kind=mysql\n");
+        System.setProperty("camel.main.profile", "dev");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("mysql");
+    }
+
+    @Test
+    void missingProfileFileFallsBackToBase() throws Exception {
+        writeFile("application.properties", "forage.jdbc.db.kind=h2\n");
+        System.setProperty("camel.main.profile", "dev");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("h2");
+    }
+
+    @Test
+    void noProfileOnlyApplicationProperties() throws Exception {
+        writeFile("application.properties", "forage.jdbc.db.kind=h2\n");
+        writeFile("application-dev.properties", "forage.jdbc.db.kind=postgresql\n");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("h2");
+    }
+
+    @Test
+    void profileResolvedFromApplicationProperties() throws Exception {
+        writeFile("application.properties", "camel.main.profile=prod\nforage.jdbc.db.kind=h2\n");
+        writeFile("application-prod.properties", "forage.jdbc.db.kind=postgresql\n");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("postgresql");
+    }
+
+    @Test
+    void forageSpecificFilesStillWork() throws Exception {
+        writeFile("forage-jdbc.properties", "forage.jdbc.db.kind=postgresql\n");
+
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).containsKey("jdbc");
+        assertThat(result.get("jdbc").get("db.kind")).containsExactly("postgresql");
+    }
+
+    @Test
+    void noPropertiesFiles() throws Exception {
+        Map<String, Map<String, List<String>>> result = ForagePropertyScanner.scanProperties(tempDir, catalog);
+
+        assertThat(result).isEmpty();
+    }
+
+    private void writeFile(String name, String content) throws IOException {
+        File file = new File(tempDir, name);
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(content);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add profile-aware property scanning to `ForagePropertyScanner`, mirroring Camel's profile resolution: sys prop `camel.main.profile` → env var `CAMEL_MAIN_PROFILE` → `camel.main.profile` in `application.properties`
- Profile properties override base `application.properties` values with correct file attribution per property
- Propagate profile from `KameletMain` to the scanner via `ForagePlugin.beforeRun()`, so JBang's default `--profile dev` is visible to the scanner

## Test plan

- [x] Profile properties discovered via sys prop
- [x] Profile overrides base with correct file attribution
- [x] No profile set → only `application.properties` scanned
- [x] Profile resolved from `application.properties`
- [x] Profile file only (no `application.properties`) works
- [x] Missing profile file falls back to base
- [x] `forage-*.properties` files continue to work independently
- [x] All 53 tests pass (`mvn verify`)

Closes #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application profiles are now properly integrated and propagated into system configuration, enabling environment-specific behavior and customization options.
  * Property file loading has been enhanced to support profile-based configuration overrides, allowing profile-specific files to automatically supersede base properties.

* **Tests**
  * Comprehensive test coverage added for profile resolution, property file discovery, and configuration override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->