### PR TITLE
Fix #396: Include Camel, CSB, and CQ version information in catalog

### DIFF
--- a/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageCatalog.java
+++ b/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageCatalog.java
@@ -1,6 +1,7 @@
 package io.kaoto.forage.catalog.model;
 
 import java.util.List;
+import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -19,6 +20,9 @@ public class ForageCatalog {
 
     @JsonProperty("timestamp")
     private long timestamp;
+
+    @JsonProperty("runtimeVersions")
+    private Map<String, String> runtimeVersions;
 
     @JsonProperty("factories")
     private List<ForageFactory> factories;
@@ -47,6 +51,14 @@ public class ForageCatalog {
 
     public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public Map<String, String> getRuntimeVersions() {
+        return runtimeVersions;
+    }
+
+    public void setRuntimeVersions(Map<String, String> runtimeVersions) {
+        this.runtimeVersions = runtimeVersions;
     }
 
     public List<ForageFactory> getFactories() {

--- a/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageCatalogReader.java
+++ b/core/forage-catalog-reader/src/main/java/io/kaoto/forage/catalog/reader/ForageCatalogReader.java
@@ -684,6 +684,33 @@ public final class ForageCatalogReader {
                 .toList();
     }
 
+    /**
+     * Gets all runtime versions from the catalog.
+     *
+     * @return map of group ID to version string, or empty map if not available
+     */
+    public Map<String, String> getRuntimeVersions() {
+        Map<String, String> versions = catalog.getRuntimeVersions();
+        return versions != null ? Collections.unmodifiableMap(versions) : Collections.emptyMap();
+    }
+
+    /**
+     * Gets the runtime version for a specific group ID.
+     *
+     * @param groupId the group ID (e.g., "org.apache.camel")
+     * @return Optional containing the version string if found
+     */
+    public Optional<String> getRuntimeVersion(String groupId) {
+        if (groupId == null) {
+            return Optional.empty();
+        }
+        Map<String, String> versions = catalog.getRuntimeVersions();
+        if (versions == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(versions.get(groupId));
+    }
+
     // ─── Helper Methods ───────────────────────────────────────────────────
 
     /**

--- a/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageCatalogReaderTest.java
+++ b/core/forage-catalog-reader/src/test/java/io/kaoto/forage/catalog/reader/ForageCatalogReaderTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,11 @@ class ForageCatalogReaderTest {
               "version": "1.0-test",
               "generatedBy": "test",
               "timestamp": 1234567890,
+              "runtimeVersions": {
+                "org.apache.camel": "4.18.2",
+                "org.apache.camel.springboot": "4.18.2",
+                "org.apache.camel.extensions.quarkus": "3.33.0"
+              },
               "factories": [
                 {
                   "name": "JDBC DataSource Factory",
@@ -197,5 +203,35 @@ class ForageCatalogReaderTest {
         assertThat(metadata).isPresent();
         Optional<String> shortKey = metadata.get().getShortPrefixPropertyKey();
         assertThat(shortKey).isPresent().hasValue("jdbc.name");
+    }
+
+    @Test
+    void testGetRuntimeVersions() {
+        Map<String, String> versions = reader.getRuntimeVersions();
+        assertThat(versions).hasSize(3);
+        assertThat(versions).containsEntry("org.apache.camel", "4.18.2");
+        assertThat(versions).containsEntry("org.apache.camel.springboot", "4.18.2");
+        assertThat(versions).containsEntry("org.apache.camel.extensions.quarkus", "3.33.0");
+    }
+
+    @Test
+    void testGetRuntimeVersion() {
+        Optional<String> version = reader.getRuntimeVersion("org.apache.camel");
+        assertThat(version).isPresent().hasValue("4.18.2");
+
+        version = reader.getRuntimeVersion("org.apache.camel.extensions.quarkus");
+        assertThat(version).isPresent().hasValue("3.33.0");
+    }
+
+    @Test
+    void testGetRuntimeVersionNotFound() {
+        Optional<String> version = reader.getRuntimeVersion("org.unknown");
+        assertThat(version).isEmpty();
+    }
+
+    @Test
+    void testGetRuntimeVersionNull() {
+        Optional<String> version = reader.getRuntimeVersion(null);
+        assertThat(version).isEmpty();
     }
 }

--- a/core/forage-core-common/pom.xml
+++ b/core/forage-core-common/pom.xml
@@ -59,12 +59,14 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>**/forage-version.txt</include>
+                    <include>**/runtime-versions.properties</include>
                 </includes>
             </resource>
             <resource>
                 <directory>src/main/resources</directory>
                 <excludes>
                     <exclude>**/forage-version.txt</exclude>
+                    <exclude>**/runtime-versions.properties</exclude>
                 </excludes>
             </resource>
         </resources>

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/RuntimeVersionHelper.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/RuntimeVersionHelper.java
@@ -1,0 +1,33 @@
+package io.kaoto.forage.core.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * A utility class that provides runtime version information for Apache Camel,
+ * Camel Spring Boot, and Camel Extension for Quarkus.
+ */
+public final class RuntimeVersionHelper {
+
+    public static final Properties VERSIONS;
+
+    static {
+        VERSIONS = initVersions();
+    }
+
+    private RuntimeVersionHelper() {}
+
+    private static Properties initVersions() {
+        Properties props = new Properties();
+        try (InputStream stream = RuntimeVersionHelper.class.getResourceAsStream("/runtime-versions.properties")) {
+            if (stream == null) {
+                throw new IllegalStateException("Resource /runtime-versions.properties not found on classpath");
+            }
+            props.load(stream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return props;
+    }
+}

--- a/core/forage-core-common/src/main/resources/runtime-versions.properties
+++ b/core/forage-core-common/src/main/resources/runtime-versions.properties
@@ -1,0 +1,3 @@
+org.apache.camel=${camel.version}
+org.apache.camel.springboot=${camel-spring-boot.version}
+org.apache.camel.extensions.quarkus=${camel-quarkus.version}

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/common/RuntimeVersionHelperTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/common/RuntimeVersionHelperTest.java
@@ -1,0 +1,34 @@
+package io.kaoto.forage.core.common;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RuntimeVersionHelperTest {
+
+    @Test
+    void testVersionsAreLoaded() {
+        assertThat(RuntimeVersionHelper.VERSIONS).isNotNull();
+        assertThat(RuntimeVersionHelper.VERSIONS).isNotEmpty();
+    }
+
+    @Test
+    void testCamelVersionIsPresent() {
+        assertThat(RuntimeVersionHelper.VERSIONS.getProperty("org.apache.camel"))
+                .isNotNull()
+                .isNotEmpty();
+    }
+
+    @Test
+    void testCamelSpringBootVersionIsPresent() {
+        assertThat(RuntimeVersionHelper.VERSIONS.getProperty("org.apache.camel.springboot"))
+                .isNotNull()
+                .isNotEmpty();
+    }
+
+    @Test
+    void testCamelQuarkusVersionIsPresent() {
+        assertThat(RuntimeVersionHelper.VERSIONS.getProperty("org.apache.camel.extensions.quarkus"))
+                .isNotNull()
+                .isNotEmpty();
+    }
+}

--- a/tooling/camel-jbang-plugin-forage/src/main/resources/versions.properties
+++ b/tooling/camel-jbang-plugin-forage/src/main/resources/versions.properties
@@ -1,3 +1,6 @@
 project.version=@project.version@
-quarkus.version=@quarkus.version@
 camel.version=@camel.version@
+camel-spring-boot.version=@camel-spring-boot.version@
+camel-quarkus.version=@camel-quarkus.version@
+quarkus.version=@quarkus.version@
+spring-boot.version=@spring-boot.version@

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CatalogGenerator.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CatalogGenerator.java
@@ -72,6 +72,7 @@ public class CatalogGenerator {
         ForageCatalog catalog = new ForageCatalog();
         catalog.setVersion("2.0");
         catalog.setFactories(factories);
+        catalog.setRuntimeVersions(collectRuntimeVersions(project.getProperties()));
         catalog.setGeneratedBy("forage-maven-catalog-plugin");
         catalog.setTimestamp(System.currentTimeMillis());
 
@@ -658,6 +659,23 @@ public class CatalogGenerator {
         File outputFile = new File(outputDirectory, "forage-catalog.yaml");
         yamlObjectMapper.writeValue(outputFile, catalog);
         return outputFile;
+    }
+
+    private Map<String, String> collectRuntimeVersions(Properties projectProperties) {
+        Map<String, String> versions = new LinkedHashMap<>();
+        addVersionIfPresent(versions, projectProperties, "org.apache.camel", "camel.version");
+        addVersionIfPresent(versions, projectProperties, "org.apache.camel.springboot", "camel-spring-boot.version");
+        addVersionIfPresent(
+                versions, projectProperties, "org.apache.camel.extensions.quarkus", "camel-quarkus.version");
+        return versions;
+    }
+
+    private void addVersionIfPresent(
+            Map<String, String> versions, Properties properties, String key, String propertyName) {
+        String value = properties.getProperty(propertyName);
+        if (value != null && !value.isEmpty()) {
+            versions.put(key, value);
+        }
     }
 
     // Setters for configuration


### PR DESCRIPTION
## Summary

- Add Maven-filtered `runtime-versions.properties` to `forage-core-common` with Apache Camel, Camel Spring Boot, and Camel Extension for Quarkus version placeholders
- Create `RuntimeVersionHelper` class to load these versions at runtime
- Add `runtimeVersions` map to `ForageCatalog` model and populate it in `CatalogGenerator` from Maven project properties
- Expose `getRuntimeVersions()` and `getRuntimeVersion(groupId)` on `ForageCatalogReader`
- Update JBang plugin `versions.properties` with missing CSB, CQ, and Spring Boot versions

## Test plan

- [x] `RuntimeVersionHelperTest` verifies properties are loaded with non-empty values
- [x] `ForageCatalogReaderTest` verifies runtime version queries against test catalog JSON
- [x] Full reactor build passes
- [x] Generated catalog contains `runtimeVersions` field with correct values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime version information to catalog data, making version mappings available to downstream tools and readers.
  * Exposed APIs to retrieve all runtime versions or look up a specific runtime version.
  * Added packaged runtime version mappings for supported Camel-related runtimes and expanded version property support.

* **Bug Fixes**
  * Improved handling when runtime version data is missing or a lookup is invalid, returning empty results instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->