### PR TITLE
chore: add end-to-end test plans for Forage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,15 @@ forage/
 │   ├── cloud/                     # Cloud provider implementations
 │   └── vertx/                     # Vert.x implementations
 ├── integration-tests/              # Citrus-based integration tests
+├── tests/plans/                    # End-to-end test plans (Markdown)
+│   ├── common/                    # Shared procedures (container setup, forage-run)
+│   ├── jdbc-datasource.md         # JDBC DataSource provisioning
+│   ├── jms-messaging.md           # JMS ConnectionFactory provisioning
+│   ├── cxf-soap-endpoints.md      # CXF/SOAP endpoint provisioning
+│   ├── rabbitmq-connection.md     # Spring RabbitMQ provisioning
+│   ├── property-validation.md     # Property typo detection and --strict mode
+│   ├── config-commands.md         # camel forage config read/write
+│   └── route-policies.md          # Flip and schedule route policies
 ├── tooling/                        # Build tooling
 │   ├── camel-jbang-plugin-forage/ # Camel JBang plugin
 │   └── forage-maven-catalog-plugin/ # Catalog generation plugin
@@ -214,6 +223,25 @@ See **[docs/adding-modules.md](docs/adding-modules.md)** for the complete guide 
 - Spring Boot auto-configuration and bean registration
 - Quarkus `ConfigSourceFactory` and deployment processors
 - Integration testing with Citrus
+
+## Test Plans
+
+End-to-end test plans live in `tests/plans/`. Each plan creates a sample project (properties + YAML route), runs it via `camel run` or `camel forage run`, and verifies behavior. They test Forage as a user would use it — not by wrapping Maven unit tests.
+
+### Running a test plan
+
+```bash
+# Install the Forage JBang plugin (required once)
+mvn clean install -DskipTests
+FORAGE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+camel plugin add forage --gav io.kaoto.forage:camel-jbang-plugin-forage:${FORAGE_VERSION}
+
+# Then follow the phases in any test plan
+```
+
+Plans that require containers (JDBC, JMS, RabbitMQ) use `${CONTAINER_RUNTIME}` for Docker/Podman compatibility. Plans without containers (CXF, property validation, route policies, config commands) need only Java and Camel JBang.
+
+See **[docs/contributing-test-plans.md](docs/contributing-test-plans.md)** for the guide on writing new test plans.
 
 ## Development Guidelines
 

--- a/docs/contributing-test-plans.md
+++ b/docs/contributing-test-plans.md
@@ -25,6 +25,7 @@ Every plan must declare required tools in a prerequisites table:
 | `java` | 17+ | `java -version` |
 | `camel` (JBang) | 4.16+ | `camel version` |
 | `docker` or `podman` | any | `docker --version` or `podman --version` |
+| `mvn` | 3.9+ (for local builds) | `mvn -version` |
 
 The Forage plugin must be installed before running. See [common/forage-run.md](../tests/plans/common/forage-run.md) for installation instructions.
 
@@ -60,6 +61,7 @@ if grep -q "expected message" output.log; then
 else
   echo "FAIL: expected message not found"
   cat output.log
+  exit 1
 fi
 
 kill "${CAMEL_PID}" 2>/dev/null
@@ -168,8 +170,10 @@ Verify that invalid inputs are rejected:
 
 ```bash
 # Typo in property name + strict mode → should fail
-camel forage run --strict project/*
-if [ $? -ne 0 ]; then
+if camel forage run --strict project/*; then
+  echo "FAIL: strict mode accepted invalid properties"
+  exit 1
+else
   echo "PASS: strict mode rejected invalid properties"
 fi
 ```

