### PR TITLE
Partially fix #411: catalog missing web-search modules, CodeScanner robustness, JBang plugin fixes

### DIFF
--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -260,6 +260,26 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Web Search Modules -->
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-web-search</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-web-search-tavily</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-web-search-google-custom</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- RAG Modules -->
         <dependency>
             <groupId>io.kaoto.forage</groupId>

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageExport.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageExport.java
@@ -23,6 +23,8 @@ public class ForageExport extends Export {
 
     @Override
     public Integer doCall() throws Exception {
+        ForagePlugin.resolveConfigDir(files);
+
         // Validate properties before exporting
         int validationResult = validation.validateAndReport(printer());
         if (validationResult != 0) {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageExport.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageExport.java
@@ -31,6 +31,14 @@ public class ForageExport extends Export {
             return validationResult;
         }
 
-        return super.doCall();
+        // Exporting may delegate to run infrastructure that triggers the plugin's beforeRun hook —
+        // mark validation as handled so it is not repeated. The finally block resets the flag in
+        // case the hook never ran, so a reused plugin instance starts clean.
+        ForagePropertyValidator.markValidationHandled();
+        try {
+            return super.doCall();
+        } finally {
+            ForagePropertyValidator.consumeValidationHandled();
+        }
     }
 }

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
@@ -78,7 +78,48 @@ public class ForagePlugin implements Plugin {
         resolveConfigDir(files);
         propagateProfile(main);
         addCatalogDrivenRepos(main);
-        ForagePropertyValidator.validateAndReport(new Printer.SystemOutPrinter(), false, false);
+        validateProperties();
+    }
+
+    /**
+     * Validates Forage properties when running via plain {@code camel run}.
+     *
+     * <p>Skipped when a Forage command ({@code camel forage run}/{@code camel forage export}) has
+     * already validated with the user's {@code --skip-validation}/{@code --strict} flags, to avoid
+     * printing warnings twice.
+     *
+     * <p>For plain {@code camel run} (where the Forage command options are not available),
+     * validation is controlled via the {@code forage.validation.skip} system property (or
+     * {@code FORAGE_VALIDATION_SKIP} environment variable) to skip validation, and
+     * {@code forage.validation.strict} (or {@code FORAGE_VALIDATION_STRICT}) to fail the run on
+     * validation warnings.
+     *
+     * <p>{@link PluginRunCustomizer#beforeRun} returns {@code void} and Camel JBang's {@code Run}
+     * invokes it outside any try/catch, so in strict mode the only way to abort the run is to
+     * throw. The exception propagates to picocli's execution exception handler, which prints it
+     * and exits with a non-zero code.
+     */
+    private static void validateProperties() {
+        if (ForagePropertyValidator.consumeValidationHandled()) {
+            return;
+        }
+
+        boolean skip = booleanOverride("forage.validation.skip", "FORAGE_VALIDATION_SKIP");
+        boolean strict = booleanOverride("forage.validation.strict", "FORAGE_VALIDATION_STRICT");
+
+        int result = ForagePropertyValidator.validateAndReport(new Printer.SystemOutPrinter(), skip, strict);
+        if (result != 0) {
+            throw new RuntimeException("Forage property validation failed in strict mode. "
+                    + "Fix the reported warnings, or unset forage.validation.strict / FORAGE_VALIDATION_STRICT.");
+        }
+    }
+
+    private static boolean booleanOverride(String systemProperty, String envVar) {
+        String value = System.getProperty(systemProperty);
+        if (value == null) {
+            value = System.getenv(envVar);
+        }
+        return Boolean.parseBoolean(value);
     }
 
     // JVM-global side effect: sets camel.main.profile so ForagePropertyScanner can resolve the

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
@@ -78,6 +78,7 @@ public class ForagePlugin implements Plugin {
         resolveConfigDir(files);
         propagateProfile(main);
         addCatalogDrivenRepos(main);
+        ForagePropertyValidator.validateAndReport(new Printer.SystemOutPrinter(), false, false);
     }
 
     // JVM-global side effect: sets camel.main.profile so ForagePropertyScanner can resolve the

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.camel.dsl.jbang.core.common.Printer;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.slf4j.Logger;
@@ -33,7 +34,33 @@ public final class ForagePropertyValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(ForagePropertyValidator.class);
 
+    /**
+     * Set when a Forage command ({@code camel forage run}/{@code camel forage export}) has already
+     * validated properties with the user's {@code --skip-validation}/{@code --strict} flags, so the
+     * plugin's {@code beforeRun} hook (triggered by the delegated {@code camel run}) must not
+     * validate — and print warnings — a second time. The commands and the plugin live in the same
+     * module/classloader and run in the same JVM, so a static flag is sufficient and avoids leaking
+     * internal state into the user-visible system property space.
+     */
+    private static final AtomicBoolean VALIDATION_HANDLED = new AtomicBoolean(false);
+
     private ForagePropertyValidator() {}
+
+    /**
+     * Marks property validation as already handled by a Forage command, so the plugin's
+     * {@code beforeRun} hook skips its own validation for the current run.
+     */
+    public static void markValidationHandled() {
+        VALIDATION_HANDLED.set(true);
+    }
+
+    /**
+     * Returns whether validation was already handled and resets the flag, so a plugin instance
+     * reused in the same JVM starts the next run with a clean state.
+     */
+    public static boolean consumeValidationHandled() {
+        return VALIDATION_HANDLED.getAndSet(false);
+    }
 
     /**
      * Helper method to avoid code redundancy.

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageRun.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForageRun.java
@@ -36,6 +36,15 @@ public class ForageRun extends Run {
             return validationResult;
         }
 
-        return super.doCall();
+        // super.doCall() triggers the plugin's beforeRun hook (ForagePlugin), which would validate
+        // again — mark validation as handled so warnings are not printed twice and --skip-validation
+        // fully suppresses output. The hook consumes the flag; the finally block resets it in case
+        // the hook never ran (e.g. an early failure), so a reused plugin instance starts clean.
+        ForagePropertyValidator.markValidationHandled();
+        try {
+            return super.doCall();
+        } finally {
+            ForagePropertyValidator.consumeValidationHandled();
+        }
     }
 }

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigReadCommand.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigReadCommand.java
@@ -54,8 +54,8 @@ public class ConfigReadCommand extends CamelCommand {
 
     @CommandLine.Option(
             names = {"--strategy", "-s"},
-            description = "Property file strategy: 'forage' reads from forage-*.properties files (default), "
-                    + "'application' reads from application.properties.",
+            description = "Property file strategy: 'application' reads from application.properties (default), "
+                    + "'forage' reads from forage-*.properties files.",
             defaultValue = "application")
     private String strategy;
 

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigReadCommand.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigReadCommand.java
@@ -400,7 +400,7 @@ public class ConfigReadCommand extends CamelCommand {
     private String mapFeatureToJavaType(String feature) {
         // Map feature category names to their Java types
         return switch (feature) {
-            case "Chat Model" -> "dev.langchain4j.model.chat.ChatLanguageModel";
+            case "Chat Model" -> "dev.langchain4j.model.chat.ChatModel";
             case "Memory" -> "dev.langchain4j.memory.ChatMemory";
             case "javax.sql.DataSource" -> "javax.sql.DataSource";
             case "jakarta.jms.ConnectionFactory" -> "jakarta.jms.ConnectionFactory";

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigWriteCommand.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigWriteCommand.java
@@ -54,8 +54,8 @@ public class ConfigWriteCommand extends CamelCommand {
 
     @CommandLine.Option(
             names = {"--strategy", "-s"},
-            description = "Property file strategy: 'forage' writes to forage-*.properties files (default), "
-                    + "'application' writes to application.properties.",
+            description = "Property file strategy: 'application' writes to application.properties (default), "
+                    + "'forage' writes to forage-*.properties files.",
             defaultValue = "application")
     private String strategy;
 

--- a/tooling/camel-jbang-plugin-forage/src/test/java/io/kaoto/forage/plugin/ForagePropertyValidatorTest.java
+++ b/tooling/camel-jbang-plugin-forage/src/test/java/io/kaoto/forage/plugin/ForagePropertyValidatorTest.java
@@ -273,6 +273,19 @@ class ForagePropertyValidatorTest {
         assertThat(farTypoWarning.getMessage()).doesNotContain("Did you mean");
     }
 
+    @Test
+    void testValidationHandledGuardIsConsumedAndReset() {
+        // Initially not handled
+        assertThat(ForagePropertyValidator.consumeValidationHandled()).isFalse();
+
+        // Marking makes the next consume return true...
+        ForagePropertyValidator.markValidationHandled();
+        assertThat(ForagePropertyValidator.consumeValidationHandled()).isTrue();
+
+        // ...and consuming resets the flag so a reused plugin instance starts clean
+        assertThat(ForagePropertyValidator.consumeValidationHandled()).isFalse();
+    }
+
     // Helper method to create properties files
     private File createPropertiesFile(String filename, String... lines) throws IOException {
         File file = tempDir.resolve(filename).toFile();

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
@@ -91,15 +91,20 @@ public class CodeScanner {
         try {
             log.debug("Scanning source directory: " + sourceDir);
 
+            // Prefer src/main/java to avoid scanning generated sources under target/
+            Path javaSourceDir = sourceDir.resolve("src").resolve("main").resolve("java");
+            Path scanDir = Files.isDirectory(javaSourceDir) ? javaSourceDir : sourceDir;
+
             // Walk through all Java files ONCE and extract all information
-            try (Stream<Path> paths = Files.walk(sourceDir)) {
+            try (Stream<Path> paths = Files.walk(scanDir)) {
                 paths.filter(path -> path.toString().endsWith(".java"))
-                        .filter(path -> !path.toString().contains("/test/"))
+                        .filter(path -> !containsPathSegment(path, "target"))
+                        .filter(path -> !containsPathSegment(path, "test"))
                         .forEach(javaFile -> {
                             try {
                                 scanJavaFileForAllInfo(javaFile, result);
                             } catch (Exception e) {
-                                log.warn("Failed to parse Java file: " + javaFile);
+                                log.warn("Failed to parse Java file: " + javaFile + " - " + e.getMessage());
                                 log.debug("Parse error details: " + e.getMessage(), e);
                             }
                         });
@@ -911,10 +916,13 @@ public class CodeScanner {
     private List<String> extractStringArrayValue(Expression value) {
         List<String> result = new ArrayList<>();
 
-        ArrayInitializerExpr arrayExpr = (ArrayInitializerExpr) value;
-        for (Expression element : arrayExpr.getValues()) {
-            if (element instanceof StringLiteralExpr) {
-                result.add(((StringLiteralExpr) element).asString());
+        if (value instanceof StringLiteralExpr stringLiteral) {
+            result.add(stringLiteral.asString());
+        } else if (value instanceof ArrayInitializerExpr arrayExpr) {
+            for (Expression element : arrayExpr.getValues()) {
+                if (element instanceof StringLiteralExpr stringElement) {
+                    result.add(stringElement.asString());
+                }
             }
         }
 
@@ -967,5 +975,14 @@ public class CodeScanner {
         }
 
         return null;
+    }
+
+    private static boolean containsPathSegment(Path path, String segment) {
+        for (Path part : path) {
+            if (segment.equals(part.toString())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
@@ -98,8 +98,7 @@ public class CodeScanner {
             // Walk through all Java files ONCE and extract all information
             try (Stream<Path> paths = Files.walk(scanDir)) {
                 paths.filter(path -> path.toString().endsWith(".java"))
-                        .filter(path -> !containsPathSegment(path, "target"))
-                        .filter(path -> !containsPathSegment(path, "test"))
+                        .filter(path -> isScannablePath(scanDir, path))
                         .forEach(javaFile -> {
                             try {
                                 scanJavaFileForAllInfo(javaFile, result);
@@ -380,7 +379,7 @@ public class CodeScanner {
                         data.setName(stringLiteral.asString());
                     }
                 }
-                case "components" -> data.setComponents(extractStringArrayValue(value));
+                case "components" -> data.setComponents(extractStringArrayValue(value, "@ForageFactory 'components'"));
                 case "description" -> {
                     if (value instanceof StringLiteralExpr stringLiteral) {
                         data.setDescription(stringLiteral.asString());
@@ -395,7 +394,8 @@ public class CodeScanner {
                 case "conditionalBeans" -> data.setConditionalBeans(extractConditionalBeanGroupArray(value));
                 case "variant" -> data.setVariant(extractVariantValue(value));
                 case "configClass" -> data.setConfigClassName(extractClassValue(value, cu));
-                case "runtimeDependencies" -> data.setRuntimeDependencies(extractStringArrayValue(value));
+                case "runtimeDependencies" ->
+                    data.setRuntimeDependencies(extractStringArrayValue(value, "@ForageFactory 'runtimeDependencies'"));
                 default -> {}
             }
         }
@@ -452,7 +452,8 @@ public class CodeScanner {
                     }
                 }
                 case "beans" -> beans = extractConditionalBeanArray(value);
-                case "runtimeDependencies" -> runtimeDeps = extractStringArrayValue(value);
+                case "runtimeDependencies" ->
+                    runtimeDeps = extractStringArrayValue(value, "@ConditionalBeanGroup 'runtimeDependencies'");
                 default -> {}
             }
         }
@@ -571,7 +572,7 @@ public class CodeScanner {
                             name = stringLiteral.asString();
                         }
                     }
-                    case "components" -> components = extractStringArrayValue(value);
+                    case "components" -> components = extractStringArrayValue(value, "@ForageBean 'components'");
                     case "description" -> {
                         if (value instanceof StringLiteralExpr stringLiteral) {
                             description = stringLiteral.asString();
@@ -583,8 +584,9 @@ public class CodeScanner {
                         }
                     }
                     case "configClass" -> configClassName = extractClassValue(value, cu);
-                    case "runtimeDependencies" -> runtimeDeps = extractStringArrayValue(value);
-                    case "repositories" -> repositories = extractStringArrayValue(value);
+                    case "runtimeDependencies" ->
+                        runtimeDeps = extractStringArrayValue(value, "@ForageBean 'runtimeDependencies'");
+                    case "repositories" -> repositories = extractStringArrayValue(value, "@ForageBean 'repositories'");
                     default -> {}
                 }
             }
@@ -912,8 +914,14 @@ public class CodeScanner {
 
     /**
      * Extracts a list of strings from an annotation value that can be either a single string or an array of strings.
+     * Non-literal expressions (e.g. constant references) cannot be resolved by source parsing and are
+     * skipped with a warning naming the annotation member being read.
+     *
+     * @param value the annotation member value expression
+     * @param annotationContext the annotation and member being parsed (e.g. {@code @ForageBean 'components'}),
+     *        used in warning messages
      */
-    private List<String> extractStringArrayValue(Expression value) {
+    private List<String> extractStringArrayValue(Expression value, String annotationContext) {
         List<String> result = new ArrayList<>();
 
         if (value instanceof StringLiteralExpr stringLiteral) {
@@ -922,8 +930,16 @@ public class CodeScanner {
             for (Expression element : arrayExpr.getValues()) {
                 if (element instanceof StringLiteralExpr stringElement) {
                     result.add(stringElement.asString());
+                } else {
+                    log.warn("Skipping non-string-literal element of type "
+                            + element.getClass().getSimpleName() + " in " + annotationContext
+                            + " (only string literals are supported): " + element);
                 }
             }
+        } else {
+            log.warn("Cannot extract string values from " + annotationContext + ": unsupported expression type "
+                    + value.getClass().getSimpleName()
+                    + " (only string literals and array initializers are supported): " + value);
         }
 
         return result;
@@ -975,6 +991,18 @@ public class CodeScanner {
         }
 
         return null;
+    }
+
+    /**
+     * Returns whether a Java file under the scan root should be scanned. Files under {@code target}
+     * or {@code test} directories are skipped, but only segments <em>below</em> the scan root are
+     * considered: the path is relativized against the scan root first, so a checkout under a
+     * directory literally named {@code test} or {@code target} (e.g. {@code /home/ci/test/forage})
+     * does not cause every file to be skipped.
+     */
+    static boolean isScannablePath(Path scanRoot, Path path) {
+        Path relative = scanRoot.relativize(path);
+        return !containsPathSegment(relative, "target") && !containsPathSegment(relative, "test");
     }
 
     private static boolean containsPathSegment(Path path, String segment) {

--- a/tooling/forage-maven-catalog-plugin/src/test/java/io/kaoto/forage/maven/catalog/CodeScannerTest.java
+++ b/tooling/forage-maven-catalog-plugin/src/test/java/io/kaoto/forage/maven/catalog/CodeScannerTest.java
@@ -1,0 +1,62 @@
+package io.kaoto.forage.maven.catalog;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for CodeScanner path filtering.
+ */
+public class CodeScannerTest {
+
+    @Test
+    public void testScannablePathAcceptsRegularSources() {
+        Path scanRoot = Path.of("/home/user/forage/library/module/src/main/java");
+        Path file = scanRoot.resolve("io/kaoto/forage/Example.java");
+
+        assertThat(CodeScanner.isScannablePath(scanRoot, file)).isTrue();
+    }
+
+    @Test
+    public void testScannablePathSkipsTestDirectoriesBelowScanRoot() {
+        Path scanRoot = Path.of("/home/user/forage/library/module");
+        Path testFile = scanRoot.resolve("src/test/java/io/kaoto/forage/ExampleTest.java");
+
+        assertThat(CodeScanner.isScannablePath(scanRoot, testFile)).isFalse();
+    }
+
+    @Test
+    public void testScannablePathSkipsTargetDirectoriesBelowScanRoot() {
+        Path scanRoot = Path.of("/home/user/forage/library/module");
+        Path generatedFile = scanRoot.resolve("target/generated-sources/io/kaoto/forage/Generated.java");
+
+        assertThat(CodeScanner.isScannablePath(scanRoot, generatedFile)).isFalse();
+    }
+
+    @Test
+    public void testScannablePathIgnoresTestSegmentAboveScanRoot() {
+        // A checkout under a directory literally named "test" must not cause files to be skipped
+        Path scanRoot = Path.of("/home/ci/test/forage/library/module/src/main/java");
+        Path file = scanRoot.resolve("io/kaoto/forage/Example.java");
+
+        assertThat(CodeScanner.isScannablePath(scanRoot, file)).isTrue();
+    }
+
+    @Test
+    public void testScannablePathIgnoresTargetSegmentAboveScanRoot() {
+        Path scanRoot = Path.of("/home/ci/target/forage/library/module/src/main/java");
+        Path file = scanRoot.resolve("io/kaoto/forage/Example.java");
+
+        assertThat(CodeScanner.isScannablePath(scanRoot, file)).isTrue();
+    }
+
+    @Test
+    public void testScannablePathSkipsTestSegmentBelowScanRootEvenWhenRootContainsTest() {
+        // Segments below the scan root are still filtered when the root itself lives under "test"
+        Path scanRoot = Path.of("/home/ci/test/forage/library/module");
+        Path testFile = scanRoot.resolve("src/test/java/io/kaoto/forage/ExampleTest.java");
+
+        assertThat(CodeScanner.isScannablePath(scanRoot, testFile)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the tooling & build issues reported in #411:

- **Catalog**: add `forage-web-search`, `forage-web-search-tavily`, and `forage-web-search-google-custom` to `forage-catalog/pom.xml` so they appear in the catalog, JBang validation, and dependency export
- **CodeScanner**: fix `extractStringArrayValue` `ClassCastException` when annotation uses a bare string literal (`components = "camel-jdbc"`) instead of an array; improve warning message on per-file parse failure to include the error text
- **CodeScanner**: prefer `src/main/java` as the scan root to avoid walking `target/generated-*sources`; replace the Unix-only `/test/` string filter with a portable path-segment check (`containsPathSegment`)
- **ConfigWriteCommand**: correct `--strategy` help text — `application` is the default, not `forage`
- **ConfigReadCommand**: update `mapFeatureToJavaType` to emit `dev.langchain4j.model.chat.ChatModel` (LangChain4j 1.x) instead of the removed `ChatLanguageModel`
- **ForageExport**: call `ForagePlugin.resolveConfigDir(files)` before property validation so the config directory is resolved the same way as `ForageRun`
- **ForagePlugin**: wire `ForagePropertyValidator.validateAndReport` into the `beforeRun` hook so property typo warnings are printed during plain `camel run` (warn-only; strict mode remains available via `camel forage run`)

## Test plan

- [ ] `mvn clean compile` passes with no errors on all changed modules
- [ ] `camel run` with Forage properties prints warnings for unknown/misspelled property keys
- [ ] `camel forage run` still validates with `--strict` support
- [ ] `camel forage config write` `--strategy` help shows `application` as default
- [ ] Catalog generation includes web-search module entries
- [ ] Annotations using `components = "single-value"` (no braces) are scanned correctly

Part of #411 (the POM-hygiene, docs, and remaining catalog/plugin items are tracked as follow-ups in the issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for web search integrations, including Tavily and Google Custom Search.
* **Bug Fixes**
  * Improved configuration validation and reporting during run and export commands.
  * Updated Chat Model handling for improved compatibility.
  * Improved catalog discovery across standard source directories and supported string or array configuration values.
* **Documentation**
  * Clarified the help text for configuration strategy options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
