### PR TITLE
chore: upgrade GitHub Actions to latest versions and pin by commit hash

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -12,10 +12,10 @@ jobs:
     if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -24,7 +24,7 @@ jobs:
       - name: Generate catalog
         run: mvn -B --no-transfer-progress install -DskipTests -pl forage-catalog -am
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,12 +22,12 @@ jobs:
     if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -36,7 +36,7 @@ jobs:
       - name: Generate catalog
         run: mvn -B --no-transfer-progress install -DskipTests -pl forage-catalog -am
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -50,7 +50,7 @@ jobs:
         working-directory: website
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/site
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -20,13 +20,13 @@ jobs:
     if: github.repository == 'KaotoIO/forage'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref: main
         persist-credentials: false
         fetch-depth: 0
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
       run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml
     - name: Upload test reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-reports
         path: |

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -43,9 +43,9 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -64,9 +64,9 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -75,7 +75,7 @@ jobs:
         run: mvn -B --no-transfer-progress '-Dsurefire.rerunFailingTestsCount=2' '-Dci.env.name=github.com' install failsafe:integration-test failsafe:verify --file pom.xml
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-reports
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       # Configure build steps as you'd normally do
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -82,7 +82,7 @@ jobs:
       # Create a release
 
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # v2.5.0
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.releaseVersion }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release
           path: |


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions across all workflows to their latest versions
- Pin every action by commit SHA for supply-chain security

### Actions upgraded

| Action | Previous | New |
|--------|----------|-----|
| `actions/checkout` | v4.2.2 / v6 | v7.0.0 |
| `actions/dependency-review-action` | v4.5.0 | v5.0.0 |
| `actions/setup-java` | v5 | v5.5.0 |
| `actions/setup-python` | v5 | v6.3.0 |
| `actions/upload-pages-artifact` | v3 | v5.0.0 |
| `actions/deploy-pages` | v4 | v5.0.0 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `jreleaser/release-action` | v2 | v2.5.0 |

## Test plan

- [ ] CI workflows pass on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, testing, documentation, deployment, and release workflows to newer action versions.
  * Pinned workflow actions to specific revisions for more consistent and reliable executions.
  * Improved dependency review, artifact uploads, documentation publishing, and release automation without changing workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->