### PR TITLE
Fix #384: Make Shibboleth repo addition conditional via catalog metadata

### DIFF
--- a/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageBean.java
+++ b/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageBean.java
@@ -33,6 +33,9 @@ public class ForageBean {
     @JsonProperty("runtimeDependencies")
     private Map<String, List<String>> runtimeDependencies;
 
+    @JsonProperty("repositories")
+    private List<String> repositories;
+
     public ForageBean() {}
 
     public ForageBean(String name, String description, String className, String gav) {
@@ -96,6 +99,14 @@ public class ForageBean {
 
     public void setRuntimeDependencies(Map<String, List<String>> runtimeDependencies) {
         this.runtimeDependencies = runtimeDependencies;
+    }
+
+    public List<String> getRepositories() {
+        return repositories;
+    }
+
+    public void setRepositories(List<String> repositories) {
+        this.repositories = repositories;
     }
 
     @Override

--- a/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageCatalogReader.java
+++ b/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageCatalogReader.java
@@ -511,6 +511,36 @@ public final class ForageCatalogReader {
     }
 
     /**
+     * Gets additional Maven repository URLs declared by a bean.
+     *
+     * @param beanName the bean name (e.g., "soap")
+     * @return list of repository URLs, or empty list if none
+     */
+    public List<String> getBeanRepositories(String beanName) {
+        if (beanName == null) {
+            return List.of();
+        }
+
+        for (ForageFactory factory : catalog.getFactories()) {
+            List<FeatureBeans> beansByFeature = factory.getBeansByFeature();
+            if (beansByFeature == null) {
+                continue;
+            }
+            for (FeatureBeans featureBeans : beansByFeature) {
+                if (featureBeans.getBeans() == null) {
+                    continue;
+                }
+                for (ForageBean bean : featureBeans.getBeans()) {
+                    if (beanName.equalsIgnoreCase(bean.getName()) && bean.getRepositories() != null) {
+                        return bean.getRepositories();
+                    }
+                }
+            }
+        }
+        return List.of();
+    }
+
+    /**
      * Gets runtime dependencies for a bean in a specific variant.
      *
      * @param beanName the bean name (e.g., "postgresql", "artemis")

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/ForageBean.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/ForageBean.java
@@ -65,4 +65,12 @@ public @interface ForageBean {
      * @return array of variant-prefixed GAV strings
      */
     String[] runtimeDependencies() default {};
+
+    /**
+     * Additional Maven repository URLs required to resolve this bean's transitive dependencies.
+     * Only applied during {@code camel run} to configure KameletMain repositories.
+     *
+     * @return array of Maven repository URLs
+     */
+    String[] repositories() default {};
 }

--- a/library/cxf/forage-cxf-soap/src/main/java/io/kaoto/forage/cxf/soap/SoapEndpointProvider.java
+++ b/library/cxf/forage-cxf-soap/src/main/java/io/kaoto/forage/cxf/soap/SoapEndpointProvider.java
@@ -9,7 +9,8 @@ import io.kaoto.forage.cxf.common.CxfConfig;
         value = "soap",
         components = {"camel-cxf"},
         description = "Apache CXF SOAP (JAX-WS) endpoint",
-        feature = "org.apache.camel.component.cxf.jaxws.CxfEndpoint")
+        feature = "org.apache.camel.component.cxf.jaxws.CxfEndpoint",
+        repositories = {"https://build.shibboleth.net/maven/releases/"})
 public class SoapEndpointProvider implements CxfEndpointProvider {
 
     @Override

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
@@ -113,6 +113,43 @@ public class CatalogDrivenExportCustomizer implements ExportCustomizer {
         return dependencies;
     }
 
+    /**
+     * Resolves additional Maven repository URLs from the catalog for active beans.
+     * Used by {@link ForagePlugin} to conditionally add repos during {@code camel run}.
+     */
+    public Set<String> resolveRepositories() {
+        Set<String> repositories = new LinkedHashSet<>();
+        ForageCatalogReader catalog = ForageCatalogReader.getInstance();
+        Map<String, Map<String, List<String>>> properties = getScannedProperties();
+
+        for (String factoryTypeKey : properties.keySet()) {
+            Map<String, List<String>> factoryProperties = properties.get(factoryTypeKey);
+
+            catalog.getFactoryMetadata(factoryTypeKey).ifPresent(metadata -> {
+                if (metadata.configEntries() != null) {
+                    for (ConfigEntry entry : metadata.configEntries()) {
+                        if ("bean-name".equals(entry.getType())) {
+                            String propSuffix = extractPropertySuffix(entry.getName(), factoryTypeKey);
+                            if (propSuffix != null) {
+                                Set<String> beanKinds = findAllValues(factoryProperties, propSuffix);
+                                if (beanKinds.isEmpty()
+                                        && entry.getDefaultValue() != null
+                                        && !entry.getDefaultValue().isEmpty()) {
+                                    beanKinds = Set.of(entry.getDefaultValue());
+                                }
+                                for (String kind : beanKinds) {
+                                    repositories.addAll(catalog.getBeanRepositories(kind));
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        return repositories;
+    }
+
     private Map<String, Map<String, List<String>>> getScannedProperties() {
         if (scannedProperties == null) {
             try {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
@@ -123,28 +123,9 @@ public class CatalogDrivenExportCustomizer implements ExportCustomizer {
         Map<String, Map<String, List<String>>> properties = getScannedProperties();
 
         for (String factoryTypeKey : properties.keySet()) {
-            Map<String, List<String>> factoryProperties = properties.get(factoryTypeKey);
-
-            catalog.getFactoryMetadata(factoryTypeKey).ifPresent(metadata -> {
-                if (metadata.configEntries() != null) {
-                    for (ConfigEntry entry : metadata.configEntries()) {
-                        if ("bean-name".equals(entry.getType())) {
-                            String propSuffix = extractPropertySuffix(entry.getName(), factoryTypeKey);
-                            if (propSuffix != null) {
-                                Set<String> beanKinds = findAllValues(factoryProperties, propSuffix);
-                                if (beanKinds.isEmpty()
-                                        && entry.getDefaultValue() != null
-                                        && !entry.getDefaultValue().isEmpty()) {
-                                    beanKinds = Set.of(entry.getDefaultValue());
-                                }
-                                for (String kind : beanKinds) {
-                                    repositories.addAll(catalog.getBeanRepositories(kind));
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            for (io.kaoto.forage.catalog.model.ForageBean bean : catalog.getAllBeansForFactory(factoryTypeKey)) {
+                repositories.addAll(catalog.getBeanRepositories(bean.getName()));
+            }
         }
 
         return repositories;

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
@@ -74,12 +74,10 @@ public class ForagePlugin implements Plugin {
         });
     }
 
-    private static final String SHIBBOLETH_REPO = "https://build.shibboleth.net/maven/releases/";
-
     private void beforeRun(KameletMain main, List<String> files) {
         resolveConfigDir(files);
         propagateProfile(main);
-        addShibbolethRepo(main);
+        addCatalogDrivenRepos(main);
     }
 
     // JVM-global side effect: sets camel.main.profile so ForagePropertyScanner can resolve the
@@ -96,12 +94,24 @@ public class ForagePlugin implements Plugin {
         }
     }
 
-    private static void addShibbolethRepo(KameletMain main) {
+    private static void addCatalogDrivenRepos(KameletMain main) {
+        try {
+            CatalogDrivenExportCustomizer customizer = new CatalogDrivenExportCustomizer();
+            Set<String> repos = customizer.resolveRepositories();
+            for (String repoUrl : repos) {
+                addRepository(main, repoUrl);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to resolve catalog-driven repositories: {}", e.getMessage());
+        }
+    }
+
+    private static void addRepository(KameletMain main, String repoUrl) {
         String existing = main.getRepositories();
-        if (existing != null && existing.contains(SHIBBOLETH_REPO)) {
+        if (existing != null && existing.contains(repoUrl)) {
             return;
         }
-        String repos = existing == null || existing.isBlank() ? SHIBBOLETH_REPO : existing + "," + SHIBBOLETH_REPO;
+        String repos = existing == null || existing.isBlank() ? repoUrl : existing + "," + repoUrl;
         main.setRepositories(repos);
     }
 

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
@@ -548,6 +548,7 @@ public class CodeScanner {
         String feature = "";
         String configClassName = null;
         List<String> runtimeDeps = null;
+        List<String> repositories = null;
 
         // Extract annotation values
         if (annotation instanceof SingleMemberAnnotationExpr singleMember) {
@@ -578,6 +579,7 @@ public class CodeScanner {
                     }
                     case "configClass" -> configClassName = extractClassValue(value, cu);
                     case "runtimeDependencies" -> runtimeDeps = extractStringArrayValue(value);
+                    case "repositories" -> repositories = extractStringArrayValue(value);
                     default -> {}
                 }
             }
@@ -590,6 +592,9 @@ public class CodeScanner {
         bean.setConfigClassName(configClassName);
         if (runtimeDeps != null && !runtimeDeps.isEmpty()) {
             bean.setRuntimeDependencies(ScannedBean.parseVariantDependencies(runtimeDeps));
+        }
+        if (repositories != null && !repositories.isEmpty()) {
+            bean.setRepositories(repositories);
         }
         return bean;
     }

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/ScannedBean.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/ScannedBean.java
@@ -23,6 +23,7 @@ public class ScannedBean {
     private String feature;
     private String configClassName;
     private Map<String, List<String>> runtimeDependencies;
+    private List<String> repositories;
 
     public ScannedBean() {
         this.bean = new ForageBean();
@@ -117,6 +118,14 @@ public class ScannedBean {
         this.runtimeDependencies = runtimeDependencies;
     }
 
+    public List<String> getRepositories() {
+        return repositories;
+    }
+
+    public void setRepositories(List<String> repositories) {
+        this.repositories = repositories;
+    }
+
     /**
      * Parses "variant:gav" format strings into a variant->gavs map.
      */
@@ -148,6 +157,7 @@ public class ScannedBean {
         catalogBean.setClassName(bean.getClassName());
         catalogBean.setGav(gav);
         catalogBean.setRuntimeDependencies(runtimeDependencies);
+        catalogBean.setRepositories(repositories);
         return catalogBean;
     }
 


### PR DESCRIPTION
## Summary
- Added optional `repositories` attribute to `@ForageBean` annotation and catalog model
- `ForagePlugin.beforeRun()` now resolves repositories from the catalog based on active beans instead of unconditionally adding the Shibboleth repo
- Tagged `SoapEndpointProvider` with the Shibboleth repo URL — only users with CXF SOAP properties configured will have it added

## Test plan
- [x] Full build passes (`mvn clean install -DskipTests`)
- [x] Catalog output verified: SOAP bean has `repositories` field, no other beans do
- [ ] Run a non-CXF scenario (e.g., JDBC) with `camel run` and verify no Shibboleth repo requests in logs
- [ ] Run a CXF scenario and verify the Shibboleth repo IS added

Closes #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring Maven repositories at the component level within the catalog, allowing each component to specify custom repositories needed for dependency resolution.
  * Introduced catalog-driven repository resolution to dynamically configure repositories during runtime instead of using hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->