### PR TITLE
Document both LTS and Latest version streams

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,10 @@ jobs:
           mvn -DskipTests -Darguments="-DskipTests" -Pdist -B --no-transfer-progress --file pom.xml -Dtag=v${{ github.event.inputs.releaseVersion }} -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform
 
       - name: Update docs version
+        env:
+          BRANCH: ${{ github.ref_name }}
+          VERSION: ${{ github.event.inputs.releaseVersion }}
         run: |
-          BRANCH="${{ github.ref_name }}"
-          VERSION="${{ github.event.inputs.releaseVersion }}"
-
           if [ "$BRANCH" = "main" ]; then
             sed -i "s/forage_version: \".*\"/forage_version: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,22 @@ jobs:
 
       - name: Update docs version
         run: |
-          sed -i 's/forage_version: ".*"/forage_version: "${{ github.event.inputs.releaseVersion }}"/' website/mkdocs.yml
-          git add website/mkdocs.yml
-          git commit -m "docs: update stable version to ${{ github.event.inputs.releaseVersion }}"
-          git push
+          BRANCH="${{ github.ref_name }}"
+          VERSION="${{ github.event.inputs.releaseVersion }}"
+
+          if [ "$BRANCH" = "main" ]; then
+            sed -i "s/forage_version: \".*\"/forage_version: \"${VERSION}\"/" website/mkdocs.yml
+            git add website/mkdocs.yml
+            git commit -m "docs: update LTS version to ${VERSION}"
+            git push
+          else
+            git fetch origin main
+            git checkout main -- website/mkdocs.yml
+            sed -i "s/forage_latest_version: \".*\"/forage_latest_version: \"${VERSION}\"/" website/mkdocs.yml
+            git add website/mkdocs.yml
+            git commit -m "docs: update latest version to ${VERSION}"
+            git push origin HEAD:main
+          fi
 
       # Create a release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - LangChain4j 1.x
 - Maven, Spotless (Palantir Java Format), JUnit 5, AssertJ, Testcontainers, Citrus Test Framework
 
