### PR TITLE
Add OSS Helper project rules and AI contribution guide section

### DIFF
--- a/.oss-ai-helper-rules/project-guidelines.md
+++ b/.oss-ai-helper-rules/project-guidelines.md
@@ -1,0 +1,22 @@
+# Project Guidelines
+
+This rule file contains branching, commit, PR, and task-finding conventions for the project. Commands read this file to determine how to name branches, format commits, and search for tasks.
+
+- **Fix branch:** `fix/<ISSUE_NUMBER>`
+- **Feature branch:** `feature/<ISSUE_NUMBER>-<short-slug>`
+- **Bugfix branch:** `bugfix/<ISSUE_NUMBER>`
+- **Quick-fix branch:** `quick-fix/<short-slug>`
+- **SonarCloud branch:** _(not configured)_
+- **Commit format (fix):** `Fix #<ISSUE_NUMBER>: <brief description>`
+- **Commit format (quick-fix):** `chore: <brief description>`
+- **CI-issue branch:** `ci-issue/<short-slug>`
+- **Commit format (ci-issue):** `ci: <brief description>`
+- **PR creation:** always
+- **Find-task source:** GitHub labels
+- **Find-task beginner label:** `good first issue`
+- **Find-task experienced label:** `help wanted`
+- **Find-task intermediate:** _(none)_
+- **Scope-too-large redirect:** `/oss-create-issue`
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/.oss-ai-helper-rules/project-info.md
+++ b/.oss-ai-helper-rules/project-info.md
@@ -1,0 +1,16 @@
+# Project Information
+
+This rule file contains project-specific metadata used by OSS Helper commands. Commands detect the current project by matching `git remote get-url origin` against the remote pattern below.
+
+- **Remote pattern:** `KaotoIO/forage`
+- **GitHub repo:** `KaotoIO/forage`
+- **Issue tracker:** GitHub
+- **Issue tracker URL:** `https://github.com/KaotoIO/forage/issues`
+- **Issue ID format:** numeric
+- **SonarCloud component key:** _(none)_
+- **Documentation URL:** _(none)_
+- **Related repositories:** _(none)_
+- **Create-issue supported:** yes
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/.oss-ai-helper-rules/project-standards.md
+++ b/.oss-ai-helper-rules/project-standards.md
@@ -1,0 +1,19 @@
+# Project Standards
+
+This rule file contains build tools, commands, and code style constraints for the project. Commands read this file to determine how to build, test, and format code.
+
+- **Build tool:** Maven
+- **Build command:** `mvn verify`
+- **Test command:** `mvn verify`
+- **Format command:** `cd <module> && mvn -DskipTests install`
+- **Module-specific build:** yes (always run `mvn` in the module directory where changes occurred)
+- **Parallelized Maven:** no (resource intensive, do NOT parallelize Maven jobs)
+- **Code style restrictions:**
+  - Do NOT use Lombok (unless already present in the file)
+  - Records are allowed for internal/non-API classes; do NOT convert existing public API classes to Records
+  - Do NOT change public API signatures without justification
+  - Do NOT add new dependencies without justification
+  - Maintain backwards compatibility for public APIs
+
+## Version
+9cff91b315de9587ebd2f353d255dd837190061c

--- a/README.md
+++ b/README.md
@@ -294,6 +294,15 @@ This project follows standard Maven conventions. To build:
 mvn clean install
 ```
 
+### AI-assisted contributions
+
+Contributors using AI coding assistants (such as [Claude Code](https://github.com/anthropics/claude-code) or similar tools) can take advantage of the project rules in the `.oss-ai-helper-rules/` directory and the `CLAUDE.md` file at the repository root.
+
+These files provide AI agents with project-specific context such as build commands, code style restrictions, branching conventions, issue tracker details, and contribution guidelines.
+They are maintained as part of the repository so that AI-assisted contributions follow the same standards as manual ones.
+
+The `.oss-ai-helper-rules/` files are designed for use with the [OSS Helper](https://github.com/Open-Harness-Engineering/ai-agents-oss-helper) toolset, which provides ready-made skills for common contribution tasks (fixing issues, creating PRs, running CI checks, and more).
+
 ### Integrating Apache Camel Components
 
 If you're developing Apache Camel components and want to integrate them with the Forage library, or if you want to create new providers for AI models, vector databases, or other services, please refer to our comprehensive [Contributing Beans Guide](docs/contributing-beans.md).


### PR DESCRIPTION
## Summary

- Add `.oss-ai-helper-rules/` directory with project-specific rules (project info, guidelines, and standards) for use with the [OSS Helper](https://github.com/Open-Harness-Engineering/ai-agents-oss-helper) toolset
- Add an "AI-assisted contributions" section to the README explaining the available tooling for AI-assisted contributions

These rules provide AI coding assistants with project-specific context (build commands, code style, branching conventions, issue tracker details) so that AI-assisted contributions follow the same standards as manual ones.

## Test plan

- [x] Verify `.oss-ai-helper-rules/` files contain correct project metadata
- [ ] Verify README renders correctly with the new section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project guidance files covering branching, commit/CI message formats, PR expectations, issue labeling, and scope limits.
  * Added project metadata and standards notes for build, test, formatting, and code-style expectations.
  * Updated the README with an AI-assisted contributions section pointing contributors to the project-specific rules.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->