### PR TITLE
chore: fix unresolvable javadoc @link for AgentCreator in SimpleAgent

### DIFF
--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/simple/SimpleAgent.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/simple/SimpleAgent.java
@@ -20,7 +20,7 @@ import dev.langchain4j.service.tool.ToolProviderResult;
 /**
  * Simple implementation of an AI agent that provides basic chat functionality.
  *
- * <p>This class is a singleton shared across threads — it is created once by {@link AgentCreator}
+ * <p>This class is a singleton shared across threads — it is created once by {@link io.kaoto.forage.agent.AgentCreator}
  * and registered in the Camel registry. The {@link #configure(AgentConfiguration)} method is called
  * exactly once during creation; the configuration is immutable for the agent's lifetime.
  *


### PR DESCRIPTION
## Summary
- Fully qualify `{@link AgentCreator}` in `SimpleAgent` javadoc to `{@link io.kaoto.forage.agent.AgentCreator}` — the reference was unresolvable because `AgentCreator` is in the parent package and not imported, causing `maven-javadoc-plugin` to fail with exit code 1 during snapshot publishing.

## Test plan
- [x] Verified `mvn javadoc:jar` passes locally on `forage-agent` module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation references for consistency and clarity.

---

**Note:** This release contains only internal documentation improvements with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->