+## Branching and Versioning Strategy
+
+Forage uses **major.minor.micro** versioning (`1.4.0`, `1.4.1`, `1.5.0`, etc.).
+
+| Branch | Tracks | Version | Description |
+|--------|--------|---------|-------------|
+| `main` | Apache Camel LTS | `1.4.x` | Follows the latest Camel LTS release (currently 4.18.x). Micro bumps (`1.4.0` → `1.4.1` → ...) for each release. |
+| `camel-latest` | Latest Apache Camel | `1.5.x` | Follows the latest Camel release (currently 4.20.x) with corresponding Spring Boot and Quarkus versions. |
+
+### Backporting
+
+When making changes (features, bug fixes, etc.), **always investigate whether the change needs backporting** to the other branch:
+- A fix on `main` may also apply to `camel-latest` and vice versa.
+- After completing work on one branch, check if the same change is relevant to the other branch and create a backport PR if needed.
+- Use `/oss-backport-pr` to automate backporting when applicable.
+
 ## Build Commands
 
 ```bash
@@ -211,10 +227,3 @@ See **[docs/adding-modules.md](docs/adding-modules.md)** for the complete guide 
 - Properties files named `<module-name>.properties` in resources
 - **Special cases:** `FlipRoutePolicyConfig` and `ScheduleRoutePolicyConfig` extend `AbstractConfig` and follow the standard configuration pattern. Their ConfigEntries classes (`FlipRoutePolicyConfigEntries`, `ScheduleRoutePolicyConfigEntries`) use a dynamic ConfigModule pattern with factory methods (e.g., `pairedRoute(prefix)`) instead of static fields + `initModules()`, because property names are route-ID-dependent.
 
-## Active Technologies
-- Java 17+ + Apache Camel 4.16+, camel-api (RoutePolicyFactory, RoutePolicy) (001-route-policies)
-- N/A (stateless policy configuration) (001-route-policies)
-- Java 17+ + Apache Camel 4.16+ (camel-api: RoutePolicyFactory, RoutePolicy, RoutePolicySupport) (001-route-policies)
-
-## Recent Changes
-- 001-route-policies: Added Java 17+ + Apache Camel 4.16+, camel-api (RoutePolicyFactory, RoutePolicy)

--- a/core/forage-catalog-model/pom.xml
+++ b/core/forage-catalog-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-catalog-model</artifactId>

--- a/core/forage-catalog-reader/pom.xml
+++ b/core/forage-catalog-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-catalog-reader</artifactId>

--- a/core/forage-core-ai/pom.xml
+++ b/core/forage-core-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-ai</artifactId>

--- a/core/forage-core-cloud/pom.xml
+++ b/core/forage-core-cloud/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-cloud</artifactId>

--- a/core/forage-core-common/pom.xml
+++ b/core/forage-core-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-common</artifactId>

--- a/core/forage-core-cxf/pom.xml
+++ b/core/forage-core-cxf/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-cxf</artifactId>

--- a/core/forage-core-guardrails/pom.xml
+++ b/core/forage-core-guardrails/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-guardrails</artifactId>

--- a/core/forage-core-jdbc/pom.xml
+++ b/core/forage-core-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-jdbc</artifactId>

--- a/core/forage-core-jms/pom.xml
+++ b/core/forage-core-jms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-jms</artifactId>

--- a/core/forage-core-jta/pom.xml
+++ b/core/forage-core-jta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-jta</artifactId>

--- a/core/forage-core-messaging/pom.xml
+++ b/core/forage-core-messaging/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-messaging</artifactId>

--- a/core/forage-core-policy/pom.xml
+++ b/core/forage-core-policy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-policy</artifactId>

--- a/core/forage-core-security/pom.xml
+++ b/core/forage-core-security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-security</artifactId>

--- a/core/forage-core-vectordb/pom.xml
+++ b/core/forage-core-vectordb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-vectordb</artifactId>

--- a/core/forage-core-vertx/pom.xml
+++ b/core/forage-core-vertx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>core</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-core-vertx</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-catalog</artifactId>

--- a/integration-tests/common/pom.xml
+++ b/integration-tests/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>integration-tests</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/cxf/pom.xml
+++ b/integration-tests/cxf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>integration-tests</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/jdbc/pom.xml
+++ b/integration-tests/jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>integration-tests</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/jms/pom.xml
+++ b/integration-tests/jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>integration-tests</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/messaging/pom.xml
+++ b/integration-tests/messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>integration-tests</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/library/ai/agents/camel-quarkus/deployment/pom.xml
+++ b/library/ai/agents/camel-quarkus/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agent-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-agent-deployment</artifactId>

--- a/library/ai/agents/camel-quarkus/pom.xml
+++ b/library/ai/agents/camel-quarkus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agents</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>agent-camel-quarkus</artifactId>

--- a/library/ai/agents/camel-quarkus/runtime/pom.xml
+++ b/library/ai/agents/camel-quarkus/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agent-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-agent</artifactId>

--- a/library/ai/agents/forage-agent-factories/pom.xml
+++ b/library/ai/agents/forage-agent-factories/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agents</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-agent-factories</artifactId>

--- a/library/ai/agents/forage-agent/pom.xml
+++ b/library/ai/agents/forage-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agents</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-agent</artifactId>

--- a/library/ai/agents/pom.xml
+++ b/library/ai/agents/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>agents</artifactId>

--- a/library/ai/agents/spring-boot/forage-agent-starter/pom.xml
+++ b/library/ai/agents/spring-boot/forage-agent-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agent-spring-boot</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-agent-starter</artifactId>

--- a/library/ai/agents/spring-boot/pom.xml
+++ b/library/ai/agents/spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>agents</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>agent-spring-boot</artifactId>

--- a/library/ai/chat-memory/forage-memory-infinispan/pom.xml
+++ b/library/ai/chat-memory/forage-memory-infinispan/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat-memory</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-memory-infinispan</artifactId>

--- a/library/ai/chat-memory/forage-memory-message-window/pom.xml
+++ b/library/ai/chat-memory/forage-memory-message-window/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat-memory</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-memory-message-window</artifactId>

--- a/library/ai/chat-memory/forage-memory-redis/pom.xml
+++ b/library/ai/chat-memory/forage-memory-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat-memory</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-memory-redis</artifactId>

--- a/library/ai/chat-memory/pom.xml
+++ b/library/ai/chat-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>chat-memory</artifactId>

--- a/library/ai/chat-memory/tests/forage-memory-tests-tck/pom.xml
+++ b/library/ai/chat-memory/tests/forage-memory-tests-tck/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>tests</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-memory-tests-tck</artifactId>

--- a/library/ai/chat-memory/tests/pom.xml
+++ b/library/ai/chat-memory/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat-memory</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/library/ai/guardrails/forage-guardrails-input/pom.xml
+++ b/library/ai/guardrails/forage-guardrails-input/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>guardrails</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-guardrails-input</artifactId>

--- a/library/ai/guardrails/forage-guardrails-output/pom.xml
+++ b/library/ai/guardrails/forage-guardrails-output/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>guardrails</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-guardrails-output</artifactId>

--- a/library/ai/guardrails/pom.xml
+++ b/library/ai/guardrails/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>guardrails</artifactId>

--- a/library/ai/models/chat/forage-model-anthropic/pom.xml
+++ b/library/ai/models/chat/forage-model-anthropic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-anthropic</artifactId>

--- a/library/ai/models/chat/forage-model-azure-openai/pom.xml
+++ b/library/ai/models/chat/forage-model-azure-openai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-azure-openai</artifactId>

--- a/library/ai/models/chat/forage-model-bedrock/pom.xml
+++ b/library/ai/models/chat/forage-model-bedrock/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-bedrock</artifactId>

--- a/library/ai/models/chat/forage-model-dashscope/pom.xml
+++ b/library/ai/models/chat/forage-model-dashscope/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-dashscope</artifactId>

--- a/library/ai/models/chat/forage-model-google-gemini/pom.xml
+++ b/library/ai/models/chat/forage-model-google-gemini/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-google-gemini</artifactId>

--- a/library/ai/models/chat/forage-model-hugging-face/pom.xml
+++ b/library/ai/models/chat/forage-model-hugging-face/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-hugging-face</artifactId>

--- a/library/ai/models/chat/forage-model-local-ai/pom.xml
+++ b/library/ai/models/chat/forage-model-local-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-local-ai</artifactId>

--- a/library/ai/models/chat/forage-model-mistral-ai/pom.xml
+++ b/library/ai/models/chat/forage-model-mistral-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-mistral-ai</artifactId>

--- a/library/ai/models/chat/forage-model-ollama/pom.xml
+++ b/library/ai/models/chat/forage-model-ollama/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-ollama</artifactId>

--- a/library/ai/models/chat/forage-model-open-ai/pom.xml
+++ b/library/ai/models/chat/forage-model-open-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-open-ai</artifactId>

--- a/library/ai/models/chat/forage-model-watsonx-ai/pom.xml
+++ b/library/ai/models/chat/forage-model-watsonx-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>chat</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-watsonx-ai</artifactId>

--- a/library/ai/models/chat/pom.xml
+++ b/library/ai/models/chat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>models</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>chat</artifactId>

--- a/library/ai/models/embeddings/forage-model-embeddings-ollama/pom.xml
+++ b/library/ai/models/embeddings/forage-model-embeddings-ollama/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>embeddings</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-model-embeddings-ollama</artifactId>

--- a/library/ai/models/embeddings/pom.xml
+++ b/library/ai/models/embeddings/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>models</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>embeddings</artifactId>

--- a/library/ai/models/pom.xml
+++ b/library/ai/models/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>models</artifactId>

--- a/library/ai/pom.xml
+++ b/library/ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ai</artifactId>

--- a/library/ai/rag/forage-default-retrieval-augmentor/pom.xml
+++ b/library/ai/rag/forage-default-retrieval-augmentor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>rag</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-default-retrieval-augmentor</artifactId>

--- a/library/ai/rag/pom.xml
+++ b/library/ai/rag/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>rag</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-chroma/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-chroma</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-default/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-default/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-default</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-in-memory-store/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-in-memory-store/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-in-memory-store</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-infinispan/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-infinispan/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-infinispan</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-mariadb/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-mariadb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-mariadb</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-milvus</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-neo4j</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-pgvector</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-pinecone</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-qdrant</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-redis/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-redis</artifactId>

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vectordbs</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vectordb-weaviate</artifactId>

--- a/library/ai/vector-dbs/pom.xml
+++ b/library/ai/vector-dbs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vectordbs</artifactId>

--- a/library/ai/web-search/forage-web-search-google-custom/pom.xml
+++ b/library/ai/web-search/forage-web-search-google-custom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>web-search</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-web-search-google-custom</artifactId>

--- a/library/ai/web-search/forage-web-search-tavily/pom.xml
+++ b/library/ai/web-search/forage-web-search-tavily/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>web-search</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-web-search-tavily</artifactId>

--- a/library/ai/web-search/forage-web-search/pom.xml
+++ b/library/ai/web-search/forage-web-search/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>web-search</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-web-search</artifactId>

--- a/library/ai/web-search/pom.xml
+++ b/library/ai/web-search/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>ai</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>web-search</artifactId>

--- a/library/cloud/forage-azure-eventhubs/pom.xml
+++ b/library/cloud/forage-azure-eventhubs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cloud</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-azure-eventhubs</artifactId>

--- a/library/cloud/pom.xml
+++ b/library/cloud/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloud</artifactId>

--- a/library/common/forage-spring-boot-common/pom.xml
+++ b/library/common/forage-spring-boot-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>common</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-spring-boot-common</artifactId>

--- a/library/common/pom.xml
+++ b/library/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/library/cxf/camel-quarkus/deployment/pom.xml
+++ b/library/cxf/camel-quarkus/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-cxf-deployment</artifactId>

--- a/library/cxf/camel-quarkus/pom.xml
+++ b/library/cxf/camel-quarkus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/library/cxf/camel-quarkus/runtime/pom.xml
+++ b/library/cxf/camel-quarkus/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-cxf</artifactId>

--- a/library/cxf/forage-cxf-common/pom.xml
+++ b/library/cxf/forage-cxf-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-cxf-common</artifactId>

--- a/library/cxf/forage-cxf-soap/pom.xml
+++ b/library/cxf/forage-cxf-soap/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-cxf-soap</artifactId>

--- a/library/cxf/forage-cxf/pom.xml
+++ b/library/cxf/forage-cxf/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-cxf</artifactId>

--- a/library/cxf/pom.xml
+++ b/library/cxf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cxf</artifactId>

--- a/library/cxf/spring-boot/forage-cxf-starter/pom.xml
+++ b/library/cxf/spring-boot/forage-cxf-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf-spring-boot</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-cxf-starter</artifactId>

--- a/library/cxf/spring-boot/pom.xml
+++ b/library/cxf/spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>cxf</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cxf-spring-boot</artifactId>

--- a/library/jdbc/camel-quarkus/jdbc/deployment/pom.xml
+++ b/library/jdbc/camel-quarkus/jdbc/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage-quarkus-jdbc-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-jdbc-deployment</artifactId>

--- a/library/jdbc/camel-quarkus/jdbc/pom.xml
+++ b/library/jdbc/camel-quarkus/jdbc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-jdbc-parent</artifactId>

--- a/library/jdbc/camel-quarkus/jdbc/runtime/pom.xml
+++ b/library/jdbc/camel-quarkus/jdbc/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage-quarkus-jdbc-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-jdbc</artifactId>

--- a/library/jdbc/camel-quarkus/pom.xml
+++ b/library/jdbc/camel-quarkus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/library/jdbc/forage-jdbc-common/pom.xml
+++ b/library/jdbc/forage-jdbc-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-common</artifactId>

--- a/library/jdbc/forage-jdbc-db2/pom.xml
+++ b/library/jdbc/forage-jdbc-db2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-db2</artifactId>

--- a/library/jdbc/forage-jdbc-h2/pom.xml
+++ b/library/jdbc/forage-jdbc-h2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-h2</artifactId>

--- a/library/jdbc/forage-jdbc-hsqldb/pom.xml
+++ b/library/jdbc/forage-jdbc-hsqldb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-hsqldb</artifactId>

--- a/library/jdbc/forage-jdbc-mariadb/pom.xml
+++ b/library/jdbc/forage-jdbc-mariadb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-mariadb</artifactId>

--- a/library/jdbc/forage-jdbc-mssql/pom.xml
+++ b/library/jdbc/forage-jdbc-mssql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-mssql</artifactId>

--- a/library/jdbc/forage-jdbc-mysql/pom.xml
+++ b/library/jdbc/forage-jdbc-mysql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-mysql</artifactId>

--- a/library/jdbc/forage-jdbc-oracle/pom.xml
+++ b/library/jdbc/forage-jdbc-oracle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-oracle</artifactId>

--- a/library/jdbc/forage-jdbc-postgresql/pom.xml
+++ b/library/jdbc/forage-jdbc-postgresql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-postgresql</artifactId>

--- a/library/jdbc/forage-jdbc-test/pom.xml
+++ b/library/jdbc/forage-jdbc-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-test</artifactId>

--- a/library/jdbc/forage-jdbc/pom.xml
+++ b/library/jdbc/forage-jdbc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc</artifactId>

--- a/library/jdbc/pom.xml
+++ b/library/jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/library/jdbc/spring-boot/forage-jdbc-starter/pom.xml
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>spring-boot</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jdbc-starter</artifactId>

--- a/library/jdbc/spring-boot/pom.xml
+++ b/library/jdbc/spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jdbc</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot</artifactId>

--- a/library/jms/camel-quarkus/deployment/pom.xml
+++ b/library/jms/camel-quarkus/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-jms-deployment</artifactId>

--- a/library/jms/camel-quarkus/pom.xml
+++ b/library/jms/camel-quarkus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/library/jms/camel-quarkus/runtime/pom.xml
+++ b/library/jms/camel-quarkus/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-jms</artifactId>

--- a/library/jms/forage-jms-artemis/pom.xml
+++ b/library/jms/forage-jms-artemis/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jms-artemis</artifactId>

--- a/library/jms/forage-jms-common/pom.xml
+++ b/library/jms/forage-jms-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jms-common</artifactId>

--- a/library/jms/forage-jms-ibmmq/pom.xml
+++ b/library/jms/forage-jms-ibmmq/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jms-ibmmq</artifactId>

--- a/library/jms/forage-jms/pom.xml
+++ b/library/jms/forage-jms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jms</artifactId>

--- a/library/jms/pom.xml
+++ b/library/jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jms</artifactId>

--- a/library/jms/spring-boot/forage-jms-starter/pom.xml
+++ b/library/jms/spring-boot/forage-jms-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms-spring-boot</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-jms-starter</artifactId>

--- a/library/jms/spring-boot/pom.xml
+++ b/library/jms/spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>jms</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jms-spring-boot</artifactId>

--- a/library/messaging/camel-quarkus/deployment/pom.xml
+++ b/library/messaging/camel-quarkus/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-spring-rabbitmq-deployment</artifactId>

--- a/library/messaging/camel-quarkus/pom.xml
+++ b/library/messaging/camel-quarkus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/library/messaging/camel-quarkus/runtime/pom.xml
+++ b/library/messaging/camel-quarkus/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging-camel-quarkus</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-quarkus-spring-rabbitmq</artifactId>

--- a/library/messaging/forage-spring-rabbitmq-common/pom.xml
+++ b/library/messaging/forage-spring-rabbitmq-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-spring-rabbitmq-common</artifactId>

--- a/library/messaging/forage-spring-rabbitmq/pom.xml
+++ b/library/messaging/forage-spring-rabbitmq/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-spring-rabbitmq</artifactId>

--- a/library/messaging/pom.xml
+++ b/library/messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>messaging</artifactId>

--- a/library/messaging/spring-boot/forage-spring-rabbitmq-starter/pom.xml
+++ b/library/messaging/spring-boot/forage-spring-rabbitmq-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging-spring-boot</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-spring-rabbitmq-starter</artifactId>

--- a/library/messaging/spring-boot/pom.xml
+++ b/library/messaging/spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>messaging</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>messaging-spring-boot</artifactId>

--- a/library/policy/forage-policy-factory/pom.xml
+++ b/library/policy/forage-policy-factory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>policy</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-policy-factory</artifactId>

--- a/library/policy/forage-policy-flip/pom.xml
+++ b/library/policy/forage-policy-flip/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>policy</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-policy-flip</artifactId>

--- a/library/policy/forage-policy-schedule/pom.xml
+++ b/library/policy/forage-policy-schedule/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>policy</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-policy-schedule</artifactId>

--- a/library/policy/pom.xml
+++ b/library/policy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>policy</artifactId>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>library</artifactId>

--- a/library/security/forage-security-keycloak/pom.xml
+++ b/library/security/forage-security-keycloak/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>security</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-security-keycloak</artifactId>

--- a/library/security/forage-security-shiro/pom.xml
+++ b/library/security/forage-security-shiro/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>security</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-security-shiro</artifactId>

--- a/library/security/forage-security-spring/pom.xml
+++ b/library/security/forage-security-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>security</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-security-spring</artifactId>

--- a/library/security/pom.xml
+++ b/library/security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>security</artifactId>

--- a/library/vertx/forage-vertx/pom.xml
+++ b/library/vertx/forage-vertx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>vertx</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-vertx</artifactId>

--- a/library/vertx/pom.xml
+++ b/library/vertx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>library</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Forage</name>
     <url>https://github.com/KaotoIO/forage</url>

--- a/tooling/camel-jbang-plugin-forage/pom.xml
+++ b/tooling/camel-jbang-plugin-forage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>tooling</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-jbang-plugin-forage</artifactId>

--- a/tooling/forage-maven-catalog-plugin/pom.xml
+++ b/tooling/forage-maven-catalog-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>tooling</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>forage-maven-catalog-plugin</artifactId>

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.kaoto.forage</groupId>
         <artifactId>forage</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tooling</artifactId>

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -5,15 +5,23 @@ Get up and running with Forage in minutes.
 ## Prerequisites
 
 - Java 17 or later
-- [Apache Camel {{ camel_version }}+](https://camel.apache.org/) with [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) installed
+- [Apache Camel](https://camel.apache.org/) with [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) installed
 
 ## Install the Forage Plugin
 
-Forage extends Camel JBang with the `forage` plugin. Install it once:
+Forage extends Camel JBang with the `forage` plugin. Install it once, using the version that matches your Camel release:
 
-```bash
-camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_version }}
-```
+=== "Camel LTS ({{ camel_lts_version }})"
+
+    ```bash
+    camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_version }}
+    ```
+
+=== "Camel Latest ({{ camel_latest_version }})"
+
+    ```bash
+    camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_latest_version }}
+    ```
 
 Verify the installation:
 

--- a/website/docs/guides/camel-jbang.md
+++ b/website/docs/guides/camel-jbang.md
@@ -4,9 +4,17 @@ The Forage plugin for [Camel JBang](https://camel.apache.org/manual/camel-jbang.
 
 ## Installation
 
-```bash
-camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_version }}
-```
+=== "Camel LTS ({{ camel_lts_version }})"
+
+    ```bash
+    camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_version }}
+    ```
+
+=== "Camel Latest ({{ camel_latest_version }})"
+
+    ```bash
+    camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_latest_version }}
+    ```
 
 ## Running Routes
 

--- a/website/docs/guides/troubleshooting.md
+++ b/website/docs/guides/troubleshooting.md
@@ -131,9 +131,17 @@ Unknown command: forage
 
 Install or reinstall the plugin:
 
-```bash
-camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_version }}
-```
+=== "Camel LTS ({{ camel_lts_version }})"
+
+    ```bash
+    camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_version }}
+    ```
+
+=== "Camel Latest ({{ camel_latest_version }})"
+
+    ```bash
+    camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:{{ forage_latest_version }}
+    ```
 
 Verify installation:
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -78,6 +78,17 @@ A complete AI agent with tool use in just two files:
     forage.myGraniteAgent.agent.base.url=http://localhost:11434
     ```
 
