### PR TITLE
[backport camel-latest] Fix #365: Remove unnecessary ForageConnectionFactory wrapper

### DIFF
--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/ForageConnectionFactory.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/ForageConnectionFactory.java
@@ -1,5 +1,0 @@
-package io.kaoto.forage.jms.common;
-
-import jakarta.jms.ConnectionFactory;
-
-public record ForageConnectionFactory(ConnectionFactory connectionFactory) {}

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -25,7 +25,6 @@ import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.jms.common.ConnectionFactoryCommonExportHelper;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
-import io.kaoto.forage.jms.common.ForageConnectionFactory;
 
 @ForageFactory(
         value = "JMS Connection",
@@ -130,8 +129,12 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
             for (String name : prefixes) {
                 if (camelContext.getRegistry().lookupByNameAndType(name, ConnectionFactory.class) == null) {
                     ConnectionFactoryConfig cfConfig = new ConnectionFactoryConfig(name);
-                    ForageConnectionFactory forageConnectionFactory = newConnectionFactory(cfConfig, name);
-                    camelContext.getRegistry().bind(name, forageConnectionFactory.connectionFactory());
+                    ConnectionFactory connectionFactory = newConnectionFactory(cfConfig, name);
+                    if (connectionFactory != null) {
+                        camelContext.getRegistry().bind(name, connectionFactory);
+                    } else {
+                        LOG.warn("Skipping binding for '{}' because ConnectionFactory creation returned null", name);
+                    }
                 }
             }
         } else {
@@ -141,11 +144,14 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
                     final List<ServiceLoader.Provider<ConnectionFactoryProvider>> providers =
                             findProviders(ConnectionFactoryProvider.class);
                     if (providers.size() == 1) {
-                        ForageConnectionFactory forageConnectionFactory =
-                                doCreateConnectionFactory(providers.get(0), null);
-                        camelContext
-                                .getRegistry()
-                                .bind(DEFAULT_CONNECTION_FACTORY, forageConnectionFactory.connectionFactory());
+                        ConnectionFactory connectionFactory = doCreateConnectionFactory(providers.get(0), null);
+                        if (connectionFactory != null) {
+                            camelContext.getRegistry().bind(DEFAULT_CONNECTION_FACTORY, connectionFactory);
+                        } else {
+                            LOG.warn(
+                                    "Skipping binding for '{}' because ConnectionFactory creation returned null",
+                                    DEFAULT_CONNECTION_FACTORY);
+                        }
                     } else {
                         throw new IllegalArgumentException(
                                 "No ConnectionFactory implementation is present in the classpath");
@@ -157,7 +163,7 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         }
     }
 
-    private synchronized ForageConnectionFactory newConnectionFactory(
+    private synchronized ConnectionFactory newConnectionFactory(
             ConnectionFactoryConfig connectionFactoryConfig, String name) {
         final String connectionFactoryProviderClass =
                 ConnectionFactoryCommonExportHelper.transformJmsKindIntoProviderClass(
@@ -178,10 +184,10 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         return doCreateConnectionFactory(connectionFactoryProvider, name);
     }
 
-    private ForageConnectionFactory doCreateConnectionFactory(
+    private ConnectionFactory doCreateConnectionFactory(
             ServiceLoader.Provider<ConnectionFactoryProvider> provider, String name) {
         final ConnectionFactoryProvider connectionFactoryProvider = provider.get();
-        return new ForageConnectionFactory(connectionFactoryProvider.create(name));
+        return connectionFactoryProvider.create(name);
     }
 
     @Override


### PR DESCRIPTION
## Backport of #375

Cherry-pick of #375 onto `camel-latest`.

**Original PR:** #375 - Fix #365: Remove unnecessary ForageConnectionFactory wrapper
**Original author:** @JiriOndrusek
**Target branch:** `camel-latest`

### Original description

fixes https://github.com/KaotoIO/forage/issues/365

The ForageConnectionFactory wrapper was unnecessary. It was a simple record that wrapped ConnectionFactory, which was immediately unwrapped at every usage point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The `ForageConnectionFactory` wrapper type has been removed, and configured JMS connection factories are now handled directly as raw `ConnectionFactory` instances.

* **Bug Fixes**
  * JMS connection factories are now bound directly, improving how configured connections are registered.
  * If a connection factory cannot be created for a configured prefix, it is now skipped with a warning instead of being bound incorrectly.
  * Default connection factory selection now follows the same direct binding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->