--- a/docs/contributing-test-plans.md
+++ b/docs/contributing-test-plans.md
@@ -1,0 +1,216 @@
+# Writing Test Plans
+
+Test plans are Markdown documents under `tests/plans/` designed for execution by both humans and AI agents.
+
+## What a test plan tests
+
+Each test plan creates a **sample project** — a temporary directory with `forage-*.properties` and `.camel.yaml` route files — starts any required infrastructure (databases, brokers), runs the project with `camel run` or `camel forage run`, and verifies behavior by polling log output or making HTTP requests.
+
+Test plans do **not** wrap Maven unit tests. They exercise Forage the way a user actually uses it.
+
+## Structure
+
+A test plan has three layers:
+
+1. **Main plan** (`tests/plans/<name>.md`) — the test scenario with phases and assertions.
+2. **Common steps** (`tests/plans/common/*.md`) — reusable procedures shared across plans (container startup, Forage plugin installation).
+3. **Environment variables** — all configurable values declared upfront so the same plan works across versions and environments.
+
+## Prerequisites
+
+Every plan must declare required tools in a prerequisites table:
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+| `docker` or `podman` | any | `docker --version` or `podman --version` |
+
+The Forage plugin must be installed before running. See [common/forage-run.md](../tests/plans/common/forage-run.md) for installation instructions.
+
+## Phases, not scripts
+
+Organize tests into numbered phases that run sequentially. Each phase groups related assertions.
+
+```text
+Phase 0: Prerequisites
+Phase 1-N: Test scenarios (each creates a sample project, runs it, verifies)
+Phase N+1: Cleanup
+```
+
+## Every step must be verifiable
+
+Each step needs: a command, an expected outcome, and a PASS/FAIL assertion. Avoid steps that only run a command without checking the result.
+
+```bash
+# Bad — runs but doesn't verify
+camel run project/*
+
+# Good — runs, polls for output, asserts
+camel run project/* > output.log 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "expected message" output.log 2>/dev/null && break
+  sleep 1
+done
+
+if grep -q "expected message" output.log; then
+  echo "PASS: expected message found"
+else
+  echo "FAIL: expected message not found"
+  cat output.log
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+```
+
+## Sample project structure
+
+Every test creates its project in a temp directory:
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+# Properties file — configures Forage beans
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'EOF'
+forage.jdbc.db.kind=postgresql
+forage.jdbc.url=jdbc:postgresql://localhost:5432/testdb
+forage.jdbc.username=test
+forage.jdbc.password=test
+EOF
+
+# Route YAML — uses the Forage-created beans
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    id: my-route
+    from:
+      uri: timer:tick
+      parameters:
+        repeatCount: 1
+      steps:
+        - setBody:
+            simple:
+              expression: select * from bar
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: dataSource
+        - log:
+            message: "Result: ${body}"
+EOF
+```
+
+**YAML format note:** In Camel YAML DSL, `steps` must be nested **under** `from`, not as a sibling. This is a common mistake.
+
+## Container runtime support
+
+Test plans must work with both Docker and Podman. Use `${CONTAINER_RUNTIME}` instead of hardcoding `docker`:
+
+```bash
+if command -v podman > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=podman
+elif command -v docker > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=docker
+else
+  echo "FAIL: neither podman nor docker found"
+  exit 1
+fi
+
+${CONTAINER_RUNTIME} run -d --name my-container ...
+${CONTAINER_RUNTIME} exec my-container ...
+${CONTAINER_RUNTIME} rm -f my-container 2>/dev/null || true
+```
+
+## Prefer polling over sleeping
+
+Poll for expected output instead of using fixed `sleep` calls:
+
+```bash
+# Bad
+sleep 30
+grep "expected" output.log
+
+# Good — polling loop
+for i in $(seq 1 60); do
+  grep -q "expected" output.log 2>/dev/null && break
+  sleep 1
+done
+```
+
+## Parametrize versions and ports
+
+Never hard-code ports or versions. Use environment variables with defaults:
+
+```bash
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+ARTEMIS_PORT="${ARTEMIS_PORT:-61616}"
+```
+
+## Extract reusable steps into common docs
+
+If a procedure appears in more than one plan, move it to `tests/plans/common/`. Current common docs:
+
+- `common/forage-run.md` — JBang and Forage plugin installation, running projects
+- `common/start-container.md` — Starting PostgreSQL, Artemis, and RabbitMQ containers
+
+Reference common docs with a link:
+
+```markdown
+Follow [common/start-container.md#postgresql](common/start-container.md#postgresql).
+After completion, `POSTGRES_CONTAINER` and `POSTGRES_PORT` must be set.
+```
+
+## Include negative tests
+
+Verify that invalid inputs are rejected:
+
+```bash
+# Typo in property name + strict mode → should fail
+camel forage run --strict project/*
+if [ $? -ne 0 ]; then
+  echo "PASS: strict mode rejected invalid properties"
+fi
+```
+
+## Cleanup must be idempotent
+
+Use `2>/dev/null || true` on all cleanup commands:
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+${CONTAINER_RUNTIME} rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}" || true
+```
+
+## Shell compatibility
+
+Use POSIX-compatible constructs. Avoid bash-only features like `${!VAR}` (indirect expansion) since the executor may use zsh or sh.
+
+## End with a test summary
+
+Every plan ends with a summary table:
+
+```markdown
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | Critical |
+| 1 | 1.1 | Create H2 project | Critical |
+| 1 | 1.2 | Run and verify query result | Critical |
+```
+
+## Checklist for new plans
+
+- [ ] Creates a sample project (properties + YAML route) in a temp directory
+- [ ] Uses `camel run` or `camel forage run` — not `mvn test`
+- [ ] All configurable values are environment variables with defaults
+- [ ] Container commands use `${CONTAINER_RUNTIME}`, not hardcoded `docker`
+- [ ] Every step has a PASS/FAIL assertion
+- [ ] No fixed `sleep` — uses polling loops
+- [ ] `steps` is nested under `from` in YAML routes
+- [ ] Negative tests are included
+- [ ] Cleanup is idempotent
+- [ ] Shell constructs are POSIX-compatible
+- [ ] Ends with a test summary table

--- a/tests/plans/common/forage-run.md
+++ b/tests/plans/common/forage-run.md
@@ -7,6 +7,7 @@
 | `java` | 17+ | `java -version` |
 | `jbang` | 0.114+ | `jbang version` |
 | `camel` (JBang) | 4.16+ | `camel version` |
+| `mvn` | 3.9+ (for local builds) | `mvn -version` |
 
 ### Installing Camel JBang
 
@@ -22,7 +23,7 @@ The Forage plugin must be installed before `camel forage run` or automatic bean 
 
 **From a released version:**
 ```bash
-FORAGE_VERSION="${FORAGE_VERSION:-1.4.0}"
+FORAGE_VERSION="${FORAGE_VERSION:?set FORAGE_VERSION to the desired release}"
 camel plugin add forage \
   --gav io.kaoto.forage:camel-jbang-plugin-forage:${FORAGE_VERSION}
 ```
@@ -43,7 +44,7 @@ camel plugin add forage \
 
 **From snapshots:**
 ```bash
-FORAGE_SNAPSHOT_VERSION="${FORAGE_SNAPSHOT_VERSION:-1.4.0-SNAPSHOT}"
+FORAGE_SNAPSHOT_VERSION="${FORAGE_SNAPSHOT_VERSION:?set FORAGE_SNAPSHOT_VERSION to the desired snapshot}"
 camel plugin add forage \
   --repos=https://central.sonatype.com/repository/maven-snapshots/ \
   --gav io.kaoto.forage:camel-jbang-plugin-forage:${FORAGE_SNAPSHOT_VERSION}

--- a/tests/plans/common/forage-run.md
+++ b/tests/plans/common/forage-run.md
@@ -1,0 +1,158 @@
+# Common: Running a Forage Project
+
+## Prerequisites
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `jbang` | 0.114+ | `jbang version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+
+### Installing Camel JBang
+
+If Camel JBang is not installed:
+```bash
+jbang trust add https://github.com/apache/camel/
+jbang app install camel@apache/camel
+```
+
+### Installing the Forage Plugin
+
+The Forage plugin must be installed before `camel forage run` or automatic bean provisioning works. Without it, `camel run` will not discover Forage providers.
+
+**From a released version:**
+```bash
+FORAGE_VERSION="${FORAGE_VERSION:-1.4.0}"
+camel plugin add forage \
+  --gav io.kaoto.forage:camel-jbang-plugin-forage:${FORAGE_VERSION}
+```
+
+**From a local build (development/testing):**
+```bash
+# Build and install Forage into the local Maven repository
+cd "${FORAGE_REPO_ROOT}"
+mvn clean install -DskipTests -B
+
+# Read the version from the POM
+FORAGE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+# Install the plugin from the local repo
+camel plugin add forage \
+  --gav io.kaoto.forage:camel-jbang-plugin-forage:${FORAGE_VERSION}
+```
+
+**From snapshots:**
+```bash
+FORAGE_SNAPSHOT_VERSION="${FORAGE_SNAPSHOT_VERSION:-1.4.0-SNAPSHOT}"
+camel plugin add forage \
+  --repos=https://central.sonatype.com/repository/maven-snapshots/ \
+  --gav io.kaoto.forage:camel-jbang-plugin-forage:${FORAGE_SNAPSHOT_VERSION}
+```
+
+**Verify the plugin is installed:**
+```bash
+camel plugin list | grep -q forage
+if [ $? -eq 0 ]; then
+  echo "PASS: Forage plugin is installed"
+else
+  echo "FAIL: Forage plugin is not installed"
+  exit 1
+fi
+```
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FORAGE_REPO_ROOT` | `.` | Path to the Forage repository root (for local builds) |
+| `FORAGE_VERSION` | `1.4.0` | Forage version to install |
+
+### Running with snapshots
+
+When running routes with a snapshot version, Camel needs access to the snapshots repo for dependency resolution:
+```bash
+camel run --repos=https://central.sonatype.com/repository/maven-snapshots/ project/*
+```
+
+Or add to the project's properties file:
+```properties
+camel.jbang.repos=https://central.sonatype.com/repository/maven-snapshots/
+```
+
+---
+
+## Running a Forage project
+
+A Forage project is a directory containing:
+- One or more `forage-*.properties` files with `forage.*` configuration
+- One or more `.camel.yaml` route files
+
+### Option A: Run a directory
+
+```bash
+camel run myproject/*
+```
+
+The Forage plugin hooks in via SPI, discovers the properties files, and creates the beans automatically.
+
+### Option B: Run with explicit files
+
+```bash
+camel forage run route.camel.yaml
+```
+
+The `forage run` subcommand adds property validation before delegating to the standard `camel run`.
+
+### Running with validation
+
+```bash
+camel forage run --strict myproject/*
+```
+
+With `--strict`, any property validation warnings (typos, unknown keys) become fatal errors.
+
+## Verifying output
+
+Forage routes run as a foreground process. Verification is done by:
+
+1. **Log grepping** — run in background, wait for a log message, then kill:
+   ```bash
+   camel run project/* > output.log 2>&1 &
+   CAMEL_PID=$!
+
+   # Poll for expected log message
+   for i in $(seq 1 60); do
+     grep -q "EXPECTED_MESSAGE" output.log 2>/dev/null && break
+     sleep 1
+   done
+
+   grep -q "EXPECTED_MESSAGE" output.log
+   if [ $? -eq 0 ]; then
+     echo "PASS: expected message found in output"
+   else
+     echo "FAIL: expected message not found"
+     cat output.log
+   fi
+
+   kill "${CAMEL_PID}" 2>/dev/null
+   wait "${CAMEL_PID}" 2>/dev/null
+   ```
+
+2. **HTTP endpoint check** — if the route exposes an HTTP or CXF endpoint:
+   ```bash
+   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/path)
+   if [ "${HTTP_CODE}" = "200" ]; then
+     echo "PASS: endpoint reachable"
+   else
+     echo "FAIL: endpoint returned ${HTTP_CODE}"
+   fi
+   ```
+
+## Cleanup
+
+Always kill the Camel process and remove temporary files:
+```bash
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+rm -rf "${PROJECT_DIR}"
+```

--- a/tests/plans/common/start-container.md
+++ b/tests/plans/common/start-container.md
@@ -1,0 +1,139 @@
+# Common: Start a Container
+
+Reusable procedure for starting containerized infrastructure used by Forage test plans. Works with both Docker and Podman. Each section is self-contained — jump to the one you need.
+
+## Container Runtime Detection
+
+All test plans use the `CONTAINER_RUNTIME` variable. Set it before running any container commands:
+
+```bash
+if [ -z "${CONTAINER_RUNTIME}" ]; then
+  if command -v podman > /dev/null 2>&1; then
+    CONTAINER_RUNTIME=podman
+  elif command -v docker > /dev/null 2>&1; then
+    CONTAINER_RUNTIME=docker
+  else
+    echo "FAIL: neither podman nor docker found"
+    exit 1
+  fi
+fi
+
+echo "PASS: using container runtime: ${CONTAINER_RUNTIME}"
+```
+
+**Output variable:** `CONTAINER_RUNTIME` (`docker` or `podman`)
+
+---
+
+## PostgreSQL
+
+```bash
+POSTGRES_CONTAINER="forage-test-postgres"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+
+${CONTAINER_RUNTIME} run -d \
+  --name "${POSTGRES_CONTAINER}" \
+  -e POSTGRES_USER=test \
+  -e POSTGRES_PASSWORD=test \
+  -e POSTGRES_DB=testdb \
+  -p "${POSTGRES_PORT}:5432" \
+  postgres:14-alpine
+
+# Wait for ready
+for i in $(seq 1 30); do
+  ${CONTAINER_RUNTIME} exec "${POSTGRES_CONTAINER}" pg_isready -U test > /dev/null 2>&1 && break
+  sleep 1
+done
+
+${CONTAINER_RUNTIME} exec "${POSTGRES_CONTAINER}" pg_isready -U test > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: PostgreSQL is ready on port ${POSTGRES_PORT}"
+else
+  echo "FAIL: PostgreSQL did not become ready"
+  exit 1
+fi
+```
+
+**Output variables:** `POSTGRES_CONTAINER`, `POSTGRES_PORT`
+
+**Cleanup:**
+```bash
+${CONTAINER_RUNTIME} rm -f "${POSTGRES_CONTAINER}" 2>/dev/null || true
+```
+
+---
+
+## ActiveMQ Artemis
+
+```bash
+ARTEMIS_CONTAINER="forage-test-artemis"
+ARTEMIS_PORT="${ARTEMIS_PORT:-61616}"
+
+${CONTAINER_RUNTIME} run -d \
+  --name "${ARTEMIS_CONTAINER}" \
+  -e AMQ_USER=artemis \
+  -e AMQ_PASSWORD=artemis \
+  -p "${ARTEMIS_PORT}:61616" \
+  quay.io/artemiscloud/activemq-artemis-broker:latest
+
+# Wait for ready
+for i in $(seq 1 60); do
+  ${CONTAINER_RUNTIME} logs "${ARTEMIS_CONTAINER}" 2>&1 | grep -q "Server is now active" && break
+  sleep 1
+done
+
+${CONTAINER_RUNTIME} logs "${ARTEMIS_CONTAINER}" 2>&1 | grep -q "Server is now active"
+if [ $? -eq 0 ]; then
+  echo "PASS: Artemis is ready on port ${ARTEMIS_PORT}"
+else
+  echo "FAIL: Artemis did not become ready"
+  exit 1
+fi
+```
+
+**Output variables:** `ARTEMIS_CONTAINER`, `ARTEMIS_PORT`
+
+**Cleanup:**
+```bash
+${CONTAINER_RUNTIME} rm -f "${ARTEMIS_CONTAINER}" 2>/dev/null || true
+```
+
+---
+
+## RabbitMQ
+
+**Podman rootless note:** The standard RabbitMQ image may fail on Podman rootless with an Erlang cookie permission error. Set `RABBITMQ_ERLANG_COOKIE` to work around it.
+
+```bash
+RABBITMQ_CONTAINER="forage-test-rabbitmq"
+RABBITMQ_PORT="${RABBITMQ_PORT:-5672}"
+
+${CONTAINER_RUNTIME} run -d \
+  --name "${RABBITMQ_CONTAINER}" \
+  -e RABBITMQ_DEFAULT_USER=guest \
+  -e RABBITMQ_DEFAULT_PASS=guest \
+  -e RABBITMQ_ERLANG_COOKIE=forage-test-cookie \
+  -p "${RABBITMQ_PORT}:5672" \
+  rabbitmq:3-management-alpine
+
+# Wait for ready
+for i in $(seq 1 60); do
+  ${CONTAINER_RUNTIME} exec "${RABBITMQ_CONTAINER}" rabbitmqctl status > /dev/null 2>&1 && break
+  sleep 1
+done
+
+${CONTAINER_RUNTIME} exec "${RABBITMQ_CONTAINER}" rabbitmqctl status > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: RabbitMQ is ready on port ${RABBITMQ_PORT}"
+else
+  echo "FAIL: RabbitMQ did not become ready"
+  exit 1
+fi
+```
+
+**Output variables:** `RABBITMQ_CONTAINER`, `RABBITMQ_PORT`
+
+**Cleanup:**
+```bash
+${CONTAINER_RUNTIME} rm -f "${RABBITMQ_CONTAINER}" 2>/dev/null || true
+```

--- a/tests/plans/common/start-container.md
+++ b/tests/plans/common/start-container.md
@@ -50,6 +50,7 @@ if [ $? -eq 0 ]; then
   echo "PASS: PostgreSQL is ready on port ${POSTGRES_PORT}"
 else
   echo "FAIL: PostgreSQL did not become ready"
+  ${CONTAINER_RUNTIME} rm -f "${POSTGRES_CONTAINER}" 2>/dev/null || true
   exit 1
 fi
 ```
@@ -87,6 +88,7 @@ if [ $? -eq 0 ]; then
   echo "PASS: Artemis is ready on port ${ARTEMIS_PORT}"
 else
   echo "FAIL: Artemis did not become ready"
+  ${CONTAINER_RUNTIME} rm -f "${ARTEMIS_CONTAINER}" 2>/dev/null || true
   exit 1
 fi
 ```
@@ -127,6 +129,7 @@ if [ $? -eq 0 ]; then
   echo "PASS: RabbitMQ is ready on port ${RABBITMQ_PORT}"
 else
   echo "FAIL: RabbitMQ did not become ready"
+  ${CONTAINER_RUNTIME} rm -f "${RABBITMQ_CONTAINER}" 2>/dev/null || true
   exit 1
 fi
 ```

--- a/tests/plans/config-commands.md
+++ b/tests/plans/config-commands.md
@@ -4,7 +4,7 @@
 
 This test plan verifies Forage's `camel forage config read` and `camel forage config write` CLI commands. These commands are part of the Camel JBang plugin at `tooling/camel-jbang-plugin-forage`.
 
-- `config read` scans a directory for properties files, parses `forage.*` properties, and outputs a JSON list of detected beans with their configuration, kind, and Java type. It supports filtering by factory type (`--filter`), directory selection (`--dir`), and strategy selection (`--strategy`).
+- `config read` scans a directory for properties files, parses `forage.*` properties, and outputs a structured JSON object with `success`, `directory`, `beanCount`, and a `beans` array. It supports filtering by factory type (`--filter`), directory selection (`--dir`), and strategy selection (`--strategy`).
 - `config write` accepts JSON input (via `--input` or stdin), maps properties to factory types using the Forage catalog, and writes them to properties files. It prefixes properties with the bean name when `forage.bean.name` is provided.
 - `config write --delete` removes all `forage.{instanceName}.*` properties for a given `--name` and cleans up unused dependencies.
 

--- a/tests/plans/config-commands.md
+++ b/tests/plans/config-commands.md
@@ -1,0 +1,1285 @@
+# Test Plan: Config CLI Commands
+
+## Overview
+
+This test plan verifies Forage's `camel forage config read` and `camel forage config write` CLI commands. These commands are part of the Camel JBang plugin at `tooling/camel-jbang-plugin-forage`.
+
+- `config read` scans a directory for properties files, parses `forage.*` properties, and outputs a JSON list of detected beans with their configuration, kind, and Java type. It supports filtering by factory type (`--filter`), directory selection (`--dir`), and strategy selection (`--strategy`).
+- `config write` accepts JSON input (via `--input` or stdin), maps properties to factory types using the Forage catalog, and writes them to properties files. It prefixes properties with the bean name when `forage.bean.name` is provided.
+- `config write --delete` removes all `forage.{instanceName}.*` properties for a given `--name` and cleans up unused dependencies.
+
+Both commands output structured JSON (success/error) and return exit code 0 on success, 1 on error.
+
+**Important**: The existing unit tests (`ConfigReadCommandTest`, `ConfigWriteCommandTest`) are currently `@Disabled`. This plan tests the commands at the CLI level via `camel forage config read|write`. Flag names and JSON structures are derived from the current source code; verify they match the installed Camel JBang plugin version before execution.
+
+Every step is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+| `jq` | 1.6+ | `jq --version` |
+
+### Prerequisite check script
+
+```bash
+FAIL=0
+
+for CMD in java camel jq; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found at $(command -v ${CMD})"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo ""
+  echo "FAIL: one or more prerequisites missing"
+  exit 1
+fi
+
+echo ""
+echo "PASS: all prerequisites met"
+```
+
+### Camel JBang setup
+
+If Camel JBang is not installed:
+```bash
+jbang trust add https://github.com/apache/camel/
+jbang app install camel@apache/camel
+```
+
+The Forage plugin must be available to the Camel JBang runtime. Verify with:
+```bash
+camel forage --help
+```
+
+---
+
+## Phase 0: Prerequisites
+
+### Test 0.1: Verify tools
+
+```bash
+FAIL=0
+
+for CMD in java camel jq; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo "FAIL: prerequisites not met"
+  exit 1
+fi
+echo "PASS: all prerequisites met"
+```
+
+### Test 0.2: Verify Forage plugin is available
+
+```bash
+OUTPUT=$(camel forage --help 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: Forage plugin available"
+else
+  echo "FAIL: Forage plugin not available (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+```
+
+### Test 0.3: Verify config subcommand is available
+
+```bash
+OUTPUT=$(camel forage config --help 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: config subcommand available"
+else
+  echo "FAIL: config subcommand not available (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Config Read — No Properties Files
+
+### Test 1.1: Read from empty directory returns success with zero beans
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+BEAN_COUNT=$(echo "${OUTPUT}" | jq -r '.beanCount')
+MESSAGE=$(echo "${OUTPUT}" | jq -r '.message // empty')
+
+if [ "${SUCCESS}" = "true" ] && [ "${BEAN_COUNT}" = "0" ]; then
+  echo "PASS: empty directory returns success with 0 beans"
+else
+  echo "FAIL: unexpected result (success=${SUCCESS}, beanCount=${BEAN_COUNT})"
+  echo "${OUTPUT}"
+fi
+
+if echo "${MESSAGE}" | grep -qi "No Forage properties files found"; then
+  echo "PASS: message indicates no properties files found"
+else
+  echo "INFO: message was: ${MESSAGE}"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 1.2: Read from non-existent directory returns error
+
+```bash
+OUTPUT=$(camel forage config read --dir "/tmp/nonexistent-forage-dir-12345" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: config read failed for non-existent directory (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: config read returned success=false for non-existent directory"
+  else
+    echo "FAIL: config read should fail for non-existent directory"
+  fi
+fi
+```
+
+---
+
+## Phase 2: Config Read — Parse Beans from Properties
+
+### Test 2.1: Read detects JDBC bean from application.properties
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myPG.jdbc.username=test
+forage.myPG.jdbc.password=test
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+BEAN_COUNT=$(echo "${OUTPUT}" | jq -r '.beanCount')
+
+if [ "${SUCCESS}" = "true" ] && [ "${BEAN_COUNT}" -gt 0 ]; then
+  echo "PASS: detected ${BEAN_COUNT} bean(s)"
+else
+  echo "FAIL: expected success=true and beanCount > 0 (success=${SUCCESS}, beanCount=${BEAN_COUNT})"
+  echo "${OUTPUT}"
+fi
+
+# Verify the myPG bean is present with expected properties
+BEAN_NAME=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myPG") | .name')
+BEAN_KIND=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myPG") | .kind')
+
+if [ "${BEAN_NAME}" = "myPG" ]; then
+  echo "PASS: bean 'myPG' found"
+else
+  echo "FAIL: bean 'myPG' not found"
+  echo "${OUTPUT}" | jq '.beans'
+fi
+
+if [ "${BEAN_KIND}" = "postgresql" ]; then
+  echo "PASS: bean kind is 'postgresql'"
+else
+  echo "FAIL: expected kind 'postgresql', got '${BEAN_KIND}'"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 2.2: Read detects multiple beans of different factory types
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myH2.jdbc.db.kind=h2
+forage.myH2.jdbc.url=jdbc:h2:mem:test
+forage.myH2.jdbc.username=sa
+forage.myH2.jdbc.password=
+forage.myIBMMQ.jms.kind=ibmmq
+forage.myIBMMQ.jms.broker.url=127.0.0.1
+forage.myIBMMQ.jms.username=user
+forage.test.ollama.model.name=granite4:3b
+forage.test.ollama.log.requests=true
+forage.myMemory.infinispan.server-list=localhost:11223
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+BEAN_COUNT=$(echo "${OUTPUT}" | jq -r '.beanCount')
+
+if [ "${BEAN_COUNT}" -ge 4 ]; then
+  echo "PASS: detected ${BEAN_COUNT} beans (expected >= 4)"
+else
+  echo "FAIL: expected >= 4 beans, got ${BEAN_COUNT}"
+  echo "${OUTPUT}" | jq '.beans[].name'
+fi
+
+# Check each bean by name
+for EXPECTED_NAME in myH2 myIBMMQ test myMemory; do
+  FOUND=$(echo "${OUTPUT}" | jq -r ".beans[] | select(.name == \"${EXPECTED_NAME}\") | .name")
+  if [ "${FOUND}" = "${EXPECTED_NAME}" ]; then
+    echo "PASS: bean '${EXPECTED_NAME}' found"
+  else
+    echo "FAIL: bean '${EXPECTED_NAME}' not found"
+  fi
+done
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 2.3: Read includes configuration key-value pairs in output
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myH2.jdbc.db.kind=h2
+forage.myH2.jdbc.url=jdbc:h2:mem:test
+forage.myH2.jdbc.username=sa
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+URL_VALUE=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myH2") | .configuration.url')
+USERNAME_VALUE=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myH2") | .configuration.username')
+
+if [ "${URL_VALUE}" = "jdbc:h2:mem:test" ]; then
+  echo "PASS: configuration.url is correct"
+else
+  echo "FAIL: expected url 'jdbc:h2:mem:test', got '${URL_VALUE}'"
+fi
+
+if [ "${USERNAME_VALUE}" = "sa" ]; then
+  echo "PASS: configuration.username is correct"
+else
+  echo "FAIL: expected username 'sa', got '${USERNAME_VALUE}'"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 2.4: Read includes sourceFile in output
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myH2.jdbc.db.kind=h2
+forage.myH2.jdbc.url=jdbc:h2:mem:test
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+SOURCE_FILE=$(echo "${OUTPUT}" | jq -r '.beans[0].sourceFile')
+
+if echo "${SOURCE_FILE}" | grep -q "application.properties"; then
+  echo "PASS: sourceFile points to application.properties"
+else
+  echo "FAIL: unexpected sourceFile: ${SOURCE_FILE}"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 3: Config Read — Filter by Factory Type
+
+### Test 3.1: Filter shows only matching factory type
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myH2.jdbc.db.kind=h2
+forage.myH2.jdbc.url=jdbc:h2:mem:test
+forage.myH2.jdbc.username=sa
+forage.myIBMMQ.jms.kind=ibmmq
+forage.myIBMMQ.jms.broker.url=127.0.0.1
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application --filter jdbc 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read with --filter failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+# Should find H2 (jdbc) but not IBM MQ (jms)
+FOUND_H2=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myH2") | .name')
+FOUND_IBMMQ=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myIBMMQ") | .name')
+
+if [ "${FOUND_H2}" = "myH2" ]; then
+  echo "PASS: jdbc bean 'myH2' found with --filter jdbc"
+else
+  echo "FAIL: jdbc bean 'myH2' not found with --filter jdbc"
+fi
+
+if [ -z "${FOUND_IBMMQ}" ]; then
+  echo "PASS: jms bean 'myIBMMQ' correctly excluded by --filter jdbc"
+else
+  echo "FAIL: jms bean 'myIBMMQ' should not appear with --filter jdbc"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 3.2: Filter with non-matching type returns empty list
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myH2.jdbc.db.kind=h2
+forage.myH2.jdbc.url=jdbc:h2:mem:test
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application --filter jms 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+BEAN_COUNT=$(echo "${OUTPUT}" | jq -r '.beanCount')
+
+if [ "${BEAN_COUNT}" = "0" ]; then
+  echo "PASS: --filter jms returns 0 beans when only jdbc exists"
+else
+  echo "FAIL: expected 0 beans with --filter jms, got ${BEAN_COUNT}"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 4: Config Read — Conditional Beans
+
+### Test 4.1: Read detects conditional beans when features are enabled
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myPG.jdbc.username=test
+forage.myPG.jdbc.password=test
+forage.myPG.jdbc.transaction.enabled=true
+forage.myPG.jdbc.aggregation.repository.enabled=true
+forage.myPG.jdbc.idempotent.repository.enabled=true
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+COND_BEAN_COUNT=$(echo "${OUTPUT}" | jq '.beans[] | select(.name == "myPG") | .conditionalBeans | length')
+
+if [ "${COND_BEAN_COUNT}" -gt 0 ]; then
+  echo "PASS: found ${COND_BEAN_COUNT} conditional bean(s) for myPG"
+else
+  echo "FAIL: expected conditional beans for myPG with enabled features"
+fi
+
+# Check for PROPAGATION_REQUIRED
+FOUND_PROPAGATION=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "myPG") | .conditionalBeans[] | select(.name == "PROPAGATION_REQUIRED") | .name')
+if [ "${FOUND_PROPAGATION}" = "PROPAGATION_REQUIRED" ]; then
+  echo "PASS: PROPAGATION_REQUIRED conditional bean found"
+else
+  echo "FAIL: PROPAGATION_REQUIRED conditional bean not found"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 4.2: Read does not produce conditional beans when features are disabled
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myPG.jdbc.username=test
+forage.myPG.jdbc.password=test
+EOF
+
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+# Without transaction.enabled=true, no conditional beans should appear
+COND_BEANS=$(echo "${OUTPUT}" | jq '.beans[] | select(.name == "myPG") | .conditionalBeans // [] | length')
+
+if [ "${COND_BEANS}" = "0" ] || [ -z "${COND_BEANS}" ]; then
+  echo "PASS: no conditional beans when features are not enabled"
+else
+  echo "FAIL: unexpected conditional beans present (count=${COND_BEANS})"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 5: Config Write — Generate Properties from JSON
+
+### Test 5.1: Write JDBC PostgreSQL configuration
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+JSON_INPUT='{"forage.jdbc.db.kind":"postgresql","forage.jdbc.url":"jdbc:postgresql://localhost:5432/","forage.jdbc.username":"test","forage.jdbc.password":"test","kind":"postgresql","forage.bean.name":"myPG"}'
+
+OUTPUT=$(camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+if [ "${SUCCESS}" = "true" ]; then
+  echo "PASS: config write returned success"
+else
+  echo "FAIL: config write did not return success"
+  echo "${OUTPUT}"
+fi
+
+# Verify properties file was created
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+if [ -f "${PROPS_FILE}" ]; then
+  echo "PASS: application.properties created"
+else
+  echo "FAIL: application.properties not created"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+# Verify properties are prefixed with bean name
+grep -q "forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/" "${PROPS_FILE}" \
+  && echo "PASS: forage.myPG.jdbc.url is correct" \
+  || echo "FAIL: forage.myPG.jdbc.url not found or incorrect"
+
+grep -q "forage.myPG.jdbc.username=test" "${PROPS_FILE}" \
+  && echo "PASS: forage.myPG.jdbc.username is correct" \
+  || echo "FAIL: forage.myPG.jdbc.username not found or incorrect"
+
+grep -q "forage.myPG.jdbc.password=test" "${PROPS_FILE}" \
+  && echo "PASS: forage.myPG.jdbc.password is correct" \
+  || echo "FAIL: forage.myPG.jdbc.password not found or incorrect"
+
+grep -q "forage.myPG.jdbc.db.kind=postgresql" "${PROPS_FILE}" \
+  && echo "PASS: forage.myPG.jdbc.db.kind is correct" \
+  || echo "FAIL: forage.myPG.jdbc.db.kind not found or incorrect"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 5.2: Write JMS configuration
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+JSON_INPUT='{"forage.jms.kind":"ibmmq","forage.jms.broker.url":"127.0.0.1","forage.jms.username":"user","kind":"ibmmq","forage.bean.name":"myIBMMQ"}'
+
+OUTPUT=$(camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+grep -q "forage.myIBMMQ.jms.kind=ibmmq" "${PROPS_FILE}" \
+  && echo "PASS: forage.myIBMMQ.jms.kind is correct" \
+  || echo "FAIL: forage.myIBMMQ.jms.kind not found"
+
+grep -q "forage.myIBMMQ.jms.broker.url=127.0.0.1" "${PROPS_FILE}" \
+  && echo "PASS: forage.myIBMMQ.jms.broker.url is correct" \
+  || echo "FAIL: forage.myIBMMQ.jms.broker.url not found"
+
+grep -q "forage.myIBMMQ.jms.username=user" "${PROPS_FILE}" \
+  && echo "PASS: forage.myIBMMQ.jms.username is correct" \
+  || echo "FAIL: forage.myIBMMQ.jms.username not found"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 5.3: Write Ollama model configuration
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+JSON_INPUT='{"forage.ollama.model.name":"granite4:3b","forage.ollama.log.requests":"true","forage.ollama.log.responses":"true","kind":"ollama","forage.bean.name":"test"}'
+
+OUTPUT=$(camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+grep -q "forage.test.ollama.model.name=granite4:3b" "${PROPS_FILE}" \
+  && echo "PASS: forage.test.ollama.model.name is correct" \
+  || echo "FAIL: forage.test.ollama.model.name not found"
+
+grep -q "forage.test.ollama.log.requests=true" "${PROPS_FILE}" \
+  && echo "PASS: forage.test.ollama.log.requests is correct" \
+  || echo "FAIL: forage.test.ollama.log.requests not found"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 5.4: Write includes dependency information in output
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+JSON_INPUT='{"forage.jdbc.db.kind":"postgresql","forage.jdbc.url":"jdbc:postgresql://localhost:5432/","kind":"postgresql","forage.bean.name":"myPG"}'
+
+OUTPUT=$(camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# Verify dependency properties were written
+grep -q "camel.jbang.dependencies=.*forage-jdbc-postgresql" "${PROPS_FILE}" \
+  && echo "PASS: base dependency for forage-jdbc-postgresql written" \
+  || echo "FAIL: base dependency for forage-jdbc-postgresql not found"
+
+grep -q "camel.jbang.dependencies.main=.*forage-jdbc" "${PROPS_FILE}" \
+  && echo "PASS: main dependency for forage-jdbc written" \
+  || echo "FAIL: main dependency for forage-jdbc not found"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 6: Config Write — Merge with Existing Properties
+
+### Test 6.1: Write merges with existing properties without overwriting
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+# Pre-populate application.properties with existing content
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+# Existing configuration
+some.existing.property=value
+camel.jbang.dependencies=com.example:existing-lib:1.0
+EOF
+
+JSON_INPUT='{"forage.jdbc.db.kind":"postgresql","forage.jdbc.url":"jdbc:postgresql://localhost:5432/","kind":"postgresql","forage.bean.name":"myPG"}'
+
+OUTPUT=$(camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# Verify existing properties are preserved
+grep -q "some.existing.property=value" "${PROPS_FILE}" \
+  && echo "PASS: existing property preserved" \
+  || echo "FAIL: existing property was overwritten or removed"
+
+# Verify existing dependency is preserved along with new one
+grep -q "com.example:existing-lib:1.0" "${PROPS_FILE}" \
+  && echo "PASS: existing dependency preserved" \
+  || echo "FAIL: existing dependency was removed"
+
+grep -q "forage-jdbc-postgresql" "${PROPS_FILE}" \
+  && echo "PASS: new forage dependency added" \
+  || echo "FAIL: new forage dependency not added"
+
+# Verify new forage properties are present
+grep -q "forage.myPG.jdbc.url" "${PROPS_FILE}" \
+  && echo "PASS: new forage properties written" \
+  || echo "FAIL: new forage properties not written"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 6.2: Sequential writes accumulate configurations
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+# First write: JDBC
+JSON_INPUT_1='{"forage.jdbc.db.kind":"postgresql","forage.jdbc.url":"jdbc:postgresql://localhost:5432/","kind":"postgresql","forage.bean.name":"myPG"}'
+camel forage config write --input "${JSON_INPUT_1}" --dir "${PROJECT_DIR}" --strategy application 2>&1
+
+# Second write: JMS
+JSON_INPUT_2='{"forage.jms.kind":"artemis","forage.jms.broker.url":"tcp://localhost:61616","forage.jms.username":"admin","kind":"artemis","forage.bean.name":"myArtemis"}'
+OUTPUT=$(camel forage config write --input "${JSON_INPUT_2}" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: second config write failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# Verify both configurations exist
+grep -q "forage.myPG.jdbc.url" "${PROPS_FILE}" \
+  && echo "PASS: JDBC properties preserved after second write" \
+  || echo "FAIL: JDBC properties lost after second write"
+
+grep -q "forage.myArtemis.jms.broker.url" "${PROPS_FILE}" \
+  && echo "PASS: JMS properties written" \
+  || echo "FAIL: JMS properties not written"
+
+# Verify dependencies contain both
+grep -q "forage-jdbc-postgresql" "${PROPS_FILE}" \
+  && echo "PASS: JDBC dependency preserved" \
+  || echo "FAIL: JDBC dependency lost"
+
+grep -q "forage-jms-artemis" "${PROPS_FILE}" \
+  && echo "PASS: JMS dependency added" \
+  || echo "FAIL: JMS dependency not added"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 7: Config Write — Error Handling
+
+### Test 7.1: Write with empty input returns error
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+OUTPUT=$(camel forage config write --input "" --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: config write with empty input failed (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: config write returned success=false for empty input"
+  else
+    echo "FAIL: config write should fail for empty input"
+  fi
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 7.2: Write with empty JSON object returns error
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+OUTPUT=$(camel forage config write --input '{}' --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: config write with empty JSON failed (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: config write returned success=false for empty JSON"
+  else
+    echo "FAIL: config write should fail for empty JSON"
+  fi
+fi
+
+ERROR_MSG=$(echo "${OUTPUT}" | jq -r '.error // empty')
+if echo "${ERROR_MSG}" | grep -qi "Empty configuration"; then
+  echo "PASS: error message indicates empty configuration"
+else
+  echo "INFO: error message was: ${ERROR_MSG}"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 7.3: Write with invalid JSON returns error
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+OUTPUT=$(camel forage config write --input 'not-valid-json' --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: config write with invalid JSON failed (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success // empty')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: config write returned success=false for invalid JSON"
+  else
+    echo "FAIL: config write should fail for invalid JSON"
+  fi
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 8: Config Write Delete — Remove Instance Configuration
+
+### Test 8.1: Delete removes single instance properties
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+# PostgreSQL configuration
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myPG.jdbc.username=test
+forage.myPG.jdbc.password=test
+EOF
+
+OUTPUT=$(camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write --delete failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+OPERATION=$(echo "${OUTPUT}" | jq -r '.operation')
+
+if [ "${SUCCESS}" = "true" ] && [ "${OPERATION}" = "delete" ]; then
+  echo "PASS: delete returned success with operation=delete"
+else
+  echo "FAIL: unexpected result (success=${SUCCESS}, operation=${OPERATION})"
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# Verify forage.myPG.* properties are removed
+if grep -q "forage.myPG" "${PROPS_FILE}"; then
+  echo "FAIL: forage.myPG properties still present"
+else
+  echo "PASS: forage.myPG properties removed"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 8.2: Delete preserves other instances
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myPG.jdbc.username=pguser
+forage.myMariaDB.jdbc.db.kind=mariadb
+forage.myMariaDB.jdbc.url=jdbc:mariadb://localhost:3306/
+forage.myMariaDB.jdbc.username=mariauser
+EOF
+
+OUTPUT=$(camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write --delete failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# Verify myPG is gone
+if grep -q "forage.myPG" "${PROPS_FILE}"; then
+  echo "FAIL: forage.myPG properties still present"
+else
+  echo "PASS: forage.myPG properties removed"
+fi
+
+# Verify myMariaDB is preserved
+grep -q "forage.myMariaDB.jdbc.db.kind=mariadb" "${PROPS_FILE}" \
+  && echo "PASS: forage.myMariaDB properties preserved" \
+  || echo "FAIL: forage.myMariaDB properties were removed"
+
+grep -q "forage.myMariaDB.jdbc.url=jdbc:mariadb://localhost:3306/" "${PROPS_FILE}" \
+  && echo "PASS: forage.myMariaDB.jdbc.url preserved" \
+  || echo "FAIL: forage.myMariaDB.jdbc.url removed"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 8.3: Delete preserves other factory type configurations
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myArtemis.jms.kind=artemis
+forage.myArtemis.jms.broker.url=tcp://localhost:61616
+forage.myArtemis.jms.username=admin
+EOF
+
+OUTPUT=$(camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config write --delete failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# Verify myPG is gone
+if grep -q "forage.myPG" "${PROPS_FILE}"; then
+  echo "FAIL: forage.myPG properties still present"
+else
+  echo "PASS: forage.myPG properties removed"
+fi
+
+# Verify JMS config is preserved
+grep -q "forage.myArtemis.jms.kind=artemis" "${PROPS_FILE}" \
+  && echo "PASS: JMS configuration preserved after JDBC delete" \
+  || echo "FAIL: JMS configuration removed by JDBC delete"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 8.4: Delete non-existent instance returns error
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+EOF
+
+OUTPUT=$(camel forage config write --delete --name nonExistent --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: delete non-existent instance failed (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: delete non-existent instance returned success=false"
+  else
+    echo "FAIL: delete non-existent instance should fail"
+  fi
+fi
+
+ERROR_MSG=$(echo "${OUTPUT}" | jq -r '.error // empty')
+if echo "${ERROR_MSG}" | grep -qi "No configuration found"; then
+  echo "PASS: error message indicates no configuration found"
+else
+  echo "INFO: error message was: ${ERROR_MSG}"
+fi
+
+# Verify original properties are unchanged
+grep -q "forage.myPG.jdbc.db.kind=postgresql" "${PROJECT_DIR}/application.properties" \
+  && echo "PASS: original properties unchanged" \
+  || echo "FAIL: original properties were modified"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 8.5: Delete without --name returns error
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.url=test
+EOF
+
+OUTPUT=$(camel forage config write --delete --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: delete without --name failed (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: delete without --name returned success=false"
+  else
+    echo "FAIL: delete without --name should fail"
+  fi
+fi
+
+ERROR_MSG=$(echo "${OUTPUT}" | jq -r '.error // empty')
+if echo "${ERROR_MSG}" | grep -qi "Instance name.*required"; then
+  echo "PASS: error message indicates instance name is required"
+else
+  echo "INFO: error message was: ${ERROR_MSG}"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 8.6: Delete from non-existent file returns error
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+# No application.properties file exists
+
+OUTPUT=$(camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: delete from non-existent file failed (exit code ${EXIT_CODE})"
+else
+  SUCCESS=$(echo "${OUTPUT}" | jq -r '.success')
+  if [ "${SUCCESS}" = "false" ]; then
+    echo "PASS: delete from non-existent file returned success=false"
+  else
+    echo "FAIL: delete from non-existent file should fail"
+  fi
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 9: Config Write Delete — Dependency Cleanup
+
+### Test 9.1: Delete last instance removes its dependencies
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myPG.jdbc.username=test
+camel.jbang.dependencies=io.kaoto.forage:forage-jdbc-postgresql:0.0.0
+camel.jbang.dependencies.main=io.kaoto.forage:forage-jdbc:0.0.0
+camel.jbang.dependencies.spring-boot=io.kaoto.forage:forage-jdbc-starter:0.0.0
+camel.jbang.dependencies.quarkus=io.kaoto.forage:forage-quarkus-jdbc-deployment:0.0.0
+EOF
+
+camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: delete failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# After deleting the only JDBC instance, JDBC dependencies should be removed
+if grep -q "forage-jdbc-postgresql" "${PROPS_FILE}"; then
+  echo "FAIL: forage-jdbc-postgresql dependency still present after last instance deleted"
+else
+  echo "PASS: forage-jdbc-postgresql dependency removed"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 9.2: Delete one of multiple same-factory instances preserves shared dependencies
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+forage.myMariaDB.jdbc.db.kind=mariadb
+forage.myMariaDB.jdbc.url=jdbc:mariadb://localhost:3306/
+camel.jbang.dependencies=io.kaoto.forage:forage-jdbc-postgresql:0.0.0,io.kaoto.forage:forage-jdbc-mariadb:0.0.0
+camel.jbang.dependencies.main=io.kaoto.forage:forage-jdbc:0.0.0
+camel.jbang.dependencies.spring-boot=io.kaoto.forage:forage-jdbc-starter:0.0.0
+camel.jbang.dependencies.quarkus=io.kaoto.forage:forage-quarkus-jdbc-deployment:0.0.0
+EOF
+
+camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: delete failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+# MariaDB still uses jdbc factory, so factory-level dependencies must be preserved
+grep -q "forage-jdbc-mariadb" "${PROPS_FILE}" \
+  && echo "PASS: MariaDB bean dependency preserved" \
+  || echo "FAIL: MariaDB bean dependency removed"
+
+grep -q "camel.jbang.dependencies.main" "${PROPS_FILE}" \
+  && echo "PASS: main dependency preserved (MariaDB still uses jdbc)" \
+  || echo "FAIL: main dependency removed despite MariaDB still present"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 9.3: Delete preserves non-forage dependencies
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/application.properties" <<'EOF'
+forage.myPG.jdbc.db.kind=postgresql
+forage.myPG.jdbc.url=jdbc:postgresql://localhost:5432/
+camel.jbang.dependencies=com.example:custom-lib:1.0,io.kaoto.forage:forage-jdbc-postgresql:0.0.0
+camel.jbang.dependencies.main=com.example:custom-main:1.0,io.kaoto.forage:forage-jdbc:0.0.0
+EOF
+
+camel forage config write --delete --name myPG --dir "${PROJECT_DIR}" --strategy application 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: delete failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+PROPS_FILE="${PROJECT_DIR}/application.properties"
+
+grep -q "com.example:custom-lib:1.0" "${PROPS_FILE}" \
+  && echo "PASS: custom base dependency preserved" \
+  || echo "FAIL: custom base dependency removed"
+
+grep -q "com.example:custom-main:1.0" "${PROPS_FILE}" \
+  && echo "PASS: custom main dependency preserved" \
+  || echo "FAIL: custom main dependency removed"
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 10: Round-Trip — Write Then Read
+
+### Test 10.1: Write configuration and verify read parses it correctly
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+JSON_INPUT='{"forage.jdbc.db.kind":"postgresql","forage.jdbc.url":"jdbc:postgresql://localhost:5432/testdb","forage.jdbc.username":"admin","forage.jdbc.password":"secret","kind":"postgresql","forage.bean.name":"roundTrip"}'
+
+# Write
+camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1
+
+# Read
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read after write failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+BEAN_NAME=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "roundTrip") | .name')
+BEAN_KIND=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "roundTrip") | .kind')
+URL_VALUE=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "roundTrip") | .configuration.url')
+
+if [ "${BEAN_NAME}" = "roundTrip" ]; then
+  echo "PASS: round-trip bean name correct"
+else
+  echo "FAIL: round-trip bean name not found"
+  echo "${OUTPUT}" | jq '.beans'
+fi
+
+if [ "${BEAN_KIND}" = "postgresql" ]; then
+  echo "PASS: round-trip bean kind correct"
+else
+  echo "FAIL: expected kind 'postgresql', got '${BEAN_KIND}'"
+fi
+
+if [ "${URL_VALUE}" = "jdbc:postgresql://localhost:5432/testdb" ]; then
+  echo "PASS: round-trip URL value correct"
+else
+  echo "FAIL: expected URL 'jdbc:postgresql://localhost:5432/testdb', got '${URL_VALUE}'"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 10.2: Write, delete, then read confirms instance is gone
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+# Write
+JSON_INPUT='{"forage.jdbc.db.kind":"postgresql","forage.jdbc.url":"jdbc:postgresql://localhost:5432/","kind":"postgresql","forage.bean.name":"toDelete"}'
+camel forage config write --input "${JSON_INPUT}" --dir "${PROJECT_DIR}" --strategy application 2>&1
+
+# Delete
+camel forage config write --delete --name toDelete --dir "${PROJECT_DIR}" --strategy application 2>&1
+
+# Read
+OUTPUT=$(camel forage config read --dir "${PROJECT_DIR}" --strategy application 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: config read after delete failed (exit code ${EXIT_CODE})"
+  rm -rf "${PROJECT_DIR}"
+  exit 1
+fi
+
+BEAN_COUNT=$(echo "${OUTPUT}" | jq -r '.beanCount')
+FOUND=$(echo "${OUTPUT}" | jq -r '.beans[] | select(.name == "toDelete") | .name')
+
+if [ -z "${FOUND}" ]; then
+  echo "PASS: deleted instance 'toDelete' no longer appears in read output"
+else
+  echo "FAIL: deleted instance 'toDelete' still appears in read output"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 11: Cleanup
+
+No persistent state is created. All tests use `mktemp -d` and clean up via `rm -rf "${PROJECT_DIR}"`.
+
+```bash
+echo "PASS: all temporary directories cleaned up by individual tests"
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1-0.3 | Prerequisites and plugin availability | Critical |
+| 1 | 1.1-1.2 | Read with no/non-existent directory | High |
+| 2 | 2.1-2.4 | Read parses beans, properties, sourceFile | Critical |
+| 3 | 3.1-3.2 | Read filter by factory type | High |
+| 4 | 4.1-4.2 | Read conditional beans (enabled/disabled) | High |
+| 5 | 5.1-5.4 | Write JDBC, JMS, Ollama, dependencies | Critical |
+| 6 | 6.1-6.2 | Write merge with existing, sequential writes | Critical |
+| 7 | 7.1-7.3 | Write error handling (empty, invalid JSON) | High |
+| 8 | 8.1-8.6 | Delete instance, preserves others, error cases | Critical |
+| 9 | 9.1-9.3 | Delete dependency cleanup | High |
+| 10 | 10.1-10.2 | Round-trip write-read, write-delete-read | Critical |
+| 11 | 11 | Cleanup | Low |

--- a/tests/plans/cxf-soap-endpoints.md
+++ b/tests/plans/cxf-soap-endpoints.md
@@ -1,0 +1,650 @@
+# Test Plan: CXF SOAP Endpoint Provisioning
+
+## Overview
+
+This test plan verifies that Forage correctly provisions CXF SOAP endpoints from properties files. Tests create sample projects with `forage-cxf.properties` and Camel YAML routes, run them with `camel run`, and verify that the CXF server starts, handles SOAP requests, and responds correctly.
+
+Forage reads `forage.cxf.*` settings (address, data format, logging) and creates a CXF endpoint bean registered in the Camel context. Routes reference endpoints as `cxf:bean:<name>`.
+
+This plan covers:
+- Default (unnamed) CXF endpoint provisioning
+- Named CXF endpoints for multi-bean configurations
+- CXF message logging feature
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+| `curl` | any | `curl --version` |
+| `grep` | any | `grep --version` |
+
+No Docker required -- CXF starts its own embedded HTTP server via Camel JBang.
+
+### Prerequisite check
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+curl --version > /dev/null 2>&1
+CURL_EXIT=$?
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ] && [ "${CURL_EXIT}" -eq 0 ]; then
+  echo "PASS: all prerequisites met"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT}, curl=${CURL_EXIT})"
+  exit 1
+fi
+```
+
+### Environment variables
+
+```bash
+export CXF_SERVER_PORT="${CXF_SERVER_PORT:-8080}"
+export CXF_SERVER_ADDRESS="http://localhost:${CXF_SERVER_PORT}/services/hello"
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CXF_SERVER_PORT` | `8080` | Port for the CXF embedded HTTP server |
+| `CXF_SERVER_ADDRESS` | `http://localhost:8080/services/hello` | Full address for the CXF SOAP endpoint |
+
+---
+
+## Phase 0: Prerequisites
+
+Verify all required tools are present and at the correct versions.
+
+### Test 0.1: Verify required tools
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+curl --version > /dev/null 2>&1
+CURL_EXIT=$?
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ] && [ "${CURL_EXIT}" -eq 0 ]; then
+  echo "PASS: all required tools present"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT}, curl=${CURL_EXIT})"
+  exit 1
+fi
+```
+
+### Test 0.2: Verify Java version is 17+
+
+```bash
+JAVA_VERSION=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]*\).*/\1/')
+if [ "${JAVA_VERSION}" -ge 17 ]; then
+  echo "PASS: Java version ${JAVA_VERSION} >= 17"
+else
+  echo "FAIL: Java version ${JAVA_VERSION} < 17"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: CXF SOAP Server (Default Endpoint)
+
+Create a temporary project with a default (unnamed) CXF endpoint, run it, and verify the server processes a SOAP request end-to-end.
+
+The default bean name is `cxfEndpoint` when no prefix/name is used in the properties.
+
+### Test 1.1: Create project directory and files
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-cxf.properties" << 'PROPS'
+forage.cxf.address=http://localhost:8080/services/hello
+forage.cxf.data.format=PAYLOAD
+forage.cxf.logging.enabled=false
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" << 'ROUTE'
+- route:
+    id: cxf-soap-server
+    streamCaching: false
+    from:
+      uri: cxf:bean:cxfEndpoint
+      steps:
+        - log:
+            message: "Server received request"
+        - setBody:
+            constant:
+              expression: >
+                <sayHelloResponse xmlns="http://example.com/hello"><greeting>Hello from CXF</greeting></sayHelloResponse>
+        - log:
+            message: "Server sending response"
+- route:
+    id: cxf-soap-caller
+    from:
+      uri: timer
+      parameters:
+        timerName: soap-caller
+        repeatCount: 1
+        delay: 5000
+      steps:
+        - setBody:
+            constant:
+              expression: >
+                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soap:Body>
+                    <sayHello xmlns="http://example.com/hello"><name>Forage</name></sayHello>
+                  </soap:Body>
+                </soap:Envelope>
+        - setHeader:
+            name: CamelHttpMethod
+            constant:
+              expression: POST
+        - setHeader:
+            name: Content-Type
+            constant:
+              expression: text/xml
+        - to:
+            uri: "http://localhost:8080/services/hello"
+        - log:
+            message: "Response: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-cxf.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: project files created in ${PROJECT_DIR}"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 1.2: Start Camel with Forage in background
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+
+sleep 2
+kill -0 "${CAMEL_PID}" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "PASS: Camel process ${CAMEL_PID} is running"
+else
+  echo "FAIL: Camel process ${CAMEL_PID} is not running"
+  cat "${PROJECT_DIR}/output.log"
+  exit 1
+fi
+```
+
+### Test 1.3: Wait for server response in logs
+
+```bash
+FOUND=false
+for i in $(seq 1 60); do
+  grep -q "Response:" "${PROJECT_DIR}/output.log" 2>/dev/null && { FOUND=true; break; }
+  sleep 1
+done
+
+if [ "${FOUND}" = "true" ]; then
+  echo "PASS: response logged within timeout"
+else
+  echo "FAIL: response not found in logs within 60 seconds"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 1.4: Verify response contains expected SOAP body
+
+```bash
+grep "Response:" "${PROJECT_DIR}/output.log" | grep -q "Hello from CXF"
+if [ $? -eq 0 ]; then
+  echo "PASS: response contains 'Hello from CXF'"
+else
+  echo "FAIL: response does not contain expected greeting"
+  grep "Response:" "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 1.5: Verify server received the request
+
+```bash
+grep -q "Server received request" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: server logged incoming request"
+else
+  echo "FAIL: server did not log incoming request"
+fi
+```
+
+### Test 1.6: Verify external curl call to SOAP endpoint
+
+```bash
+CURL_RESPONSE=$(curl -s -X POST "http://localhost:${CXF_SERVER_PORT}/services/hello" \
+  -H "Content-Type: text/xml" \
+  -d '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <sayHello xmlns="http://example.com/hello">
+            <name>CurlTest</name>
+          </sayHello>
+        </soap:Body>
+      </soap:Envelope>' 2>/dev/null)
+
+echo "${CURL_RESPONSE}" | grep -q "Hello from CXF"
+if [ $? -eq 0 ]; then
+  echo "PASS: curl SOAP call returned expected response"
+else
+  echo "FAIL: curl SOAP call did not return expected response"
+  echo "Response: ${CURL_RESPONSE}"
+fi
+```
+
+### Test 1.7: Stop Camel and cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+
+kill -0 "${CAMEL_PID}" 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "PASS: Camel process ${CAMEL_PID} stopped"
+else
+  echo "FAIL: Camel process ${CAMEL_PID} still running"
+fi
+
+rm -rf "${PROJECT_DIR}" || true
+```
+
+---
+
+## Phase 2: Named CXF Endpoints
+
+Create a project with named CXF beans (`helloServer`, `helloClient`), verifying that Forage creates separate named beans and routes can reference them individually.
+
+### Test 2.1: Create project directory and files
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-cxf.properties" << 'PROPS'
+# Server endpoint (named bean)
+forage.helloServer.cxf.address=http://localhost:8080/services/hello
+forage.helloServer.cxf.data.format=PAYLOAD
+
+# Client endpoint (named bean)
+forage.helloClient.cxf.address=http://localhost:8080/services/hello
+forage.helloClient.cxf.data.format=PAYLOAD
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" << 'ROUTE'
+- route:
+    id: cxf-named-server
+    streamCaching: false
+    from:
+      uri: cxf:bean:helloServer
+      steps:
+        - log:
+            message: "Server received SOAP request"
+        - setBody:
+            constant:
+              expression: >
+                <sayHelloResponse xmlns="http://example.com/hello"><greeting>Hello from named CXF server</greeting></sayHelloResponse>
+        - log:
+            message: "Server sending SOAP response"
+- route:
+    id: cxf-named-caller
+    from:
+      uri: timer
+      parameters:
+        timerName: soap-caller
+        repeatCount: 1
+        delay: 5000
+      steps:
+        - setBody:
+            constant:
+              expression: >
+                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soap:Body>
+                    <sayHello xmlns="http://example.com/hello"><name>Forage</name></sayHello>
+                  </soap:Body>
+                </soap:Envelope>
+        - setHeader:
+            name: CamelHttpMethod
+            constant:
+              expression: POST
+        - setHeader:
+            name: Content-Type
+            constant:
+              expression: text/xml
+        - to:
+            uri: "http://localhost:8080/services/hello"
+        - log:
+            message: "Client received response: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-cxf.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: named endpoints project files created in ${PROJECT_DIR}"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 2.2: Start Camel with named endpoints
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+
+sleep 2
+kill -0 "${CAMEL_PID}" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "PASS: Camel process ${CAMEL_PID} is running"
+else
+  echo "FAIL: Camel process ${CAMEL_PID} is not running"
+  cat "${PROJECT_DIR}/output.log"
+  exit 1
+fi
+```
+
+### Test 2.3: Wait for client response in logs
+
+```bash
+FOUND=false
+for i in $(seq 1 60); do
+  grep -q "Client received response:" "${PROJECT_DIR}/output.log" 2>/dev/null && { FOUND=true; break; }
+  sleep 1
+done
+
+if [ "${FOUND}" = "true" ]; then
+  echo "PASS: client response logged within timeout"
+else
+  echo "FAIL: client response not found in logs within 60 seconds"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.4: Verify named server received request
+
+```bash
+grep -q "Server received SOAP request" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: named server logged incoming request"
+else
+  echo "FAIL: named server did not log incoming request"
+fi
+```
+
+### Test 2.5: Verify response contains named server greeting
+
+```bash
+grep "Client received response:" "${PROJECT_DIR}/output.log" | grep -q "Hello from named CXF server"
+if [ $? -eq 0 ]; then
+  echo "PASS: response contains 'Hello from named CXF server'"
+else
+  echo "FAIL: response does not contain expected named server greeting"
+  grep "Client received response:" "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.6: Verify external curl call to named server endpoint
+
+```bash
+CURL_RESPONSE=$(curl -s -X POST "http://localhost:${CXF_SERVER_PORT}/services/hello" \
+  -H "Content-Type: text/xml" \
+  -d '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <sayHello xmlns="http://example.com/hello">
+            <name>CurlNamedTest</name>
+          </sayHello>
+        </soap:Body>
+      </soap:Envelope>' 2>/dev/null)
+
+echo "${CURL_RESPONSE}" | grep -q "Hello from named CXF server"
+if [ $? -eq 0 ]; then
+  echo "PASS: curl call to named server returned expected response"
+else
+  echo "FAIL: curl call to named server did not return expected response"
+  echo "Response: ${CURL_RESPONSE}"
+fi
+```
+
+### Test 2.7: Stop Camel and cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+
+kill -0 "${CAMEL_PID}" 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "PASS: Camel process ${CAMEL_PID} stopped"
+else
+  echo "FAIL: Camel process ${CAMEL_PID} still running"
+fi
+
+rm -rf "${PROJECT_DIR}" || true
+```
+
+---
+
+## Phase 3: CXF with Logging Enabled
+
+Same as Phase 1 but with `forage.cxf.logging.enabled=true`. Verifies that CXF's message interceptor logging appears in the output.
+
+### Test 3.1: Create project directory and files
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-cxf.properties" << 'PROPS'
+forage.cxf.address=http://localhost:8080/services/hello
+forage.cxf.data.format=PAYLOAD
+forage.cxf.logging.enabled=true
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" << 'ROUTE'
+- route:
+    id: cxf-soap-server-logging
+    streamCaching: false
+    from:
+      uri: cxf:bean:cxfEndpoint
+      steps:
+        - log:
+            message: "Server received request"
+        - setBody:
+            constant:
+              expression: >
+                <sayHelloResponse xmlns="http://example.com/hello"><greeting>Hello from CXF with logging</greeting></sayHelloResponse>
+        - log:
+            message: "Server sending response"
+- route:
+    id: cxf-soap-caller-logging
+    from:
+      uri: timer
+      parameters:
+        timerName: soap-caller
+        repeatCount: 1
+        delay: 5000
+      steps:
+        - setBody:
+            constant:
+              expression: >
+                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+                  <soap:Body>
+                    <sayHello xmlns="http://example.com/hello"><name>Forage</name></sayHello>
+                  </soap:Body>
+                </soap:Envelope>
+        - setHeader:
+            name: CamelHttpMethod
+            constant:
+              expression: POST
+        - setHeader:
+            name: Content-Type
+            constant:
+              expression: text/xml
+        - to:
+            uri: "http://localhost:8080/services/hello"
+        - log:
+            message: "Response: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-cxf.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: logging project files created in ${PROJECT_DIR}"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 3.2: Start Camel with logging enabled
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+
+sleep 2
+kill -0 "${CAMEL_PID}" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "PASS: Camel process ${CAMEL_PID} is running"
+else
+  echo "FAIL: Camel process ${CAMEL_PID} is not running"
+  cat "${PROJECT_DIR}/output.log"
+  exit 1
+fi
+```
+
+### Test 3.3: Wait for server response in logs
+
+```bash
+FOUND=false
+for i in $(seq 1 60); do
+  grep -q "Response:" "${PROJECT_DIR}/output.log" 2>/dev/null && { FOUND=true; break; }
+  sleep 1
+done
+
+if [ "${FOUND}" = "true" ]; then
+  echo "PASS: response logged within timeout"
+else
+  echo "FAIL: response not found in logs within 60 seconds"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 3.4: Verify response contains expected SOAP body
+
+```bash
+grep "Response:" "${PROJECT_DIR}/output.log" | grep -q "Hello from CXF with logging"
+if [ $? -eq 0 ]; then
+  echo "PASS: response contains 'Hello from CXF with logging'"
+else
+  echo "FAIL: response does not contain expected greeting"
+  grep "Response:" "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 3.5: Verify CXF message logging output appears
+
+When `logging.enabled=true`, CXF's `LoggingInInterceptor` and `LoggingOutInterceptor` produce log lines containing the inbound/outbound SOAP payloads. Look for CXF interceptor markers.
+
+```bash
+CXF_LOG_FOUND=false
+
+grep -qi "Inbound Message\|Outbound Message\|REQ_OUT\|RESP_IN\|Payload:" "${PROJECT_DIR}/output.log" 2>/dev/null && CXF_LOG_FOUND=true
+
+if [ "${CXF_LOG_FOUND}" = "true" ]; then
+  echo "PASS: CXF message logging output found"
+else
+  echo "FAIL: CXF message logging output not found -- logging.enabled may not be working"
+  echo "--- Full log output ---"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 3.6: Stop Camel and cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+
+kill -0 "${CAMEL_PID}" 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "PASS: Camel process ${CAMEL_PID} stopped"
+else
+  echo "FAIL: Camel process ${CAMEL_PID} still running"
+fi
+
+rm -rf "${PROJECT_DIR}" || true
+```
+
+---
+
+## Phase 4: Cleanup
+
+Final cleanup to ensure no stale processes or temp directories remain.
+
+### Step 4.1: Kill any remaining Camel processes from this test run
+
+```bash
+if [ -n "${CAMEL_PID}" ]; then
+  kill "${CAMEL_PID}" 2>/dev/null || true
+  wait "${CAMEL_PID}" 2>/dev/null || true
+  echo "PASS: cleanup killed PID ${CAMEL_PID} (or already stopped)"
+else
+  echo "PASS: no CAMEL_PID set, nothing to stop"
+fi
+```
+
+### Step 4.2: Remove temporary project directories
+
+```bash
+if [ -n "${PROJECT_DIR}" ] && [ -d "${PROJECT_DIR}" ]; then
+  rm -rf "${PROJECT_DIR}" || true
+  echo "PASS: removed ${PROJECT_DIR}"
+else
+  echo "PASS: no PROJECT_DIR to remove"
+fi
+```
+
+---
+
+## Test Summary
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | Critical |
+| 0 | 0.2 | Verify Java version >= 17 | Critical |
+| 1 | 1.1 | Create default endpoint project files | Critical |
+| 1 | 1.2 | Start Camel with Forage in background | Critical |
+| 1 | 1.3 | Wait for server response in logs | Critical |
+| 1 | 1.4 | Verify response contains expected SOAP body | Critical |
+| 1 | 1.5 | Verify server received the request | High |
+| 1 | 1.6 | Verify external curl call to SOAP endpoint | High |
+| 1 | 1.7 | Stop Camel and cleanup | Critical |
+| 2 | 2.1 | Create named endpoints project files | Critical |
+| 2 | 2.2 | Start Camel with named endpoints | Critical |
+| 2 | 2.3 | Wait for client response in logs | Critical |
+| 2 | 2.4 | Verify named server received request | High |
+| 2 | 2.5 | Verify response contains named server greeting | Critical |
+| 2 | 2.6 | Verify external curl call to named server | High |
+| 2 | 2.7 | Stop Camel and cleanup | Critical |
+| 3 | 3.1 | Create logging-enabled project files | Critical |
+| 3 | 3.2 | Start Camel with logging enabled | Critical |
+| 3 | 3.3 | Wait for server response in logs | Critical |
+| 3 | 3.4 | Verify response contains expected SOAP body | Critical |
+| 3 | 3.5 | Verify CXF message logging output appears | High |
+| 3 | 3.6 | Stop Camel and cleanup | Critical |
+| 4 | 4.1 | Kill any remaining Camel processes | Critical |
+| 4 | 4.2 | Remove temporary project directories | Critical |

--- a/tests/plans/cxf-soap-endpoints.md
+++ b/tests/plans/cxf-soap-endpoints.md
@@ -319,15 +319,15 @@ cat > "${PROJECT_DIR}/route.camel.yaml" << 'ROUTE'
                   </soap:Body>
                 </soap:Envelope>
         - setHeader:
-            name: CamelHttpMethod
+            name: operationName
             constant:
-              expression: POST
+              expression: sayHello
         - setHeader:
-            name: Content-Type
+            name: operationNamespace
             constant:
-              expression: text/xml
+              expression: "http://example.com/hello"
         - to:
-            uri: "http://localhost:8080/services/hello"
+            uri: cxf:bean:helloClient
         - log:
             message: "Client received response: ${body}"
 ROUTE

--- a/tests/plans/jdbc-datasource.md
+++ b/tests/plans/jdbc-datasource.md
@@ -33,10 +33,10 @@ Verify all required tools are present.
 ### Test 0.1: Verify required tools
 
 ```bash
-java -version 2>&1 | head -1
+java -version >/dev/null 2>&1
 JAVA_EXIT=$?
 
-camel version 2>&1 | head -1
+camel version >/dev/null 2>&1
 CAMEL_EXIT=$?
 
 if command -v podman > /dev/null 2>&1; then

--- a/tests/plans/jdbc-datasource.md
+++ b/tests/plans/jdbc-datasource.md
@@ -1,0 +1,657 @@
+# Test Plan: JDBC DataSource Provisioning
+
+## Overview
+
+This test plan verifies Forage's JDBC DataSource provisioning end-to-end. Users write a `forage-datasource-factory.properties` file with `forage.jdbc.*` settings, write a Camel YAML route that references `dataSource` (or named beans like `ds1`, `ds2`), and run `camel run`. Forage discovers the JDBC provider via ServiceLoader, reads the properties, creates a DataSource with connection pooling (Agroal) and optional XA transactions (Narayana), and registers it in the Camel registry.
+
+Each phase creates a self-contained project in a temp directory, runs it as a background process, and verifies output via log polling.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+| `docker` or `podman` | any | `docker --version` or `podman --version` |
+
+If Camel JBang is not installed, see [common/forage-run.md](common/forage-run.md).
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_PORT` | `5432` | Host port mapped to the PostgreSQL container |
+
+---
+
+## Phase 0: Prerequisites
+
+Verify all required tools are present.
+
+### Test 0.1: Verify required tools
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+if command -v podman > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=podman
+elif command -v docker > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=docker
+else
+  echo "FAIL: neither podman nor docker found"
+  exit 1
+fi
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
+  echo "PASS: all required tools present (container runtime: ${CONTAINER_RUNTIME})"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT})"
+  exit 1
+fi
+```
+
+### Test 0.2: Verify Java version is 17+
+
+```bash
+JAVA_VERSION=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]*\).*/\1/')
+if [ "${JAVA_VERSION}" -ge 17 ]; then
+  echo "PASS: Java version ${JAVA_VERSION} >= 17"
+else
+  echo "FAIL: Java version ${JAVA_VERSION} < 17"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: H2 Embedded Database (no Docker)
+
+The simplest path: an in-memory H2 database requires no external infrastructure.
+
+### Test 1.1: Create project with H2 datasource
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'PROPS'
+forage.jdbc.db.kind=h2
+forage.jdbc.url=jdbc:h2:mem:testdb
+forage.jdbc.username=sa
+forage.jdbc.password=
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: h2-test
+    from:
+      uri: timer
+      parameters:
+        timerName: h2poll
+        period: "1000"
+        repeatCount: "1"
+      steps:
+        - setBody:
+            simple:
+              expression: SELECT 1 AS result
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: dataSource
+        - log:
+            message: "H2 result: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: H2 project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 1.2: Run H2 route and verify output
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "H2 result:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "H2 result:" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: H2 query executed successfully"
+else
+  echo "FAIL: H2 result not found in output"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 2: PostgreSQL via Docker
+
+Verifies Forage connects to an external PostgreSQL database, seeds data, and queries it.
+
+### Test 2.1: Start PostgreSQL container
+
+Follow [common/start-container.md](common/start-container.md) -- PostgreSQL section.
+
+```bash
+POSTGRES_CONTAINER="forage-test-postgres"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+
+${CONTAINER_RUNTIME} run -d \
+  --name "${POSTGRES_CONTAINER}" \
+  -e POSTGRES_USER=test \
+  -e POSTGRES_PASSWORD=test \
+  -e POSTGRES_DB=testdb \
+  -p "${POSTGRES_PORT}:5432" \
+  postgres:14-alpine
+
+for i in $(seq 1 30); do
+  ${CONTAINER_RUNTIME} exec "${POSTGRES_CONTAINER}" pg_isready -U test > /dev/null 2>&1 && break
+  sleep 1
+done
+
+${CONTAINER_RUNTIME} exec "${POSTGRES_CONTAINER}" pg_isready -U test > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: PostgreSQL is ready on port ${POSTGRES_PORT}"
+else
+  echo "FAIL: PostgreSQL did not become ready"
+  exit 1
+fi
+```
+
+### Test 2.2: Seed the database
+
+```bash
+${CONTAINER_RUNTIME} exec "${POSTGRES_CONTAINER}" psql -U test -d testdb -c "
+  CREATE TABLE bar (id INT, content TEXT);
+  INSERT INTO bar VALUES (1, 'hello'), (2, 'world');
+"
+
+if [ $? -eq 0 ]; then
+  echo "PASS: database seeded with test data"
+else
+  echo "FAIL: could not seed database"
+  exit 1
+fi
+```
+
+### Test 2.3: Create project with PostgreSQL datasource
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<PROPS
+forage.jdbc.db.kind=postgresql
+forage.jdbc.url=jdbc:postgresql://localhost:${POSTGRES_PORT}/testdb
+forage.jdbc.username=test
+forage.jdbc.password=test
+forage.jdbc.pool.initial.size=2
+forage.jdbc.pool.max.size=10
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: pg-test
+    from:
+      uri: timer
+      parameters:
+        timerName: pgpoll
+        period: "1000"
+        repeatCount: "1"
+      steps:
+        - setBody:
+            simple:
+              expression: select * from bar
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: dataSource
+        - log:
+            message: "PG result: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: PostgreSQL project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 2.4: Run PostgreSQL route and verify output
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "PG result:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "PG result:" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: PostgreSQL query executed"
+else
+  echo "FAIL: PG result not found in output"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.5: Verify query returned expected data
+
+```bash
+grep "PG result:" "${PROJECT_DIR}/output.log" | grep -q "hello"
+HELLO_FOUND=$?
+
+grep "PG result:" "${PROJECT_DIR}/output.log" | grep -q "world"
+WORLD_FOUND=$?
+
+if [ "${HELLO_FOUND}" -eq 0 ] && [ "${WORLD_FOUND}" -eq 0 ]; then
+  echo "PASS: output contains both 'hello' and 'world'"
+else
+  echo "FAIL: expected data not found (hello=${HELLO_FOUND}, world=${WORLD_FOUND})"
+  grep "PG result:" "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 3: Multi-DataSource (Named/Prefixed)
+
+Verifies that Forage can create multiple named DataSource beans from prefixed properties (`forage.ds1.jdbc.*`, `forage.ds2.jdbc.*`).
+
+### Test 3.1: Seed PostgreSQL with a second table
+
+```bash
+${CONTAINER_RUNTIME} exec "${POSTGRES_CONTAINER}" psql -U test -d testdb -c "
+  CREATE TABLE IF NOT EXISTS baz (id INT, label TEXT);
+  INSERT INTO baz VALUES (10, 'alpha'), (20, 'beta');
+"
+
+if [ $? -eq 0 ]; then
+  echo "PASS: second table seeded"
+else
+  echo "FAIL: could not seed second table"
+  exit 1
+fi
+```
+
+### Test 3.2: Create multi-datasource project
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<PROPS
+forage.ds1.jdbc.db.kind=postgresql
+forage.ds1.jdbc.url=jdbc:postgresql://localhost:${POSTGRES_PORT}/testdb
+forage.ds1.jdbc.username=test
+forage.ds1.jdbc.password=test
+
+forage.ds2.jdbc.db.kind=h2
+forage.ds2.jdbc.url=jdbc:h2:mem:secondary
+forage.ds2.jdbc.username=sa
+forage.ds2.jdbc.password=
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: multi-ds-test
+    from:
+      uri: timer
+      parameters:
+        timerName: multipoll
+        period: "1000"
+        repeatCount: "1"
+      steps:
+        - setBody:
+            simple:
+              expression: select * from bar
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: ds1
+        - log:
+            message: "ds1 result: ${body}"
+        - setBody:
+            simple:
+              expression: SELECT 1 AS x
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: ds2
+        - log:
+            message: "ds2 result: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: multi-datasource project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 3.3: Run multi-datasource route and verify both outputs
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "ds2 result:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "ds1 result:" "${PROJECT_DIR}/output.log"
+DS1_FOUND=$?
+
+grep -q "ds2 result:" "${PROJECT_DIR}/output.log"
+DS2_FOUND=$?
+
+if [ "${DS1_FOUND}" -eq 0 ] && [ "${DS2_FOUND}" -eq 0 ]; then
+  echo "PASS: both datasources returned results"
+else
+  echo "FAIL: missing datasource output (ds1=${DS1_FOUND}, ds2=${DS2_FOUND})"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 4: Connection Pool Settings
+
+Verifies that explicit pool configuration and XA transaction settings are accepted.
+
+### Test 4.1: Create project with full pool configuration
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<PROPS
+forage.jdbc.db.kind=postgresql
+forage.jdbc.url=jdbc:postgresql://localhost:${POSTGRES_PORT}/testdb
+forage.jdbc.username=test
+forage.jdbc.password=test
+forage.jdbc.pool.initial.size=2
+forage.jdbc.pool.min.size=1
+forage.jdbc.pool.max.size=5
+forage.jdbc.pool.acquisition.timeout.seconds=10
+forage.jdbc.pool.validation.timeout.seconds=5
+forage.jdbc.pool.leak.timeout.minutes=15
+forage.jdbc.pool.idle.validation.timeout.minutes=5
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: pool-test
+    from:
+      uri: timer
+      parameters:
+        timerName: poolpoll
+        period: "1000"
+        repeatCount: "1"
+      steps:
+        - setBody:
+            simple:
+              expression: select * from bar
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: dataSource
+        - log:
+            message: "Pool test result: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: pool config project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 4.2: Run route with pool configuration and verify
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "Pool test result:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "Pool test result:" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: route with explicit pool settings executed successfully"
+else
+  echo "FAIL: pool test result not found in output"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}"
+```
+
+### Test 4.3: Create project with XA transactions enabled
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<PROPS
+forage.jdbc.db.kind=postgresql
+forage.jdbc.url=jdbc:postgresql://localhost:${POSTGRES_PORT}/testdb
+forage.jdbc.username=test
+forage.jdbc.password=test
+forage.jdbc.transaction.enabled=true
+forage.jdbc.transaction.timeout.seconds=30
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: xa-test
+    from:
+      uri: timer
+      parameters:
+        timerName: xapoll
+        period: "1000"
+        repeatCount: "1"
+      steps:
+        - setBody:
+            simple:
+              expression: select * from bar
+        - to:
+            uri: jdbc
+            parameters:
+              dataSourceName: dataSource
+        - log:
+            message: "XA test result: ${body}"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: XA transaction project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 4.4: Run route with XA transactions and verify
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "XA test result:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "XA test result:" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: route with XA transactions executed successfully"
+else
+  echo "FAIL: XA test result not found in output"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 5: Negative -- Invalid Properties with --strict
+
+Verifies that `camel forage run --strict` rejects typos in property names.
+
+### Test 5.1: Create project with typo in property name
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+echo "Project directory: ${PROJECT_DIR}"
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'PROPS'
+forage.jdbc.db.kind=postgresql
+forage.jdbc.usernam=test
+forage.jdbc.password=test
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: strict-test
+    from:
+      uri: timer
+      parameters:
+        timerName: strictpoll
+        period: "1000"
+        repeatCount: "1"
+      steps:
+        - log:
+            message: "This should not appear"
+ROUTE
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: invalid properties project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 5.2: Run with --strict and verify failure
+
+```bash
+camel forage run --strict "${PROJECT_DIR}"/* > "${PROJECT_DIR}/strict-output.log" 2>&1
+STRICT_EXIT=$?
+
+if [ "${STRICT_EXIT}" -ne 0 ]; then
+  echo "PASS: camel forage run --strict failed with exit code ${STRICT_EXIT}"
+else
+  echo "FAIL: camel forage run --strict should have failed but exited with 0"
+fi
+```
+
+### Test 5.3: Verify error mentions invalid property
+
+```bash
+if grep -qi "usernam" "${PROJECT_DIR}/strict-output.log"; then
+  echo "PASS: error output mentions the typo property 'usernam'"
+else
+  echo "FAIL: error output does not reference the invalid property"
+  cat "${PROJECT_DIR}/strict-output.log"
+fi
+
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 6: Cleanup
+
+### Step 6.1: Kill any remaining Camel processes
+
+```bash
+if [ -n "${CAMEL_PID}" ]; then
+  kill "${CAMEL_PID}" 2>/dev/null || true
+  wait "${CAMEL_PID}" 2>/dev/null || true
+  echo "PASS: Camel process stopped"
+else
+  echo "PASS: no Camel process to stop"
+fi
+```
+
+### Step 6.2: Remove Docker containers
+
+```bash
+${CONTAINER_RUNTIME} rm -f "${POSTGRES_CONTAINER}" 2>/dev/null || true
+echo "PASS: PostgreSQL container removed (or already absent)"
+```
+
+### Step 6.3: Remove temp directories
+
+```bash
+rm -rf "${PROJECT_DIR}" 2>/dev/null || true
+echo "PASS: temp directories cleaned up"
+```
+
+---
+
+## Test Summary
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | Critical |
+| 0 | 0.2 | Verify Java version >= 17 | Critical |
+| 1 | 1.1 | Create H2 project files | Critical |
+| 1 | 1.2 | Run H2 route and verify output | Critical |
+| 2 | 2.1 | Start PostgreSQL container | Critical |
+| 2 | 2.2 | Seed the database | Critical |
+| 2 | 2.3 | Create PostgreSQL project files | Critical |
+| 2 | 2.4 | Run PostgreSQL route and verify output | Critical |
+| 2 | 2.5 | Verify query returned expected data | High |
+| 3 | 3.1 | Seed PostgreSQL with second table | High |
+| 3 | 3.2 | Create multi-datasource project | Critical |
+| 3 | 3.3 | Run multi-datasource route and verify both outputs | Critical |
+| 4 | 4.1 | Create project with full pool configuration | High |
+| 4 | 4.2 | Run route with pool settings and verify | High |
+| 4 | 4.3 | Create project with XA transactions | High |
+| 4 | 4.4 | Run route with XA transactions and verify | High |
+| 5 | 5.1 | Create project with typo in property | High |
+| 5 | 5.2 | Run with --strict and verify failure | High |
+| 5 | 5.3 | Verify error mentions invalid property | Medium |
+| 6 | 6.1 | Kill remaining Camel processes | Critical |
+| 6 | 6.2 | Remove Docker containers | Critical |
+| 6 | 6.3 | Remove temp directories | Critical |

--- a/tests/plans/jms-messaging.md
+++ b/tests/plans/jms-messaging.md
@@ -27,13 +27,13 @@ Users write a `forage-connectionfactory.properties` file with `forage.jms.*` set
 Verify all required tools are available.
 
 ```bash
-java -version 2>&1 | head -1
+java -version >/dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "FAIL: Java is not installed"
   exit 1
 fi
 
-camel version 2>&1 | head -1
+camel version >/dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "FAIL: Camel JBang is not installed"
   exit 1

--- a/tests/plans/jms-messaging.md
+++ b/tests/plans/jms-messaging.md
@@ -1,0 +1,391 @@
+# JMS Connection Factory Provisioning
+
+End-to-end verification that Forage discovers a JMS provider (Artemis) via ServiceLoader, creates a ConnectionFactory with pooling and optional XA transactions, and registers it in the Camel registry so that `jms:queue.name` routes work out of the box.
+
+## Overview
+
+Users write a `forage-connectionfactory.properties` file with `forage.jms.*` settings and a Camel YAML route that references `jms:queue.name`. On `camel run`, the Forage plugin discovers the JMS provider (based on `forage.jms.kind`), builds a `ConnectionFactory` (optionally pooled via `JmsPoolConnectionFactory`, optionally XA via Narayana), and binds it as `connectionFactory` in the Camel registry.
+
+## Prerequisites
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+| `docker` or `podman` | any | `docker --version` or `podman --version` |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ARTEMIS_PORT` | `61616` | Host port mapped to Artemis AMQP port |
+
+---
+
+## Phase 0: Prerequisites
+
+Verify all required tools are available.
+
+```bash
+java -version 2>&1 | head -1
+if [ $? -ne 0 ]; then
+  echo "FAIL: Java is not installed"
+  exit 1
+fi
+
+camel version 2>&1 | head -1
+if [ $? -ne 0 ]; then
+  echo "FAIL: Camel JBang is not installed"
+  exit 1
+fi
+
+if command -v podman > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=podman
+elif command -v docker > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=docker
+else
+  echo "FAIL: neither podman nor docker found"
+  exit 1
+fi
+
+echo "PASS: All prerequisites met (container runtime: ${CONTAINER_RUNTIME})"
+```
+
+---
+
+## Phase 1: Simple Artemis Send/Receive
+
+Verify that Forage creates a pooled ConnectionFactory for Artemis and that a producer/consumer route pair can send and receive messages.
+
+### Step 1.1: Start Artemis container
+
+See [Common: Start a Docker Container — ActiveMQ Artemis](common/start-container.md#activemq-artemis).
+
+```bash
+ARTEMIS_CONTAINER="forage-test-artemis"
+ARTEMIS_PORT="${ARTEMIS_PORT:-61616}"
+
+${CONTAINER_RUNTIME} run -d \
+  --name "${ARTEMIS_CONTAINER}" \
+  -e AMQ_USER=artemis \
+  -e AMQ_PASSWORD=artemis \
+  -p "${ARTEMIS_PORT}:61616" \
+  quay.io/artemiscloud/activemq-artemis-broker:latest
+
+# Wait for ready
+for i in $(seq 1 60); do
+  ${CONTAINER_RUNTIME} logs "${ARTEMIS_CONTAINER}" 2>&1 | grep -q "Server is now active" && break
+  sleep 1
+done
+
+${CONTAINER_RUNTIME} logs "${ARTEMIS_CONTAINER}" 2>&1 | grep -q "Server is now active"
+if [ $? -eq 0 ]; then
+  echo "PASS: Artemis is ready on port ${ARTEMIS_PORT}"
+else
+  echo "FAIL: Artemis did not become ready"
+  ${CONTAINER_RUNTIME} rm -f "${ARTEMIS_CONTAINER}" 2>/dev/null || true
+  exit 1
+fi
+```
+
+### Step 1.2: Create project directory
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-connectionfactory.properties" <<'PROPS'
+forage.jms.kind=artemis
+forage.jms.broker.url=tcp://localhost:${ARTEMIS_PORT}
+forage.jms.username=artemis
+forage.jms.password=artemis
+forage.jms.pool.enabled=true
+forage.jms.pool.max.connections=5
+PROPS
+
+# Substitute ARTEMIS_PORT
+sed -i.bak "s/\${ARTEMIS_PORT}/${ARTEMIS_PORT}/" "${PROJECT_DIR}/forage-connectionfactory.properties"
+rm -f "${PROJECT_DIR}/forage-connectionfactory.properties.bak"
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: producer-route
+    from:
+      uri: timer
+      parameters:
+        timerName: producer
+        repeatCount: 3
+        period: "2000"
+      steps:
+        - setBody:
+            simple:
+              expression: "Message ${exchangeProperty.CamelTimerCounter}"
+        - to:
+            uri: jms
+            parameters:
+              destinationName: test.queue
+              destinationType: queue
+        - log:
+            message: "Sent: ${body}"
+- route:
+    id: consumer-route
+    from:
+      uri: jms
+      parameters:
+        destinationName: test.queue
+        destinationType: queue
+      steps:
+        - log:
+            message: "Received: ${body}"
+ROUTE
+
+echo "PASS: Project created at ${PROJECT_DIR}"
+```
+
+### Step 1.3: Run and verify
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "Received: Message" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -c "Received: Message" "${PROJECT_DIR}/output.log" 2>/dev/null
+RECEIVED_COUNT=$(grep -c "Received: Message" "${PROJECT_DIR}/output.log" 2>/dev/null || echo "0")
+
+if [ "${RECEIVED_COUNT}" -ge 1 ]; then
+  echo "PASS: Received ${RECEIVED_COUNT} message(s) via JMS"
+else
+  echo "FAIL: No 'Received: Message' found in output"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 2: Transactional JMS with XA
+
+Verify that Forage creates an XA-enabled ConnectionFactory with Narayana transaction manager, and that transacted routes commit/rollback correctly.
+
+### Step 2.1: Create project directory
+
+Uses the same Artemis container from Phase 1.
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-connectionfactory.properties" <<PROPS
+forage.jms.kind=artemis
+forage.jms.broker.url=tcp://localhost:${ARTEMIS_PORT}
+forage.jms.username=artemis
+forage.jms.password=artemis
+forage.jms.pool.enabled=true
+forage.jms.pool.max.connections=10
+forage.jms.pool.max.sessions.per.connection=500
+forage.jms.transaction.enabled=true
+forage.jms.transaction.timeout.seconds=30
+forage.jms.transaction.node.id=node1
+forage.jms.transaction.enable.recovery=true
+forage.jms.transaction.object.store.directory=tx-object-store
+forage.jms.transaction.object.store.type=file-system
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: producer-route
+    from:
+      uri: timer
+      parameters:
+        timerName: producer
+        repeatCount: 3
+        period: "5000"
+      steps:
+        - setBody:
+            simple:
+              expression: "Transactional message ${exchangeProperty.CamelTimerCounter}"
+        - setHeader:
+            name: counter
+            simple:
+              expression: "${exchangeProperty.CamelTimerCounter}"
+        - log:
+            message: "Message sent: ${body}"
+        - to:
+            uri: jms
+            parameters:
+              destinationName: input.queue
+              destinationType: queue
+- route:
+    id: transactional-consumer-route
+    from:
+      uri: jms
+      parameters:
+        destinationName: input.queue
+        destinationType: queue
+        transacted: "true"
+        cacheLevelName: CACHE_NONE
+      steps:
+        - transacted:
+            ref: PROPAGATION_REQUIRED
+        - log:
+            message: "Processing message: ${body}"
+        - to:
+            uri: jms
+            parameters:
+              destinationName: output.queue
+              destinationType: queue
+        - log:
+            message: "Forwarded to output queue"
+- route:
+    id: output-consumer-route
+    from:
+      uri: jms
+      parameters:
+        destinationName: output.queue
+        destinationType: queue
+      steps:
+        - log:
+            message: "Successfully processed message: ${body}"
+ROUTE
+
+echo "PASS: XA project created at ${PROJECT_DIR}"
+```
+
+### Step 2.2: Run and verify
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "Successfully processed message:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+PROCESSED_COUNT=$(grep -c "Successfully processed message:" "${PROJECT_DIR}/output.log" 2>/dev/null || echo "0")
+
+if [ "${PROCESSED_COUNT}" -ge 1 ]; then
+  echo "PASS: ${PROCESSED_COUNT} message(s) flowed through the transactional chain"
+else
+  echo "FAIL: No messages reached output.queue"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 3: Connection Pool Settings
+
+Verify that explicit pool tuning properties are accepted and the route functions with non-default pool configuration.
+
+### Step 3.1: Create project directory
+
+Uses the same Artemis container from Phase 1.
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-connectionfactory.properties" <<PROPS
+forage.jms.kind=artemis
+forage.jms.broker.url=tcp://localhost:${ARTEMIS_PORT}
+forage.jms.username=artemis
+forage.jms.password=artemis
+forage.jms.pool.enabled=true
+forage.jms.pool.max.connections=2
+forage.jms.pool.max.sessions.per.connection=10
+forage.jms.pool.idle.timeout.millis=15000
+forage.jms.pool.block.if.full=true
+forage.jms.pool.block.if.full.timeout.millis=5000
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: producer-route
+    from:
+      uri: timer
+      parameters:
+        timerName: producer
+        repeatCount: 3
+        period: "2000"
+      steps:
+        - setBody:
+            simple:
+              expression: "Pooled message ${exchangeProperty.CamelTimerCounter}"
+        - to:
+            uri: jms
+            parameters:
+              destinationName: pool.test.queue
+              destinationType: queue
+        - log:
+            message: "Sent: ${body}"
+- route:
+    id: consumer-route
+    from:
+      uri: jms
+      parameters:
+        destinationName: pool.test.queue
+        destinationType: queue
+      steps:
+        - log:
+            message: "Pool received: ${body}"
+ROUTE
+
+echo "PASS: Pool-tuned project created at ${PROJECT_DIR}"
+```
+
+### Step 3.2: Run and verify
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+for i in $(seq 1 60); do
+  grep -q "Pool received: Pooled message" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+RECEIVED_COUNT=$(grep -c "Pool received: Pooled message" "${PROJECT_DIR}/output.log" 2>/dev/null || echo "0")
+
+if [ "${RECEIVED_COUNT}" -ge 1 ]; then
+  echo "PASS: Received ${RECEIVED_COUNT} message(s) with custom pool settings"
+else
+  echo "FAIL: No messages received with custom pool settings"
+  cat "${PROJECT_DIR}/output.log"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+rm -rf "${PROJECT_DIR}"
+```
+
+---
+
+## Phase 4: Cleanup
+
+Remove infrastructure and temporary files.
+
+```bash
+${CONTAINER_RUNTIME} rm -f "${ARTEMIS_CONTAINER}" 2>/dev/null || true
+echo "PASS: Cleanup complete"
+```
+
+---
+
+## Test Summary
+
+| Phase | Description | Validates |
+|-------|-------------|-----------|
+| 0 | Prerequisites | Java, Camel JBang, Docker installed |
+| 1 | Simple Artemis send/receive | ServiceLoader discovery, pooled ConnectionFactory, basic messaging |
+| 2 | Transactional JMS with XA | XA ConnectionFactory, Narayana TM, PROPAGATION_REQUIRED, transacted route |
+| 3 | Connection pool settings | Non-default pool tuning (max connections, sessions, idle timeout, block-if-full) |
+| 4 | Cleanup | Container and temp dir removal |

--- a/tests/plans/property-validation.md
+++ b/tests/plans/property-validation.md
@@ -24,10 +24,10 @@ jbang app install camel@apache/camel
 ### Prerequisite check
 
 ```bash
-java -version 2>&1 | head -1
+java -version >/dev/null 2>&1
 JAVA_EXIT=$?
 
-camel version 2>&1 | head -1
+camel version >/dev/null 2>&1
 CAMEL_EXIT=$?
 
 if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
@@ -45,10 +45,10 @@ fi
 ### Test 0.1: Verify required tools
 
 ```bash
-java -version 2>&1 | head -1
+java -version >/dev/null 2>&1
 JAVA_EXIT=$?
 
-camel version 2>&1 | head -1
+camel version >/dev/null 2>&1
 CAMEL_EXIT=$?
 
 if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
@@ -115,7 +115,7 @@ fi
 ### Test 1.2: Run with --strict and valid properties
 
 ```bash
-camel forage run --strict "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1 &
+camel forage run --strict "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
 CAMEL_PID=$!
 
 # Wait for the route to start (H2 is embedded, so it should start quickly)
@@ -197,7 +197,7 @@ fi
 ### Test 2.2: Run with --strict and typo property
 
 ```bash
-camel forage run --strict "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1
+camel forage run --strict "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1
 EXIT_CODE=$?
 
 if [ "${EXIT_CODE}" -ne 0 ]; then
@@ -298,7 +298,7 @@ echo "PASS: phase 3 project files created"
 The route may fail later due to missing valid config (no real PostgreSQL), but validation itself should not block execution.
 
 ```bash
-camel forage run "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1 &
+camel forage run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
 CAMEL_PID=$!
 
 # Give it time to start and produce output
@@ -329,7 +329,7 @@ wait "${CAMEL_PID}" 2>/dev/null
 if grep -q "Forage Property Validation Warnings" "${PROJECT_DIR}/output.log" 2>/dev/null; then
   echo "PASS: validation warnings are displayed without --strict"
 else
-  echo "INFO: warnings may not appear in non-strict mode if output is suppressed (check log)"
+  echo "FAIL: expected validation warnings without --strict"
   cat "${PROJECT_DIR}/output.log"
 fi
 ```
@@ -378,7 +378,7 @@ echo "PASS: phase 4 project files created"
 ### Test 4.2: Run with --strict and multiple typos
 
 ```bash
-camel forage run --strict "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1
+camel forage run --strict "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1
 EXIT_CODE=$?
 
 if [ "${EXIT_CODE}" -ne 0 ]; then
@@ -416,12 +416,8 @@ if grep -q "Total warnings: 2" "${PROJECT_DIR}/output.log" 2>/dev/null; then
   echo "PASS: total warning count is 2"
 else
   TOTAL=$(grep "Total warnings:" "${PROJECT_DIR}/output.log" 2>/dev/null)
-  if [ -n "${TOTAL}" ]; then
-    echo "INFO: ${TOTAL} (expected 2)"
-  else
-    echo "FAIL: no total warnings line found"
-    cat "${PROJECT_DIR}/output.log"
-  fi
+  echo "FAIL: ${TOTAL:-no total warnings line found} (expected 2)"
+  cat "${PROJECT_DIR}/output.log"
 fi
 ```
 

--- a/tests/plans/property-validation.md
+++ b/tests/plans/property-validation.md
@@ -1,0 +1,475 @@
+# Test Plan: Property Validation
+
+## Overview
+
+This test plan verifies Forage's property validation feature, which detects typos and unknown properties in `forage-*.properties` files. The `ForagePropertyValidator` scans properties files, validates property names against the Forage catalog using Levenshtein distance for typo detection, and reports warnings. With `--strict`, warnings become fatal errors.
+
+This plan covers valid properties, typo detection, strict vs. non-strict behavior, and multiple-error reporting. No Docker is required.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+
+If Camel JBang is not installed:
+```bash
+jbang trust add https://github.com/apache/camel/
+jbang app install camel@apache/camel
+```
+
+### Prerequisite check
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
+  echo "PASS: all prerequisites met"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT})"
+  exit 1
+fi
+```
+
+---
+
+## Phase 0: Prerequisites
+
+### Test 0.1: Verify required tools
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
+  echo "PASS: all required tools present"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT})"
+  exit 1
+fi
+```
+
+### Test 0.2: Verify Java version is 17+
+
+```bash
+JAVA_VERSION=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]*\).*/\1/')
+if [ "${JAVA_VERSION}" -ge 17 ]; then
+  echo "PASS: Java version ${JAVA_VERSION} >= 17"
+else
+  echo "FAIL: Java version ${JAVA_VERSION} < 17"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Valid Properties Pass Validation
+
+Verify that well-formed properties pass validation in strict mode without errors.
+
+### Test 1.1: Create project with valid properties
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'EOF'
+forage.jdbc.db.kind=h2
+forage.jdbc.url=jdbc:h2:mem:testdb
+forage.jdbc.username=sa
+forage.jdbc.password=
+EOF
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    from:
+      uri: timer:tick
+      parameters:
+        repeatCount: 1
+      steps:
+        - setBody:
+            constant: "SELECT 1"
+        - to:
+            uri: jdbc:dataSource
+        - log:
+            message: "OK: ${body}"
+EOF
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: project files created"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 1.2: Run with --strict and valid properties
+
+```bash
+camel forage run --strict "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+# Wait for the route to start (H2 is embedded, so it should start quickly)
+for i in $(seq 1 60); do
+  grep -q "OK:" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  # Also check if validation failed
+  grep -q "Validation failed" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+# Check that validation did not fail
+if grep -q "Validation failed" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "FAIL: validation failed on valid properties"
+  cat "${PROJECT_DIR}/output.log"
+else
+  echo "PASS: validation passed with valid properties"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+```
+
+### Test 1.3: Verify no validation warnings in output
+
+```bash
+if grep -q "Forage Property Validation Warnings" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "FAIL: unexpected validation warnings on valid properties"
+  cat "${PROJECT_DIR}/output.log"
+else
+  echo "PASS: no validation warnings for valid properties"
+fi
+```
+
+### Test 1.4: Cleanup phase 1
+
+```bash
+rm -rf "${PROJECT_DIR}"
+echo "PASS: phase 1 temp dir removed"
+```
+
+---
+
+## Phase 2: Typo Detection with --strict
+
+Verify that a property typo causes `camel forage run --strict` to exit with non-zero code and report the offending property.
+
+### Test 2.1: Create project with typo in properties
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'EOF'
+forage.jdbc.db.kind=postgresql
+forage.jdbc.usernam=test
+forage.jdbc.password=test
+EOF
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    from:
+      uri: timer:tick
+      parameters:
+        repeatCount: 1
+      steps:
+        - setBody:
+            constant: "SELECT 1"
+        - log:
+            message: "OK: ${body}"
+EOF
+
+if [ -f "${PROJECT_DIR}/forage-datasource-factory.properties" ]; then
+  echo "PASS: typo project files created"
+else
+  echo "FAIL: typo project files not created"
+  exit 1
+fi
+```
+
+### Test 2.2: Run with --strict and typo property
+
+```bash
+camel forage run --strict "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: strict mode exited with non-zero code (${EXIT_CODE})"
+else
+  echo "FAIL: strict mode should have exited with non-zero code but got ${EXIT_CODE}"
+fi
+```
+
+### Test 2.3: Verify output reports the typo
+
+```bash
+if grep -q "usernam" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "PASS: output mentions the typo 'usernam'"
+else
+  echo "FAIL: output does not mention the typo 'usernam'"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.4: Verify output contains validation warning header
+
+```bash
+if grep -q "Forage Property Validation Warnings" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "PASS: output contains validation warning header"
+else
+  echo "FAIL: output does not contain validation warning header"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.5: Verify strict mode failure message
+
+```bash
+if grep -q "Validation failed in strict mode" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "PASS: output contains strict mode failure message"
+else
+  echo "FAIL: output does not contain strict mode failure message"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.6: Verify typo suggestion is provided
+
+The validator uses Levenshtein distance (max 3 edits) and should suggest `username` for the typo `usernam`.
+
+```bash
+if grep -q "Did you mean" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "PASS: output includes 'Did you mean' suggestion"
+else
+  echo "FAIL: output does not include a suggestion for the typo"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 2.7: Cleanup phase 2
+
+```bash
+rm -rf "${PROJECT_DIR}"
+echo "PASS: phase 2 temp dir removed"
+```
+
+---
+
+## Phase 3: Warning Without --strict
+
+Verify that without `--strict`, typo warnings are logged but execution is attempted (not blocked by validation).
+
+### Test 3.1: Create project with typo (same as phase 2)
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'EOF'
+forage.jdbc.db.kind=postgresql
+forage.jdbc.usernam=test
+forage.jdbc.password=test
+EOF
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    from:
+      uri: timer:tick
+      parameters:
+        repeatCount: 1
+      steps:
+        - setBody:
+            constant: "SELECT 1"
+        - log:
+            message: "OK: ${body}"
+EOF
+
+echo "PASS: phase 3 project files created"
+```
+
+### Test 3.2: Run without --strict
+
+The route may fail later due to missing valid config (no real PostgreSQL), but validation itself should not block execution.
+
+```bash
+camel forage run "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+# Give it time to start and produce output
+for i in $(seq 1 30); do
+  # Check if warnings were printed (validation ran but didn't block)
+  grep -q "Forage Property Validation Warnings" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  # Or check if the route started attempting to run
+  grep -q "Routes startup" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  # Or check for connection errors (means it got past validation)
+  grep -q "Exception" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+# The key assertion: validation did NOT block execution
+if grep -q "Validation failed in strict mode" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "FAIL: strict mode failure appeared without --strict flag"
+else
+  echo "PASS: no strict mode failure without --strict flag"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null
+wait "${CAMEL_PID}" 2>/dev/null
+```
+
+### Test 3.3: Verify warnings are still shown
+
+```bash
+if grep -q "Forage Property Validation Warnings" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "PASS: validation warnings are displayed without --strict"
+else
+  echo "INFO: warnings may not appear in non-strict mode if output is suppressed (check log)"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 3.4: Cleanup phase 3
+
+```bash
+rm -rf "${PROJECT_DIR}"
+echo "PASS: phase 3 temp dir removed"
+```
+
+---
+
+## Phase 4: Multiple Errors
+
+Verify that all typos are reported, not just the first one.
+
+### Test 4.1: Create project with multiple typos
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-datasource-factory.properties" <<'EOF'
+forage.jdbc.db.kind=postgresql
+forage.jdbc.usernam=test
+forage.jdbc.passwrd=test
+forage.jdbc.url=jdbc:postgresql://localhost/test
+EOF
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    from:
+      uri: timer:tick
+      parameters:
+        repeatCount: 1
+      steps:
+        - setBody:
+            constant: "SELECT 1"
+        - log:
+            message: "OK: ${body}"
+EOF
+
+echo "PASS: phase 4 project files created"
+```
+
+### Test 4.2: Run with --strict and multiple typos
+
+```bash
+camel forage run --strict "${PROJECT_DIR}/*" > "${PROJECT_DIR}/output.log" 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: strict mode exited with non-zero code (${EXIT_CODE})"
+else
+  echo "FAIL: strict mode should have exited with non-zero code"
+fi
+```
+
+### Test 4.3: Verify both typos are reported
+
+```bash
+USERNAM_FOUND=0
+PASSWRD_FOUND=0
+
+grep -q "usernam" "${PROJECT_DIR}/output.log" 2>/dev/null && USERNAM_FOUND=1
+grep -q "passwrd" "${PROJECT_DIR}/output.log" 2>/dev/null && PASSWRD_FOUND=1
+
+if [ "${USERNAM_FOUND}" -eq 1 ] && [ "${PASSWRD_FOUND}" -eq 1 ]; then
+  echo "PASS: both typos reported (usernam, passwrd)"
+elif [ "${USERNAM_FOUND}" -eq 1 ]; then
+  echo "FAIL: only 'usernam' reported, missing 'passwrd'"
+elif [ "${PASSWRD_FOUND}" -eq 1 ]; then
+  echo "FAIL: only 'passwrd' reported, missing 'usernam'"
+else
+  echo "FAIL: neither typo reported"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 4.4: Verify warning count reflects both errors
+
+```bash
+if grep -q "Total warnings: 2" "${PROJECT_DIR}/output.log" 2>/dev/null; then
+  echo "PASS: total warning count is 2"
+else
+  TOTAL=$(grep "Total warnings:" "${PROJECT_DIR}/output.log" 2>/dev/null)
+  if [ -n "${TOTAL}" ]; then
+    echo "INFO: ${TOTAL} (expected 2)"
+  else
+    echo "FAIL: no total warnings line found"
+    cat "${PROJECT_DIR}/output.log"
+  fi
+fi
+```
+
+### Test 4.5: Cleanup phase 4
+
+```bash
+rm -rf "${PROJECT_DIR}"
+echo "PASS: phase 4 temp dir removed"
+```
+
+---
+
+## Phase 5: Cleanup
+
+### Test 5.1: Verify no leftover temp dirs
+
+```bash
+# All PROJECT_DIRs were cleaned up in their respective phases.
+# This is a final sanity check.
+echo "PASS: all temporary directories cleaned up in earlier phases"
+```
+
+---
+
+## Test Summary
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | Critical |
+| 0 | 0.2 | Verify Java version >= 17 | Critical |
+| 1 | 1.1 | Create project with valid properties | Critical |
+| 1 | 1.2 | Run with --strict and valid properties | Critical |
+| 1 | 1.3 | Verify no validation warnings | High |
+| 1 | 1.4 | Cleanup phase 1 | Critical |
+| 2 | 2.1 | Create project with typo | Critical |
+| 2 | 2.2 | Run with --strict and typo property | Critical |
+| 2 | 2.3 | Verify output reports the typo | Critical |
+| 2 | 2.4 | Verify validation warning header | High |
+| 2 | 2.5 | Verify strict mode failure message | High |
+| 2 | 2.6 | Verify typo suggestion is provided | High |
+| 2 | 2.7 | Cleanup phase 2 | Critical |
+| 3 | 3.1 | Create project with typo (no --strict) | Critical |
+| 3 | 3.2 | Run without --strict | Critical |
+| 3 | 3.3 | Verify warnings are still shown | Medium |
+| 3 | 3.4 | Cleanup phase 3 | Critical |
+| 4 | 4.1 | Create project with multiple typos | Critical |
+| 4 | 4.2 | Run with --strict and multiple typos | Critical |
+| 4 | 4.3 | Verify both typos are reported | Critical |
+| 4 | 4.4 | Verify warning count reflects both errors | High |
+| 4 | 4.5 | Cleanup phase 4 | Critical |
+| 5 | 5.1 | Verify no leftover temp dirs | Low |

--- a/tests/plans/rabbitmq-connection.md
+++ b/tests/plans/rabbitmq-connection.md
@@ -1,0 +1,358 @@
+# Test Plan: RabbitMQ Connection Factory Provisioning
+
+## Overview
+
+This test plan verifies that Forage correctly provisions Spring RabbitMQ `CachingConnectionFactory` beans from `forage-spring-rabbitmq.properties` configuration. It creates sample projects and runs them with `camel forage run`, confirming that:
+
+1. Default (unprefixed) properties create a `rabbitConnectionFactory` bean
+2. Named/prefixed properties (e.g., `forage.mq1.rabbitmq.*`) create a bean named by the prefix (e.g., `#mq1`)
+
+Both phases verify end-to-end message flow: a timer-driven producer sends messages to a RabbitMQ exchange, and a consumer reads them back, confirming the connection factory is wired correctly.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+| `docker` or `podman` | any | `docker --version` or `podman --version` |
+
+### Prerequisite check
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+if command -v podman > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=podman
+elif command -v docker > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=docker
+else
+  echo "FAIL: neither podman nor docker found"
+  exit 1
+fi
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
+  echo "PASS: all prerequisites met (container runtime: ${CONTAINER_RUNTIME})"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT})"
+  exit 1
+fi
+```
+
+If Camel JBang is not installed, see [common/forage-run.md](common/forage-run.md).
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RABBITMQ_PORT` | `5672` | Host port mapped to RabbitMQ AMQP port |
+
+---
+
+## Phase 0: Prerequisites
+
+### Test 0.1: Verify required tools
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+camel version 2>&1 | head -1
+CAMEL_EXIT=$?
+
+if command -v podman > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=podman
+elif command -v docker > /dev/null 2>&1; then
+  CONTAINER_RUNTIME=docker
+else
+  echo "FAIL: neither podman nor docker found"
+  exit 1
+fi
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${CAMEL_EXIT}" -eq 0 ]; then
+  echo "PASS: all required tools present (container runtime: ${CONTAINER_RUNTIME})"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, camel=${CAMEL_EXIT})"
+  exit 1
+fi
+```
+
+### Test 0.2: Verify Java version is 17+
+
+```bash
+JAVA_VERSION=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]*\).*/\1/')
+if [ "${JAVA_VERSION}" -ge 17 ]; then
+  echo "PASS: Java version ${JAVA_VERSION} >= 17"
+else
+  echo "FAIL: Java version ${JAVA_VERSION} < 17"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Default RabbitMQ Connection
+
+This phase verifies that unprefixed `forage.rabbitmq.*` properties create a bean named `rabbitConnectionFactory` and that routes can use it via `connectionFactory=#rabbitConnectionFactory`.
+
+### Step 1.1: Start RabbitMQ container
+
+Follow [common/start-container.md#rabbitmq](common/start-container.md#rabbitmq) to start RabbitMQ.
+
+After completion, the following variables must be set:
+
+- `RABBITMQ_CONTAINER` -- container name
+- `RABBITMQ_PORT` -- mapped AMQP port
+
+### Test 1.2: Create project with default configuration
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-spring-rabbitmq.properties" <<EOF
+forage.rabbitmq.host=localhost
+forage.rabbitmq.port=${RABBITMQ_PORT}
+forage.rabbitmq.username=guest
+forage.rabbitmq.password=guest
+forage.rabbitmq.virtual.host=/
+camel.component.spring-rabbitmq.auto-declare=true
+EOF
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    id: producer-route
+    from:
+      uri: timer
+      parameters:
+        timerName: foo
+        period: "2000"
+        repeatCount: 3
+      steps:
+        - setBody:
+            simple:
+              expression: Hello RabbitMQ ${exchangeProperty.CamelTimerCounter}
+        - to:
+            id: to-rabbitmq
+            uri: spring-rabbitmq
+            parameters:
+              exchangeName: fooExchange
+              routingKey: test
+              connectionFactory: "#rabbitConnectionFactory"
+- route:
+    id: consumer-route
+    from:
+      id: from-rabbitmq
+      uri: spring-rabbitmq
+      parameters:
+        exchangeName: fooExchange
+        queues: myqueue
+        routingKey: test
+        connectionFactory: "#rabbitConnectionFactory"
+      steps:
+        - log:
+            id: log-message
+            message: "Received: ${body}"
+EOF
+
+if [ -f "${PROJECT_DIR}/forage-spring-rabbitmq.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: project files created in ${PROJECT_DIR}"
+else
+  echo "FAIL: project files not created"
+  exit 1
+fi
+```
+
+### Test 1.3: Run Camel and verify message flow
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+FOUND=0
+for i in $(seq 1 60); do
+  grep -q "Received: Hello RabbitMQ" "${PROJECT_DIR}/output.log" 2>/dev/null && { FOUND=1; break; }
+  sleep 1
+done
+
+if [ "${FOUND}" -eq 1 ]; then
+  echo "PASS: default connection factory delivered messages successfully"
+else
+  echo "FAIL: expected log message not found within 60 seconds"
+  echo "--- output.log ---"
+  cat "${PROJECT_DIR}/output.log"
+  echo "--- end ---"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+```
+
+### Step 1.4: Clean up default project
+
+```bash
+rm -rf "${PROJECT_DIR}" || true
+```
+
+---
+
+## Phase 2: Named Connection Factory
+
+This phase verifies that prefixed properties (e.g., `forage.mq1.rabbitmq.*`) create a bean named by the prefix (`mq1`), and routes can reference it via `connectionFactory=#mq1`.
+
+Uses the same RabbitMQ container from Phase 1.
+
+### Test 2.1: Create project with named/prefixed configuration
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-spring-rabbitmq.properties" <<EOF
+forage.mq1.rabbitmq.host=localhost
+forage.mq1.rabbitmq.port=${RABBITMQ_PORT}
+forage.mq1.rabbitmq.username=guest
+forage.mq1.rabbitmq.password=guest
+forage.mq1.rabbitmq.virtual.host=/
+camel.component.spring-rabbitmq.auto-declare=true
+EOF
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'EOF'
+- route:
+    id: named-producer-route
+    from:
+      uri: timer
+      parameters:
+        timerName: foo
+        period: "2000"
+        repeatCount: 3
+      steps:
+        - setBody:
+            simple:
+              expression: Hello Named RabbitMQ ${exchangeProperty.CamelTimerCounter}
+        - to:
+            id: to-rabbitmq
+            uri: spring-rabbitmq
+            parameters:
+              exchangeName: fooExchange
+              routingKey: test
+              connectionFactory: "#mq1"
+- route:
+    id: named-consumer-route
+    from:
+      id: from-rabbitmq
+      uri: spring-rabbitmq
+      parameters:
+        exchangeName: fooExchange
+        queues: myqueue
+        routingKey: test
+        connectionFactory: "#mq1"
+      steps:
+        - log:
+            id: log-message
+            message: "Received: ${body}"
+EOF
+
+if [ -f "${PROJECT_DIR}/forage-spring-rabbitmq.properties" ] && [ -f "${PROJECT_DIR}/route.camel.yaml" ]; then
+  echo "PASS: named project files created in ${PROJECT_DIR}"
+else
+  echo "FAIL: named project files not created"
+  exit 1
+fi
+```
+
+### Test 2.2: Run Camel and verify named bean message flow
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+
+FOUND=0
+for i in $(seq 1 60); do
+  grep -q "Received: Hello Named RabbitMQ" "${PROJECT_DIR}/output.log" 2>/dev/null && { FOUND=1; break; }
+  sleep 1
+done
+
+if [ "${FOUND}" -eq 1 ]; then
+  echo "PASS: named connection factory (mq1) delivered messages successfully"
+else
+  echo "FAIL: expected log message not found within 60 seconds"
+  echo "--- output.log ---"
+  cat "${PROJECT_DIR}/output.log"
+  echo "--- end ---"
+fi
+
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+```
+
+### Step 2.3: Clean up named project
+
+```bash
+rm -rf "${PROJECT_DIR}" || true
+```
+
+---
+
+## Phase 3: Cleanup
+
+### Step 3.1: Kill Camel process (if still running)
+
+```bash
+if [ -n "${CAMEL_PID}" ]; then
+  kill "${CAMEL_PID}" 2>/dev/null || true
+  wait "${CAMEL_PID}" 2>/dev/null || true
+  echo "PASS: Camel process ${CAMEL_PID} stopped"
+else
+  echo "PASS: no CAMEL_PID set, nothing to stop"
+fi
+```
+
+### Step 3.2: Remove RabbitMQ container
+
+```bash
+${CONTAINER_RUNTIME} rm -f "${RABBITMQ_CONTAINER}" 2>/dev/null || true
+echo "PASS: RabbitMQ container removed"
+```
+
+### Step 3.3: Remove temporary directories
+
+```bash
+rm -rf "${PROJECT_DIR}" 2>/dev/null || true
+echo "PASS: temporary directories cleaned up"
+```
+
+### Step 3.4: Verify RabbitMQ container is gone
+
+```bash
+${CONTAINER_RUNTIME} ps -a --filter "name=${RABBITMQ_CONTAINER}" --format '{{.Names}}' | grep -q "${RABBITMQ_CONTAINER}"
+if [ $? -ne 0 ]; then
+  echo "PASS: RabbitMQ container is no longer present"
+else
+  echo "FAIL: RabbitMQ container still exists"
+fi
+```
+
+---
+
+## Test Summary
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | Critical |
+| 0 | 0.2 | Verify Java version >= 17 | Critical |
+| 1 | 1.1 | Start RabbitMQ container | Critical |
+| 1 | 1.2 | Create project with default configuration | Critical |
+| 1 | 1.3 | Run Camel and verify message flow (default bean) | Critical |
+| 1 | 1.4 | Clean up default project | High |
+| 2 | 2.1 | Create project with named/prefixed configuration | Critical |
+| 2 | 2.2 | Run Camel and verify named bean message flow | Critical |
+| 2 | 2.3 | Clean up named project | High |
+| 3 | 3.1 | Kill Camel process | Critical |
+| 3 | 3.2 | Remove RabbitMQ container | Critical |
+| 3 | 3.3 | Remove temporary directories | High |
+| 3 | 3.4 | Verify RabbitMQ container is gone | High |

--- a/tests/plans/rabbitmq-connection.md
+++ b/tests/plans/rabbitmq-connection.md
@@ -22,10 +22,10 @@ Both phases verify end-to-end message flow: a timer-driven producer sends messag
 ### Prerequisite check
 
 ```bash
-java -version 2>&1 | head -1
+java -version >/dev/null 2>&1
 JAVA_EXIT=$?
 
-camel version 2>&1 | head -1
+camel version >/dev/null 2>&1
 CAMEL_EXIT=$?
 
 if command -v podman > /dev/null 2>&1; then
@@ -60,10 +60,10 @@ If Camel JBang is not installed, see [common/forage-run.md](common/forage-run.md
 ### Test 0.1: Verify required tools
 
 ```bash
-java -version 2>&1 | head -1
+java -version >/dev/null 2>&1
 JAVA_EXIT=$?
 
-camel version 2>&1 | head -1
+camel version >/dev/null 2>&1
 CAMEL_EXIT=$?
 
 if command -v podman > /dev/null 2>&1; then
@@ -329,11 +329,14 @@ echo "PASS: temporary directories cleaned up"
 ### Step 3.4: Verify RabbitMQ container is gone
 
 ```bash
-${CONTAINER_RUNTIME} ps -a --filter "name=${RABBITMQ_CONTAINER}" --format '{{.Names}}' | grep -q "${RABBITMQ_CONTAINER}"
-if [ $? -ne 0 ]; then
-  echo "PASS: RabbitMQ container is no longer present"
+if container_names="$(${CONTAINER_RUNTIME} ps -a --filter "name=${RABBITMQ_CONTAINER}" --format '{{.Names}}' 2>/dev/null)"; then
+  if printf '%s\n' "${container_names}" | grep -Fxq -- "${RABBITMQ_CONTAINER}"; then
+    echo "FAIL: RabbitMQ container still exists"
+  else
+    echo "PASS: RabbitMQ container is no longer present"
+  fi
 else
-  echo "FAIL: RabbitMQ container still exists"
+  echo "FAIL: container lookup failed"
 fi
 ```
 

--- a/tests/plans/route-policies.md
+++ b/tests/plans/route-policies.md
@@ -1,0 +1,473 @@
+# Test Plan: Route Policy Provisioning
+
+## Overview
+
+End-to-end verification that Forage discovers route policy providers (flip, schedule) via ServiceLoader, creates policy instances from properties-based configuration, and applies them to Camel routes so that active/passive flipping and time-based scheduling work out of the box.
+
+Users write a `forage-policy.properties` file with `forage.route.policy.*` settings and Camel YAML routes. On `camel run`, the Forage plugin discovers enabled policies via `DefaultCamelForageRoutePolicyFactoryBean`, resolves per-route policy names from `forage.route.policy.<routeId>.name`, and delegates to the matching `RoutePolicyProvider` (flip or schedule) which configures and attaches a `RoutePolicy` to each route.
+
+Every step is fully automatable.
+
+### Known limitation
+
+Route policy modules (`forage-policy-factory`, `forage-policy-flip`, `forage-policy-schedule`) are **not** in the Forage catalog. This means the JBang plugin's catalog-driven dependency resolution does not automatically add them to the classpath. These tests will fail until route policy support is added to the catalog or a manual `--dep` flag is used. See the project issue tracker for status.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 17+ | `java -version` |
+| `camel` (JBang) | 4.16+ | `camel version` |
+
+No Docker is required. All tests use Camel timer routes and log output verification.
+
+If Camel JBang is not installed, see [common/forage-run.md](common/forage-run.md).
+
+### Prerequisite check script
+
+```bash
+FAIL=0
+
+for CMD in java camel; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found at $(command -v ${CMD})"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo ""
+  echo "FAIL: one or more prerequisites missing"
+  exit 1
+fi
+
+echo ""
+echo "PASS: all prerequisites met"
+```
+
+---
+
+## Phase 0: Prerequisites
+
+### Test 0.1: Verify tools
+
+```bash
+FAIL=0
+
+for CMD in java camel; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo "FAIL: prerequisites not met"
+  exit 1
+fi
+echo "PASS: all prerequisites met"
+```
+
+---
+
+## Phase 1: Flip Route Policy — Active/Passive
+
+Verify that when a flip policy is configured, only the initially-active route runs. The paired (passive) route should be stopped at startup.
+
+### Step 1.1: Create project directory
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-policy.properties" <<'PROPS'
+forage.route.policy.enabled=true
+
+forage.route.policy.route-primary.name=flip
+forage.route.policy.route-primary.flip.initially-active=true
+forage.route.policy.route-primary.flip.enabled=true
+forage.route.policy.route-primary.flip.paired-route=route-secondary
+
+forage.route.policy.route-secondary.name=flip
+forage.route.policy.route-secondary.flip.enabled=true
+forage.route.policy.route-secondary.flip.paired-route=route-primary
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: route-primary
+    from:
+      uri: timer
+      parameters:
+        timerName: primary
+        period: "2000"
+      steps:
+        - log:
+            message: "PRIMARY is running"
+- route:
+    id: route-secondary
+    from:
+      uri: timer
+      parameters:
+        timerName: secondary
+        period: "2000"
+      steps:
+        - log:
+            message: "SECONDARY is running"
+ROUTE
+
+echo "PASS: project directory created at ${PROJECT_DIR}"
+```
+
+### Step 1.2: Run Camel in background
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+```
+
+### Test 1.3: Verify PRIMARY route is running
+
+```bash
+for i in $(seq 1 30); do
+  grep -q "PRIMARY is running" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "PRIMARY is running" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: PRIMARY route is running"
+else
+  echo "FAIL: PRIMARY route log message not found"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 1.4: Verify SECONDARY route is NOT running
+
+The secondary route is configured with `initially-active=false`, so it should be stopped by the flip policy at startup.
+
+```bash
+sleep 5
+
+if grep -q "SECONDARY is running" "${PROJECT_DIR}/output.log"; then
+  echo "FAIL: SECONDARY route should NOT be running (it is the passive route)"
+else
+  echo "PASS: SECONDARY route is correctly stopped (passive)"
+fi
+```
+
+### Step 1.5: Cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}" || true
+echo "PASS: Phase 1 cleanup complete"
+```
+
+---
+
+## Phase 2: Schedule Route Policy — Within Active Window
+
+Verify that a route with a schedule policy runs when the current time falls within the configured start/stop window.
+
+### Step 2.1: Create project directory
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-policy.properties" <<'PROPS'
+forage.route.policy.enabled=true
+forage.route.policy.scheduled-route.name=schedule
+forage.route.policy.scheduled-route.schedule.start-time=00:00
+forage.route.policy.scheduled-route.schedule.stop-time=23:59
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: scheduled-route
+    from:
+      uri: timer
+      parameters:
+        timerName: scheduled
+        period: "2000"
+      steps:
+        - log:
+            message: "SCHEDULED is running"
+ROUTE
+
+echo "PASS: project directory created at ${PROJECT_DIR}"
+```
+
+### Step 2.2: Run Camel in background
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+```
+
+### Test 2.3: Verify scheduled route is running
+
+```bash
+for i in $(seq 1 30); do
+  grep -q "SCHEDULED is running" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+grep -q "SCHEDULED is running" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: SCHEDULED route is running within active window"
+else
+  echo "FAIL: SCHEDULED route log message not found"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Step 2.4: Cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}" || true
+echo "PASS: Phase 2 cleanup complete"
+```
+
+---
+
+## Phase 3: Schedule Route Policy — Outside Active Window
+
+Verify that a route with a schedule policy does NOT run when the current time falls outside the configured start/stop window. Uses a narrow one-minute window at 03:00-03:01 which is unlikely to overlap with test execution.
+
+### Step 3.1: Create project directory
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-policy.properties" <<'PROPS'
+forage.route.policy.enabled=true
+forage.route.policy.off-hours-route.name=schedule
+forage.route.policy.off-hours-route.schedule.start-time=03:00
+forage.route.policy.off-hours-route.schedule.stop-time=03:01
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: off-hours-route
+    from:
+      uri: timer
+      parameters:
+        timerName: offhours
+        period: "2000"
+      steps:
+        - log:
+            message: "OFF-HOURS should not run"
+ROUTE
+
+echo "PASS: project directory created at ${PROJECT_DIR}"
+```
+
+### Step 3.2: Run Camel in background
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+```
+
+### Test 3.3: Verify route does NOT produce log messages
+
+Wait for the schedule policy's initial check (runs immediately on start, then every 60 seconds). Give it 15 seconds — if the schedule check works correctly, the route should be stopped and no log messages should appear.
+
+```bash
+sleep 15
+
+if grep -q "OFF-HOURS should not run" "${PROJECT_DIR}/output.log"; then
+  echo "FAIL: OFF-HOURS route should NOT be running (outside schedule window)"
+  echo "Note: This test assumes execution is NOT between 03:00-03:01 local time"
+else
+  echo "PASS: OFF-HOURS route correctly stopped (outside schedule window)"
+fi
+```
+
+### Test 3.4: Verify schedule policy logged its decision
+
+```bash
+if grep -q "exiting schedule window\|not active on\|schedule check" "${PROJECT_DIR}/output.log"; then
+  echo "PASS: schedule policy log messages found"
+else
+  echo "INFO: no schedule policy log messages found (may need DEBUG log level)"
+fi
+```
+
+### Step 3.5: Cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}" || true
+echo "PASS: Phase 3 cleanup complete"
+```
+
+---
+
+## Phase 4: Policy Disabled
+
+Verify that when `forage.route.policy.enabled=false`, no policies are applied and all routes run normally regardless of flip/schedule configuration.
+
+### Step 4.1: Create project directory
+
+```bash
+PROJECT_DIR=$(mktemp -d)
+
+cat > "${PROJECT_DIR}/forage-policy.properties" <<'PROPS'
+forage.route.policy.enabled=false
+forage.route.policy.route-primary.name=flip
+forage.route.policy.route-primary.flip.paired-route=route-secondary
+forage.route.policy.route-primary.flip.initially-active=true
+forage.route.policy.route-secondary.name=flip
+forage.route.policy.route-secondary.flip.paired-route=route-primary
+forage.route.policy.route-secondary.flip.initially-active=false
+PROPS
+
+cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
+- route:
+    id: route-primary
+    from:
+      uri: timer
+      parameters:
+        timerName: primary
+        period: "2000"
+      steps:
+        - log:
+            message: "PRIMARY is running"
+- route:
+    id: route-secondary
+    from:
+      uri: timer
+      parameters:
+        timerName: secondary
+        period: "2000"
+      steps:
+        - log:
+            message: "SECONDARY is running"
+ROUTE
+
+echo "PASS: project directory created at ${PROJECT_DIR}"
+```
+
+### Step 4.2: Run Camel in background
+
+```bash
+camel run "${PROJECT_DIR}"/* > "${PROJECT_DIR}/output.log" 2>&1 &
+CAMEL_PID=$!
+echo "Camel started with PID ${CAMEL_PID}"
+```
+
+### Test 4.3: Verify BOTH routes are running
+
+With policies disabled, no flip policy is applied, so both routes should run normally.
+
+```bash
+for i in $(seq 1 30); do
+  grep -q "PRIMARY is running" "${PROJECT_DIR}/output.log" 2>/dev/null && \
+  grep -q "SECONDARY is running" "${PROJECT_DIR}/output.log" 2>/dev/null && break
+  sleep 1
+done
+
+PASS_COUNT=0
+
+grep -q "PRIMARY is running" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: PRIMARY route is running"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: PRIMARY route log message not found"
+fi
+
+grep -q "SECONDARY is running" "${PROJECT_DIR}/output.log"
+if [ $? -eq 0 ]; then
+  echo "PASS: SECONDARY route is running"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: SECONDARY route log message not found"
+fi
+
+if [ "${PASS_COUNT}" -eq 2 ]; then
+  echo "PASS: both routes running with policies disabled"
+else
+  echo "FAIL: expected both routes to run when policies are disabled"
+  cat "${PROJECT_DIR}/output.log"
+fi
+```
+
+### Test 4.4: Verify policy factory logged as disabled
+
+```bash
+if grep -q "Route policy factory is disabled" "${PROJECT_DIR}/output.log"; then
+  echo "PASS: policy factory correctly reports disabled"
+else
+  echo "INFO: disabled message not found (may need INFO log level)"
+fi
+```
+
+### Step 4.5: Cleanup
+
+```bash
+kill "${CAMEL_PID}" 2>/dev/null || true
+wait "${CAMEL_PID}" 2>/dev/null || true
+rm -rf "${PROJECT_DIR}" || true
+echo "PASS: Phase 4 cleanup complete"
+```
+
+---
+
+## Phase 5: Cleanup
+
+Final cleanup in case any earlier phase was interrupted.
+
+### Step 5.1: Kill any remaining Camel process
+
+```bash
+if [ -n "${CAMEL_PID}" ]; then
+  kill "${CAMEL_PID}" 2>/dev/null || true
+  wait "${CAMEL_PID}" 2>/dev/null || true
+  echo "PASS: Camel process stopped"
+else
+  echo "PASS: no Camel process to stop"
+fi
+```
+
+### Step 5.2: Remove temporary directory
+
+```bash
+if [ -n "${PROJECT_DIR}" ] && [ -d "${PROJECT_DIR}" ]; then
+  rm -rf "${PROJECT_DIR}" || true
+  echo "PASS: temporary directory removed"
+else
+  echo "PASS: no temporary directory to remove"
+fi
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify prerequisites (java, camel) | High |
+| 1 | 1.3 | PRIMARY route runs (flip policy, initially-active=true) | Critical |
+| 1 | 1.4 | SECONDARY route stopped (flip policy, initially-active=false) | Critical |
+| 2 | 2.3 | Scheduled route runs within active window (00:00-23:59) | Critical |
+| 3 | 3.3 | Off-hours route stopped outside schedule window (03:00-03:01) | Critical |
+| 3 | 3.4 | Schedule policy logs its decision | Low |
+| 4 | 4.3 | Both routes run when policies disabled | Critical |
+| 4 | 4.4 | Policy factory logs disabled status | Low |
+| 5 | 5.1-5.2 | Final cleanup | High |


### PR DESCRIPTION
## Summary

- Add 7 end-to-end test plans under `tests/plans/` that exercise Forage as a user would: create sample projects with properties + YAML routes, run via `camel run` / `camel forage run`, verify behavior
- Add 2 common docs (`common/forage-run.md` for plugin installation, `common/start-container.md` for Docker/Podman container setup)
- Add `docs/contributing-test-plans.md` — guide for writing new test plans
- Update `CLAUDE.md` with test plans section and project structure

### Test Plans

| Plan | What it tests |
|------|---------------|
| `jdbc-datasource.md` | H2 embedded, PostgreSQL via container, multi-datasource (`ds1`/`ds2`), pool settings, `--strict` validation |
| `jms-messaging.md` | Artemis send/receive, XA transactions, pool tuning |
| `cxf-soap-endpoints.md` | Default + named CXF endpoints, SOAP server/client |
| `rabbitmq-connection.md` | Default + named (`#mq1`) RabbitMQ connections |
| `property-validation.md` | Typo detection, `--strict` mode, multiple errors |
| `config-commands.md` | `config read`, `config write`, `config write --delete`, round-trip |
| `route-policies.md` | Flip active/passive, schedule time windows, policy disabled |

### Execution Results

All plans were executed against Camel JBang 4.18.2 with Forage plugin 1.4.0-SNAPSHOT:

| Plan | Result | Notes |
|------|--------|-------|
| Property Validation | **PASS** | Typo detection (`usernam` → suggests `username`), `--strict` exits with code 1, multi-error reports all typos |
| JDBC DataSource | **PASS** | PostgreSQL query via Forage-created DataSource returned `[{id=1, content=hello}, {id=2, content=world}]` |
| JMS Messaging | **PASS** | 3/3 messages sent and received via Artemis with pooled ConnectionFactory, sub-10ms latency |
| RabbitMQ Connection | **PASS** | Messages flow via `rabbitConnectionFactory` bean. Podman rootless needs Erlang cookie workaround (documented) |
| CXF SOAP | **PASS** (5/6) | Internal SOAP round-trip works, "Hello from CXF" received. External curl gets 404 (CXF transport binding in JBang mode) |
| Config Commands | **PASS** | `config read` lists beans, `config write` generates properties with dependency coordinates, round-trip works |
| Route Policies | **FAIL** | Flip policy not activated — both routes run. Policy modules are not in the Forage catalog, so JBang doesn't add them to the classpath. Documented as known limitation |

### Fixes Applied During Execution

- Artemis readiness check: `"Server is now live"` → `"Server is now active"` (image version change)
- RabbitMQ: documented Podman rootless Erlang cookie workaround
- Route YAML: fixed `steps` indentation (must be nested under `from`, not sibling)
- Route policies: fixed flip config format (added `flip.enabled=true` per route), documented catalog gap

## Test plan

- [x] Execute property-validation plan — PASS
- [x] Execute jdbc-datasource plan (PostgreSQL phase) — PASS
- [x] Execute jms-messaging plan (Artemis) — PASS
- [x] Execute rabbitmq-connection plan — PASS
- [x] Execute cxf-soap-endpoints plan — PASS (5/6)
- [x] Execute config-commands plan — PASS
- [x] Execute route-policies plan — FAIL (known limitation documented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded repository guidance for end-to-end testing, including a new “Test Plans” section and added plans under `tests/plans/`.
  * Added a contributor guide for writing executable test plans with required phases, assertions, and cleanup behavior.
  * Introduced shared instructions for running Forage-based projects and starting containerized services (Docker/Podman).
  * Added end-to-end test plans for configuration commands, JDBC, JMS, CXF/SOAP, RabbitMQ, property validation, and route policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->