+## Versions
+
+Forage publishes two release streams so you can match your Apache Camel version:
+
+| Stream | Forage | Apache Camel | Description |
+|--------|--------|-------------|-------------|
+| **LTS** | {{ forage_version }} | {{ camel_lts_version }} | Tracks the Camel LTS line — recommended for production |
+| **Latest** | {{ forage_latest_version }} | {{ camel_latest_version }} | Tracks the newest Camel release |
+
+Pick the stream that matches the Camel version you use, then follow the [Getting Started](getting-started/index.md) guide.
+
 ## Getting Started
 
 Ready to dive in? Head to the [Getting Started](getting-started/index.md) guide.

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -45,6 +45,9 @@ theme:
 
 extra:
   forage_version: "1.3"
+  forage_latest_version: "1.5.0"
+  camel_lts_version: "4.18.2"
+  camel_latest_version: "4.20.0"
 
 extra_css:
   - stylesheets/extra.css

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -2,3 +2,4 @@ mkdocs==1.6.*
 mkdocs-material==9.*
 mkdocs-minify-plugin==0.8.*
 mkdocs-macros-plugin==1.5.*
+pygments<2.20


### PR DESCRIPTION
## Summary

- Add `forage_latest_version`, `camel_lts_version`, and `camel_latest_version` variables to mkdocs.yml
- Add a version compatibility table to the homepage
- Add Camel LTS / Camel Latest tabs for plugin install commands in getting-started, camel-jbang, and troubleshooting guides
- Make the release workflow branch-aware so `camel-latest` releases update the latest version on `main`
- Pin `pygments<2.20` to fix a regression in 2.20.0 that broke code blocks with blank lines

## Test plan

- [ ] Run `mkdocs serve` locally and verify version table on homepage
- [ ] Verify LTS/Latest tabs render correctly on getting-started, camel-jbang, and troubleshooting pages
- [ ] Verify docs CI build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version-stream guidance so users can choose the appropriate install path for LTS or Latest releases.
  * Added a versions overview to the site with clear release-stream references.

* **Documentation**
  * Updated setup, installation, and troubleshooting docs to show the matching plugin command for each release stream.
  * Expanded branching/versioning guidance in contributor docs.

* **Chores**
  * Bumped project versioning across the repository to the new patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->