### PR TITLE
Fix #402: XA JMS enlistment, Narayana recovery node accumulation, idempotent repo NPE, pool validator

### DIFF
--- a/library/jdbc/forage-jdbc-common/pom.xml
+++ b/library/jdbc/forage-jdbc-common/pom.xml
@@ -65,6 +65,25 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/PooledDataSource.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/PooledDataSource.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration.ConnectionValidator;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
@@ -88,7 +89,8 @@ public abstract class PooledDataSource implements DataSourceProvider, ForageIdRe
                 .acquisitionTimeout(Duration.ofSeconds(config.acquisitionTimeoutSeconds()))
                 .validationTimeout(Duration.ofSeconds(config.validationTimeoutSeconds()))
                 .leakTimeout(Duration.ofMinutes(config.leakTimeoutMinutes()))
-                .idleValidationTimeout(Duration.ofMinutes(config.idleValidationTimeoutMinutes()));
+                .idleValidationTimeout(Duration.ofMinutes(config.idleValidationTimeoutMinutes()))
+                .connectionValidator(ConnectionValidator.defaultValidator());
 
         if (config.transactionEnabled()) {
             new TransactionConfiguration(config, id == null ? "dataSource" : id).initializeNarayana();

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepository.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepository.java
@@ -4,6 +4,7 @@ import javax.sql.DataSource;
 
 import org.apache.camel.processor.idempotent.jdbc.JdbcMessageIdRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import io.kaoto.forage.jdbc.common.DataSourceFactoryConfig;
@@ -38,8 +39,9 @@ public class ForageJdbcMessageIdRepository extends JdbcMessageIdRepository {
         if (config.transactionEnabled()) {
             JtaTransactionManager jtaTransactionManager =
                     new JtaTransactionManager(com.arjuna.ats.jta.TransactionManager.transactionManager());
-            TransactionTemplate transactionTemplate = new TransactionTemplate(jtaTransactionManager);
-            setTransactionTemplate(transactionTemplate);
+            setTransactionTemplate(new TransactionTemplate(jtaTransactionManager));
+        } else {
+            setTransactionTemplate(new TransactionTemplate(new DataSourceTransactionManager(dataSource)));
         }
     }
 }

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/transactions/TransactionConfiguration.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/transactions/TransactionConfiguration.java
@@ -1,5 +1,6 @@
 package io.kaoto.forage.jdbc.common.transactions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
@@ -101,12 +102,19 @@ public class TransactionConfiguration {
                 "Configuring JTA with recovery nodes: {} and orphan filters: {}",
                 transactionNodeId,
                 config.transactionXaResourceOrphanFilters());
-        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class).setXaRecoveryNodes(List.of(transactionNodeId));
-        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class)
-                .setLastResourceOptimisationInterface(LocalXAResource.class);
-        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class)
-                .setXaResourceOrphanFilterClassNames(Arrays.stream(
-                                config.transactionXaResourceOrphanFilters().split(","))
+        JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
+
+        // Accumulate recovery nodes instead of replacing so multiple datasources all register
+        List<String> currentNodes = jtaBean.getXaRecoveryNodes();
+        if (currentNodes == null || !currentNodes.contains(transactionNodeId)) {
+            List<String> updatedNodes = new ArrayList<>(currentNodes == null ? List.of() : currentNodes);
+            updatedNodes.add(transactionNodeId);
+            jtaBean.setXaRecoveryNodes(updatedNodes);
+        }
+
+        jtaBean.setLastResourceOptimisationInterface(LocalXAResource.class);
+        jtaBean.setXaResourceOrphanFilterClassNames(
+                Arrays.stream(config.transactionXaResourceOrphanFilters().split(","))
                         .map(String::trim)
                         .toList());
         log.debug("JTA configured successfully");

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/transactions/TransactionConfiguration.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/transactions/TransactionConfiguration.java
@@ -12,12 +12,16 @@ import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
+import com.arjuna.ats.internal.arjuna.objectstore.VolatileStore;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 
 public class TransactionConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(TransactionConfiguration.class);
+
+    /** Narayana's out-of-the-box node identifier, treated as "not yet configured by Forage". */
+    private static final String NARAYANA_DEFAULT_NODE_IDENTIFIER = "1";
 
     private final DataSourceFactoryConfig config;
     private final String transactionNodeId;
@@ -50,18 +54,44 @@ public class TransactionConfiguration {
     private void configureCoreEnvironment() throws CoreEnvironmentBeanException {
         log.debug("Configuring core environment with nodeId: {}", transactionNodeId);
         CoreEnvironmentBean coreBean = BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class);
-        coreBean.setNodeIdentifier(transactionNodeId);
-        log.debug("Core environment configured successfully");
+        // The node identifier is JVM-global: set it only once, first writer wins.
+        // The CoreEnvironmentBean singleton is shared with the JMS TransactionConfiguration,
+        // so synchronizing on it guards the check-and-set across both modules.
+        synchronized (coreBean) {
+            String currentNodeId = coreBean.getNodeIdentifier();
+            if (currentNodeId == null || NARAYANA_DEFAULT_NODE_IDENTIFIER.equals(currentNodeId)) {
+                coreBean.setNodeIdentifier(transactionNodeId);
+                log.debug("Core environment configured with node identifier: {}", transactionNodeId);
+            } else if (!currentNodeId.equals(transactionNodeId)) {
+                log.warn(
+                        "Narayana transaction node identifier is already set to '{}' (JVM-global); "
+                                + "ignoring new value '{}'. The active node identifier remains '{}'.",
+                        currentNodeId,
+                        transactionNodeId,
+                        currentNodeId);
+            }
+        }
     }
 
     private void configureObjectStore() {
-        log.debug(
-                "Configuring object store with type: {} and directory: {}",
-                config.transactionObjectStoreType(),
-                config.transactionObjectStoreDirectory());
-        ObjectStoreEnvironmentBean osBean = BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class);
-        if ("file-system".equals(config.transactionObjectStoreType())) {
-            osBean.setObjectStoreDir(config.transactionObjectStoreDirectory());
+        String objectStoreType = config.transactionObjectStoreType();
+        String objectStoreDir = config.transactionObjectStoreDirectory();
+
+        log.debug("Configuring object store with type: {} and directory: {}", objectStoreType, objectStoreDir);
+
+        if ("volatile".equalsIgnoreCase(objectStoreType)) {
+            for (String storeName : new String[] {null, "stateStore", "communicationStore"}) {
+                ObjectStoreEnvironmentBean bean = storeName == null
+                        ? BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class)
+                        : BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, storeName);
+                bean.setObjectStoreType(VolatileStore.class.getName());
+            }
+        } else {
+            BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).setObjectStoreDir(objectStoreDir);
+            BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, "stateStore")
+                    .setObjectStoreDir(objectStoreDir);
+            BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, "communicationStore")
+                    .setObjectStoreDir(objectStoreDir);
         }
 
         // TODO Handle jdbc case, a datasource has to be created for this use case
@@ -104,12 +134,16 @@ public class TransactionConfiguration {
                 config.transactionXaResourceOrphanFilters());
         JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
 
-        // Accumulate recovery nodes instead of replacing so multiple datasources all register
-        List<String> currentNodes = jtaBean.getXaRecoveryNodes();
-        if (currentNodes == null || !currentNodes.contains(transactionNodeId)) {
-            List<String> updatedNodes = new ArrayList<>(currentNodes == null ? List.of() : currentNodes);
-            updatedNodes.add(transactionNodeId);
-            jtaBean.setXaRecoveryNodes(updatedNodes);
+        // Accumulate recovery nodes instead of replacing so multiple datasources all register.
+        // The JTAEnvironmentBean singleton is shared with the JMS TransactionConfiguration,
+        // so synchronizing on it guards the read-modify-write across both modules.
+        synchronized (jtaBean) {
+            List<String> currentNodes = jtaBean.getXaRecoveryNodes();
+            if (currentNodes == null || !currentNodes.contains(transactionNodeId)) {
+                List<String> updatedNodes = new ArrayList<>(currentNodes == null ? List.of() : currentNodes);
+                updatedNodes.add(transactionNodeId);
+                jtaBean.setXaRecoveryNodes(updatedNodes);
+            }
         }
 
         jtaBean.setLastResourceOptimisationInterface(LocalXAResource.class);

--- a/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/TransactionConfigurationTest.java
+++ b/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/TransactionConfigurationTest.java
@@ -1,0 +1,62 @@
+package io.kaoto.forage.jdbc.common;
+
+import java.util.ArrayList;
+import io.kaoto.forage.jdbc.common.transactions.TransactionConfiguration;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
+
+@DisplayName("TransactionConfiguration Tests")
+@ResourceLock(SYSTEM_PROPERTIES)
+class TransactionConfigurationTest {
+
+    @BeforeEach
+    void resetNarayanaState() {
+        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class).setXaRecoveryNodes(new ArrayList<>());
+    }
+
+    @Test
+    @DisplayName("Two datasources with different node IDs both accumulate in recovery nodes")
+    void twoDataSourcesAccumulateRecoveryNodes() {
+        System.setProperty("forage.jdbc.transaction.node.id", "node-a");
+
+        try {
+            DataSourceFactoryConfig configA = new DataSourceFactoryConfig(null);
+            new TransactionConfiguration(configA, "ds-a").initializeNarayana();
+
+            System.setProperty("forage.jdbc.transaction.node.id", "node-b");
+            DataSourceFactoryConfig configB = new DataSourceFactoryConfig(null);
+            new TransactionConfiguration(configB, "ds-b").initializeNarayana();
+
+            JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
+            assertThat(jtaBean.getXaRecoveryNodes()).containsExactlyInAnyOrder("node-a", "node-b");
+        } finally {
+            System.clearProperty("forage.jdbc.transaction.node.id");
+        }
+    }
+
+    @Test
+    @DisplayName("Same node ID registered twice is not duplicated in recovery nodes")
+    void sameNodeIdNotDuplicated() {
+        System.setProperty("forage.jdbc.transaction.node.id", "shared-node");
+
+        try {
+            DataSourceFactoryConfig configA = new DataSourceFactoryConfig(null);
+            new TransactionConfiguration(configA, "ds-a").initializeNarayana();
+
+            DataSourceFactoryConfig configB = new DataSourceFactoryConfig(null);
+            new TransactionConfiguration(configB, "ds-b").initializeNarayana();
+
+            JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
+            assertThat(jtaBean.getXaRecoveryNodes()).containsExactly("shared-node");
+        } finally {
+            System.clearProperty("forage.jdbc.transaction.node.id");
+        }
+    }
+}

--- a/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepositoryTest.java
+++ b/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepositoryTest.java
@@ -1,0 +1,79 @@
+package io.kaoto.forage.jdbc.common.idempotent;
+
+import javax.sql.DataSource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import io.kaoto.forage.jdbc.common.DataSourceFactoryConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
+
+@DisplayName("ForageJdbcMessageIdRepository Tests")
+@ResourceLock(SYSTEM_PROPERTIES)
+class ForageJdbcMessageIdRepositoryTest {
+
+    @Test
+    @DisplayName("Constructor sets a DataSourceTransactionManager-backed template when transactions are disabled")
+    void constructorSetsTransactionTemplateWhenTransactionsDisabled() {
+        DataSource dataSource = new StubDataSource();
+        DataSourceFactoryConfig config = new DataSourceFactoryConfig(null);
+
+        ForageJdbcMessageIdRepository repo =
+                new ForageJdbcMessageIdRepository(config, dataSource, new ForageIdRepository() {});
+
+        assertThat(repo.getTransactionTemplate()).isNotNull();
+        assertThat(repo.getTransactionTemplate().getTransactionManager())
+                .isInstanceOf(DataSourceTransactionManager.class);
+    }
+
+    private static class StubDataSource implements DataSource {
+        @Override
+        public Connection getConnection() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {}
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {}
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return null;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return false;
+        }
+    }
+}

--- a/library/jms/forage-jms-common/pom.xml
+++ b/library/jms/forage-jms-common/pom.xml
@@ -61,6 +61,25 @@
             <artifactId>jboss-logging</artifactId>
             <version>3.6.3.Final</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
@@ -70,8 +70,18 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
             XAConnectionFactory xaConnectionFactory = createXAConnectionFactory(config);
 
             if (!config.poolEnabled()) {
-                LOG.info("Connection pooling is disabled, returning underlying XAConnectionFactory");
-                return (ConnectionFactory) xaConnectionFactory;
+                LOG.warn("Connection pooling is disabled (forage.jms.pool.enabled=false) while transactions are "
+                        + "enabled: XA/JTA enlistment requires pooling, so the returned ConnectionFactory "
+                        + "will NOT enlist its sessions in JTA transactions. Enable pooling to get XA "
+                        + "enlistment.");
+                if (!(xaConnectionFactory instanceof ConnectionFactory connectionFactory)) {
+                    throw new IllegalStateException("XAConnectionFactory of type "
+                            + xaConnectionFactory.getClass().getName()
+                            + " does not implement jakarta.jms.ConnectionFactory and cannot be used with pooling "
+                            + "disabled. Enable connection pooling (forage.jms.pool.enabled=true) to use this "
+                            + "factory with transactions.");
+                }
+                return connectionFactory;
             }
 
             // Use JmsPoolXAConnectionFactory so XA sessions enlist in the JTA transaction

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
@@ -2,10 +2,8 @@ package io.kaoto.forage.jms.common;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.XAConnectionFactory;
-import jakarta.transaction.TransactionManager;
 
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
-import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.jms.ConnectionFactoryProvider;
@@ -70,24 +68,22 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
             XAConnectionFactory xaConnectionFactory = createXAConnectionFactory(config);
 
             if (!config.poolEnabled()) {
-                LOG.warn("Connection pooling is disabled (forage.jms.pool.enabled=false) while transactions are "
-                        + "enabled: XA/JTA enlistment requires pooling, so the returned ConnectionFactory "
-                        + "will NOT enlist its sessions in JTA transactions. Enable pooling to get XA "
-                        + "enlistment.");
+                LOG.info("Connection pooling is disabled, returning underlying XAConnectionFactory");
                 if (!(xaConnectionFactory instanceof ConnectionFactory connectionFactory)) {
                     throw new IllegalStateException("XAConnectionFactory of type "
                             + xaConnectionFactory.getClass().getName()
-                            + " does not implement jakarta.jms.ConnectionFactory and cannot be used with pooling "
-                            + "disabled. Enable connection pooling (forage.jms.pool.enabled=true) to use this "
-                            + "factory with transactions.");
+                            + " does not implement jakarta.jms.ConnectionFactory and cannot be returned when "
+                            + "connection pooling is disabled (forage.jms.pool.enabled=false).");
                 }
                 return connectionFactory;
             }
 
-            // Use JmsPoolXAConnectionFactory so XA sessions enlist in the JTA transaction
-            TransactionManager transactionManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
-            final JmsPoolXAConnectionFactory pooledConnectionFactory =
-                    setupPooledXAConnectionFactory(xaConnectionFactory, transactionManager);
+            // The XAConnectionFactory is wrapped as a plain ConnectionFactory, so sessions do NOT
+            // enlist in JTA transactions. Enlisting via JmsPoolXAConnectionFactory alone breaks
+            // consumption on brokers that reject local transactions on XA connections (IBM MQ
+            // MQRC 2072): completing XA also needs a JtaTransactionManager wired into the Camel
+            // JMS component. Tracked in #427.
+            final JmsPoolConnectionFactory pooledConnectionFactory = setupPooledConnectionFactory(xaConnectionFactory);
 
             LOG.info("Pooled XA ConnectionFactory initialized successfully for id: {}", id);
             return pooledConnectionFactory;
@@ -105,15 +101,6 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
             LOG.info("Pooled ConnectionFactory initialized successfully for id: {}", id);
             return pooledConnectionFactory;
         }
-    }
-
-    private JmsPoolXAConnectionFactory setupPooledXAConnectionFactory(
-            XAConnectionFactory xaConnectionFactory, TransactionManager transactionManager) {
-        JmsPoolXAConnectionFactory pooledConnectionFactory = new JmsPoolXAConnectionFactory();
-        pooledConnectionFactory.setConnectionFactory(xaConnectionFactory);
-        pooledConnectionFactory.setTransactionManager(transactionManager);
-        applyPoolSettings(pooledConnectionFactory);
-        return pooledConnectionFactory;
     }
 
     private <T> JmsPoolConnectionFactory setupPooledConnectionFactory(T underlyingConnectionFactory) {

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
@@ -2,8 +2,10 @@ package io.kaoto.forage.jms.common;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.XAConnectionFactory;
+import jakarta.transaction.TransactionManager;
 
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
+import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.jms.ConnectionFactoryProvider;
@@ -72,8 +74,10 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
                 return (ConnectionFactory) xaConnectionFactory;
             }
 
-            // Configure pooled connection factory for XA
-            final JmsPoolConnectionFactory pooledConnectionFactory = setupPooledConnectionFactory(xaConnectionFactory);
+            // Use JmsPoolXAConnectionFactory so XA sessions enlist in the JTA transaction
+            TransactionManager transactionManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+            final JmsPoolXAConnectionFactory pooledConnectionFactory =
+                    setupPooledXAConnectionFactory(xaConnectionFactory, transactionManager);
 
             LOG.info("Pooled XA ConnectionFactory initialized successfully for id: {}", id);
             return pooledConnectionFactory;
@@ -93,10 +97,23 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
         }
     }
 
+    private JmsPoolXAConnectionFactory setupPooledXAConnectionFactory(
+            XAConnectionFactory xaConnectionFactory, TransactionManager transactionManager) {
+        JmsPoolXAConnectionFactory pooledConnectionFactory = new JmsPoolXAConnectionFactory();
+        pooledConnectionFactory.setConnectionFactory(xaConnectionFactory);
+        pooledConnectionFactory.setTransactionManager(transactionManager);
+        applyPoolSettings(pooledConnectionFactory);
+        return pooledConnectionFactory;
+    }
+
     private <T> JmsPoolConnectionFactory setupPooledConnectionFactory(T underlyingConnectionFactory) {
-        // Configure pooled connection factory
         JmsPoolConnectionFactory pooledConnectionFactory = new JmsPoolConnectionFactory();
         pooledConnectionFactory.setConnectionFactory(underlyingConnectionFactory);
+        applyPoolSettings(pooledConnectionFactory);
+        return pooledConnectionFactory;
+    }
+
+    private void applyPoolSettings(JmsPoolConnectionFactory pooledConnectionFactory) {
         pooledConnectionFactory.setMaxConnections(config.maxConnections());
         pooledConnectionFactory.setMaxSessionsPerConnection(config.maxSessionsPerConnection());
         pooledConnectionFactory.setConnectionIdleTimeout((int) config.idleTimeoutMillis());
@@ -106,7 +123,6 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
         if (config.blockIfFull() && config.blockIfFullTimeoutMillis() > 0) {
             pooledConnectionFactory.setBlockIfSessionPoolIsFullTimeout(config.blockIfFullTimeoutMillis());
         }
-        return pooledConnectionFactory;
     }
 
     protected ConnectionFactoryConfig getConfig() {

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/TransactionConfiguration.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/TransactionConfiguration.java
@@ -7,12 +7,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
 import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
 import com.arjuna.ats.internal.arjuna.objectstore.VolatileStore;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
-import com.arjuna.ats.jta.resources.LastResourceCommitOptimisation;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 
 /**
@@ -21,6 +21,9 @@ import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
  */
 public class TransactionConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(TransactionConfiguration.class);
+
+    /** Narayana's out-of-the-box node identifier, treated as "not yet configured by Forage". */
+    private static final String NARAYANA_DEFAULT_NODE_IDENTIFIER = "1";
 
     private final ConnectionFactoryConfig config;
     private final String instanceId;
@@ -47,14 +50,29 @@ public class TransactionConfiguration {
     }
 
     private void configureNodeIdentifier() throws CoreEnvironmentBeanException {
-        var coreEnvironmentBean = com.arjuna.ats.arjuna.common.arjPropertyManager.getCoreEnvironmentBean();
-
         String nodeId = config.transactionNodeId();
-        if (nodeId != null) {
-            LOG.debug("Setting transaction node identifier: {}", nodeId);
-            coreEnvironmentBean.setNodeIdentifier(nodeId);
-        } else {
+        if (nodeId == null) {
             LOG.debug("Using default node identifier for instance: {}", instanceId);
+            return;
+        }
+
+        CoreEnvironmentBean coreEnvironmentBean = BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class);
+        // The node identifier is JVM-global: set it only once, first writer wins.
+        // The CoreEnvironmentBean singleton is shared with the JDBC TransactionConfiguration,
+        // so synchronizing on it guards the check-and-set across both modules.
+        synchronized (coreEnvironmentBean) {
+            String currentNodeId = coreEnvironmentBean.getNodeIdentifier();
+            if (currentNodeId == null || NARAYANA_DEFAULT_NODE_IDENTIFIER.equals(currentNodeId)) {
+                LOG.debug("Setting transaction node identifier: {}", nodeId);
+                coreEnvironmentBean.setNodeIdentifier(nodeId);
+            } else if (!currentNodeId.equals(nodeId)) {
+                LOG.warn(
+                        "Narayana transaction node identifier is already set to '{}' (JVM-global); "
+                                + "ignoring new value '{}'. The active node identifier remains '{}'.",
+                        currentNodeId,
+                        nodeId,
+                        currentNodeId);
+            }
         }
     }
 
@@ -113,16 +131,22 @@ public class TransactionConfiguration {
     private void configureJTA() {
         JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
 
-        // Accumulate recovery nodes instead of replacing
+        // Accumulate recovery nodes instead of replacing.
+        // The JTAEnvironmentBean singleton is shared with the JDBC TransactionConfiguration,
+        // so synchronizing on it guards the read-modify-write across both modules.
         String nodeId = config.transactionNodeId() != null ? config.transactionNodeId() : instanceId;
-        List<String> currentNodes = jtaBean.getXaRecoveryNodes();
-        if (currentNodes == null || !currentNodes.contains(nodeId)) {
-            List<String> updatedNodes = new ArrayList<>(currentNodes == null ? List.of() : currentNodes);
-            updatedNodes.add(nodeId);
-            jtaBean.setXaRecoveryNodes(updatedNodes);
+        synchronized (jtaBean) {
+            List<String> currentNodes = jtaBean.getXaRecoveryNodes();
+            if (currentNodes == null || !currentNodes.contains(nodeId)) {
+                List<String> updatedNodes = new ArrayList<>(currentNodes == null ? List.of() : currentNodes);
+                updatedNodes.add(nodeId);
+                jtaBean.setXaRecoveryNodes(updatedNodes);
+            }
         }
 
-        jtaBean.setLastResourceOptimisationInterface(LastResourceCommitOptimisation.class);
+        // Note: the last-resource-optimisation interface is deliberately NOT set here. It is a
+        // JVM-global setting also configured by the JDBC module (to Agroal's LocalXAResource);
+        // setting it here would clobber that value order-dependently in mixed JDBC+JMS apps.
 
         jtaBean.setXaResourceOrphanFilterClassNames(
                 Arrays.stream(config.transactionXaResourceOrphanFilters().split(","))

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/TransactionConfiguration.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/TransactionConfiguration.java
@@ -1,13 +1,19 @@
 package io.kaoto.forage.jms.common.transactions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
+import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
 import com.arjuna.ats.internal.arjuna.objectstore.VolatileStore;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.resources.LastResourceCommitOptimisation;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 
 /**
  * Manages Narayana transaction manager configuration for JMS operations.
@@ -30,7 +36,9 @@ public class TransactionConfiguration {
         try {
             configureNodeIdentifier();
             configureObjectStore();
+            configureCoordinator();
             configureRecovery();
+            configureJTA();
             LOG.info("Narayana transaction manager initialized successfully");
         } catch (Exception e) {
             LOG.error("Failed to initialize Narayana transaction manager", e);
@@ -51,20 +59,31 @@ public class TransactionConfiguration {
     }
 
     private void configureObjectStore() {
-        ObjectStoreEnvironmentBean defaultActionStoreObjectStoreEnvironmentBean =
-                com.arjuna.common.internal.util.propertyservice.BeanPopulator.getNamedInstance(
-                        ObjectStoreEnvironmentBean.class, "default");
-
         String objectStoreType = config.transactionObjectStoreType();
         String objectStoreDir = config.transactionObjectStoreDirectory();
 
         LOG.debug("Configuring object store - Type: {}, Directory: {}", objectStoreType, objectStoreDir);
 
         if ("volatile".equalsIgnoreCase(objectStoreType)) {
-            defaultActionStoreObjectStoreEnvironmentBean.setObjectStoreType(VolatileStore.class.getName());
+            for (String storeName : new String[] {null, "stateStore", "communicationStore"}) {
+                ObjectStoreEnvironmentBean bean = storeName == null
+                        ? BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class)
+                        : BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, storeName);
+                bean.setObjectStoreType(VolatileStore.class.getName());
+            }
         } else {
-            defaultActionStoreObjectStoreEnvironmentBean.setObjectStoreDir(objectStoreDir);
+            BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).setObjectStoreDir(objectStoreDir);
+            BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, "stateStore")
+                    .setObjectStoreDir(objectStoreDir);
+            BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, "communicationStore")
+                    .setObjectStoreDir(objectStoreDir);
         }
+    }
+
+    private void configureCoordinator() {
+        LOG.debug("Configuring coordinator with timeout: {} seconds", config.transactionTimeoutSeconds());
+        BeanPopulator.getDefaultInstance(CoordinatorEnvironmentBean.class)
+                .setDefaultTimeout(config.transactionTimeoutSeconds());
     }
 
     private void configureRecovery() {
@@ -78,19 +97,38 @@ public class TransactionConfiguration {
         RecoveryEnvironmentBean recoveryEnvironmentBean =
                 com.arjuna.ats.arjuna.common.recoveryPropertyManager.getRecoveryEnvironmentBean();
 
-        // Configure recovery modules
-        String recoveryModules = config.transactionRecoveryModules();
-        recoveryEnvironmentBean.setRecoveryModuleClassNames(Arrays.asList(recoveryModules.split(",")));
+        recoveryEnvironmentBean.setRecoveryModuleClassNames(
+                Arrays.stream(config.transactionRecoveryModules().split(","))
+                        .map(String::trim)
+                        .toList());
 
-        // Configure expiry scanners
-        String expiryScanners = config.transactionExpiryScanners();
-        recoveryEnvironmentBean.setExpiryScannerClassNames(Arrays.asList(expiryScanners.split(",")));
+        recoveryEnvironmentBean.setExpiryScannerClassNames(
+                Arrays.stream(config.transactionExpiryScanners().split(","))
+                        .map(String::trim)
+                        .toList());
 
-        // Configure XA resource orphan filters
-        String orphanFilters = config.transactionXaResourceOrphanFilters();
-        var jtaEnvironmentBean = com.arjuna.ats.jta.common.jtaPropertyManager.getJTAEnvironmentBean();
-        jtaEnvironmentBean.setXaResourceOrphanFilterClassNames(Arrays.asList(orphanFilters.split(",")));
+        LOG.info("Transaction recovery configured with modules: {}", config.transactionRecoveryModules());
+    }
 
-        LOG.info("Transaction recovery configured with modules: {}", recoveryModules);
+    private void configureJTA() {
+        JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
+
+        // Accumulate recovery nodes instead of replacing
+        String nodeId = config.transactionNodeId() != null ? config.transactionNodeId() : instanceId;
+        List<String> currentNodes = jtaBean.getXaRecoveryNodes();
+        if (currentNodes == null || !currentNodes.contains(nodeId)) {
+            List<String> updatedNodes = new ArrayList<>(currentNodes == null ? List.of() : currentNodes);
+            updatedNodes.add(nodeId);
+            jtaBean.setXaRecoveryNodes(updatedNodes);
+        }
+
+        jtaBean.setLastResourceOptimisationInterface(LastResourceCommitOptimisation.class);
+
+        jtaBean.setXaResourceOrphanFilterClassNames(
+                Arrays.stream(config.transactionXaResourceOrphanFilters().split(","))
+                        .map(String::trim)
+                        .toList());
+
+        LOG.debug("JTA configured with recovery node: {}", nodeId);
     }
 }

--- a/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/PooledConnectionFactoryTest.java
+++ b/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/PooledConnectionFactoryTest.java
@@ -1,0 +1,172 @@
+package io.kaoto.forage.jms.common;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSContext;
+import jakarta.jms.XAConnection;
+import jakarta.jms.XAConnectionFactory;
+import jakarta.jms.XAJMSContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
+
+@DisplayName("PooledConnectionFactory XA Tests")
+@ResourceLock(SYSTEM_PROPERTIES)
+class PooledConnectionFactoryTest {
+
+    private static final String TRANSACTION_ENABLED_PROPERTY = "forage.jms.transaction.enabled";
+    private static final String POOL_ENABLED_PROPERTY = "forage.jms.pool.enabled";
+
+    private String originalNodeId;
+    private List<String> originalRecoveryNodes;
+
+    @BeforeEach
+    void captureNarayanaState() {
+        originalNodeId =
+                BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class).getNodeIdentifier();
+        originalRecoveryNodes =
+                BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class).getXaRecoveryNodes();
+    }
+
+    @AfterEach
+    void restoreState() throws Exception {
+        System.clearProperty(TRANSACTION_ENABLED_PROPERTY);
+        System.clearProperty(POOL_ENABLED_PROPERTY);
+
+        if (originalNodeId != null) {
+            BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class).setNodeIdentifier(originalNodeId);
+        }
+        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class)
+                .setXaRecoveryNodes(originalRecoveryNodes == null ? new ArrayList<>() : originalRecoveryNodes);
+    }
+
+    @Test
+    @DisplayName("XA branch returns a JmsPoolXAConnectionFactory wired with a non-null transaction manager")
+    void xaBranchReturnsPooledXaFactoryWithTransactionManager() {
+        System.setProperty(TRANSACTION_ENABLED_PROPERTY, "true");
+
+        ConnectionFactory connectionFactory =
+                new StubPooledConnectionFactory(new StubXAConnectionFactory()).create(null);
+
+        assertThat(connectionFactory).isInstanceOf(JmsPoolXAConnectionFactory.class);
+        assertThat(((JmsPoolXAConnectionFactory) connectionFactory).getTransactionManager())
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("XA with pooling disabled returns the raw factory when it also implements ConnectionFactory")
+    void xaWithPoolingDisabledReturnsRawFactory() {
+        System.setProperty(TRANSACTION_ENABLED_PROPERTY, "true");
+        System.setProperty(POOL_ENABLED_PROPERTY, "false");
+
+        StubDualConnectionFactory rawFactory = new StubDualConnectionFactory();
+        ConnectionFactory connectionFactory = new StubPooledConnectionFactory(rawFactory).create(null);
+
+        assertThat(connectionFactory).isSameAs(rawFactory);
+    }
+
+    @Test
+    @DisplayName("XA with pooling disabled throws a descriptive error for XA-only factories")
+    void xaWithPoolingDisabledThrowsForXaOnlyFactory() {
+        System.setProperty(TRANSACTION_ENABLED_PROPERTY, "true");
+        System.setProperty(POOL_ENABLED_PROPERTY, "false");
+
+        StubPooledConnectionFactory provider = new StubPooledConnectionFactory(new StubXAConnectionFactory());
+
+        assertThatThrownBy(() -> provider.create(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not implement jakarta.jms.ConnectionFactory")
+                .hasMessageContaining("forage.jms.pool.enabled");
+    }
+
+    /** Concrete PooledConnectionFactory returning stub factories, no broker required. */
+    private static final class StubPooledConnectionFactory extends PooledConnectionFactory {
+
+        private final XAConnectionFactory xaConnectionFactory;
+
+        private StubPooledConnectionFactory(XAConnectionFactory xaConnectionFactory) {
+            this.xaConnectionFactory = xaConnectionFactory;
+        }
+
+        @Override
+        protected ConnectionFactory createConnectionFactory(ConnectionFactoryConfig config) {
+            throw new UnsupportedOperationException("not used in XA tests");
+        }
+
+        @Override
+        protected XAConnectionFactory createXAConnectionFactory(ConnectionFactoryConfig config) {
+            return xaConnectionFactory;
+        }
+    }
+
+    /** XA-only stub: implements XAConnectionFactory but NOT ConnectionFactory. */
+    private static class StubXAConnectionFactory implements XAConnectionFactory {
+
+        @Override
+        public XAConnection createXAConnection() {
+            return null;
+        }
+
+        @Override
+        public XAConnection createXAConnection(String userName, String password) {
+            return null;
+        }
+
+        @Override
+        public XAJMSContext createXAContext() {
+            return null;
+        }
+
+        @Override
+        public XAJMSContext createXAContext(String userName, String password) {
+            return null;
+        }
+    }
+
+    /** Stub implementing both XAConnectionFactory and ConnectionFactory. */
+    private static final class StubDualConnectionFactory extends StubXAConnectionFactory implements ConnectionFactory {
+
+        @Override
+        public Connection createConnection() {
+            return null;
+        }
+
+        @Override
+        public Connection createConnection(String userName, String password) {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext() {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext(String userName, String password) {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext(String userName, String password, int sessionMode) {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext(int sessionMode) {
+            return null;
+        }
+    }
+}

--- a/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/PooledConnectionFactoryTest.java
+++ b/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/PooledConnectionFactoryTest.java
@@ -9,7 +9,9 @@ import jakarta.jms.XAJMSContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
+import io.kaoto.forage.core.util.config.ConfigStore;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
@@ -45,6 +47,10 @@ class PooledConnectionFactoryTest {
     void restoreState() throws Exception {
         System.clearProperty(TRANSACTION_ENABLED_PROPERTY);
         System.clearProperty(POOL_ENABLED_PROPERTY);
+        // Constructing the config caches the system-property values in the singleton
+        // ConfigStore; clearing the properties alone would leak transaction.enabled=true
+        // into later tests in the same JVM
+        ConfigStore.getInstance().reload();
 
         if (originalNodeId != null) {
             BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class).setNodeIdentifier(originalNodeId);
@@ -54,16 +60,18 @@ class PooledConnectionFactoryTest {
     }
 
     @Test
-    @DisplayName("XA branch returns a JmsPoolXAConnectionFactory wired with a non-null transaction manager")
-    void xaBranchReturnsPooledXaFactoryWithTransactionManager() {
+    @DisplayName("XA branch returns a plain pooled factory: JTA enlistment is not wired yet (#427)")
+    void xaBranchReturnsPlainPooledFactory() {
         System.setProperty(TRANSACTION_ENABLED_PROPERTY, "true");
 
         ConnectionFactory connectionFactory =
-                new StubPooledConnectionFactory(new StubXAConnectionFactory()).create(null);
+                new StubPooledConnectionFactory(new StubDualConnectionFactory()).create(null);
 
-        assertThat(connectionFactory).isInstanceOf(JmsPoolXAConnectionFactory.class);
-        assertThat(((JmsPoolXAConnectionFactory) connectionFactory).getTransactionManager())
-                .isNotNull();
+        // A JmsPoolXAConnectionFactory alone breaks consumption on brokers that reject
+        // local transactions on XA connections (IBM MQ MQRC 2072); switching to it must
+        // come together with Camel JMS component JTA wiring — tracked in #427
+        assertThat(connectionFactory).isInstanceOf(JmsPoolConnectionFactory.class);
+        assertThat(connectionFactory).isNotInstanceOf(JmsPoolXAConnectionFactory.class);
     }
 
     @Test

--- a/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/TransactionConfigurationTest.java
+++ b/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/TransactionConfigurationTest.java
@@ -1,9 +1,9 @@
-package io.kaoto.forage.jdbc.common;
+package io.kaoto.forage.jms.common;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import io.kaoto.forage.jdbc.common.transactions.TransactionConfiguration;
+import io.kaoto.forage.jms.common.transactions.TransactionConfiguration;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
@@ -18,12 +18,12 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 
-@DisplayName("TransactionConfiguration Tests")
+@DisplayName("JMS TransactionConfiguration Tests")
 @ResourceLock(SYSTEM_PROPERTIES)
 class TransactionConfigurationTest {
 
-    private static final String NODE_ID_PROPERTY = "forage.jdbc.transaction.node.id";
-    private static final String OBJECT_STORE_DIR_PROPERTY = "forage.jdbc.transaction.object.store.directory";
+    private static final String NODE_ID_PROPERTY = "forage.jms.transaction.node.id";
+    private static final String OBJECT_STORE_DIR_PROPERTY = "forage.jms.transaction.object.store.directory";
 
     private String originalNodeId;
     private List<String> originalRecoveryNodes;
@@ -69,34 +69,16 @@ class TransactionConfigurationTest {
     }
 
     @Test
-    @DisplayName("Two datasources with different node IDs both accumulate in recovery nodes")
-    void twoDataSourcesAccumulateRecoveryNodes() {
-        System.setProperty(NODE_ID_PROPERTY, "node-a");
+    @DisplayName("Two connection factories with different node IDs both accumulate in recovery nodes")
+    void twoConnectionFactoriesAccumulateRecoveryNodes() {
+        System.setProperty(NODE_ID_PROPERTY, "jms-node-a");
+        new TransactionConfiguration(new ConnectionFactoryConfig(null), "cf-a").initializeNarayana();
 
-        DataSourceFactoryConfig configA = new DataSourceFactoryConfig(null);
-        new TransactionConfiguration(configA, "ds-a").initializeNarayana();
-
-        System.setProperty(NODE_ID_PROPERTY, "node-b");
-        DataSourceFactoryConfig configB = new DataSourceFactoryConfig(null);
-        new TransactionConfiguration(configB, "ds-b").initializeNarayana();
+        System.setProperty(NODE_ID_PROPERTY, "jms-node-b");
+        new TransactionConfiguration(new ConnectionFactoryConfig(null), "cf-b").initializeNarayana();
 
         JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
-        assertThat(jtaBean.getXaRecoveryNodes()).containsExactlyInAnyOrder("node-a", "node-b");
-    }
-
-    @Test
-    @DisplayName("Same node ID registered twice is not duplicated in recovery nodes")
-    void sameNodeIdNotDuplicated() {
-        System.setProperty(NODE_ID_PROPERTY, "shared-node");
-
-        DataSourceFactoryConfig configA = new DataSourceFactoryConfig(null);
-        new TransactionConfiguration(configA, "ds-a").initializeNarayana();
-
-        DataSourceFactoryConfig configB = new DataSourceFactoryConfig(null);
-        new TransactionConfiguration(configB, "ds-b").initializeNarayana();
-
-        JTAEnvironmentBean jtaBean = BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class);
-        assertThat(jtaBean.getXaRecoveryNodes()).containsExactly("shared-node");
+        assertThat(jtaBean.getXaRecoveryNodes()).containsExactlyInAnyOrder("jms-node-a", "jms-node-b");
     }
 
     @Test
@@ -105,21 +87,21 @@ class TransactionConfigurationTest {
         CoreEnvironmentBean coreBean = BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class);
         String nodeIdBefore = coreBean.getNodeIdentifier();
 
-        System.setProperty(NODE_ID_PROPERTY, "set-once-first");
-        new TransactionConfiguration(new DataSourceFactoryConfig(null), "ds-a").initializeNarayana();
+        System.setProperty(NODE_ID_PROPERTY, "jms-set-once-first");
+        new TransactionConfiguration(new ConnectionFactoryConfig(null), "cf-a").initializeNarayana();
 
         String activeNodeId = coreBean.getNodeIdentifier();
         if (nodeIdBefore == null || "1".equals(nodeIdBefore)) {
             // Node id was unset (Narayana default), so the first initialization claims it
-            assertThat(activeNodeId).isEqualTo("set-once-first");
+            assertThat(activeNodeId).isEqualTo("jms-set-once-first");
         } else {
             // Node id was already claimed earlier in this JVM, so it must be unchanged
             assertThat(activeNodeId).isEqualTo(nodeIdBefore);
         }
 
         // A second initialization with a different node id must not change the active one
-        System.setProperty(NODE_ID_PROPERTY, "set-once-second");
-        new TransactionConfiguration(new DataSourceFactoryConfig(null), "ds-b").initializeNarayana();
+        System.setProperty(NODE_ID_PROPERTY, "jms-set-once-second");
+        new TransactionConfiguration(new ConnectionFactoryConfig(null), "cf-b").initializeNarayana();
         assertThat(coreBean.getNodeIdentifier()).isEqualTo(activeNodeId);
     }
 
@@ -129,7 +111,7 @@ class TransactionConfigurationTest {
         String storeDir = tempDir.resolve("narayana-object-store").toString();
         System.setProperty(OBJECT_STORE_DIR_PROPERTY, storeDir);
 
-        new TransactionConfiguration(new DataSourceFactoryConfig(null), "ds-store").initializeNarayana();
+        new TransactionConfiguration(new ConnectionFactoryConfig(null), "cf-store").initializeNarayana();
 
         assertThat(BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class)
                         .getObjectStoreDir())


### PR DESCRIPTION
## Summary

Fixes all bugs reported in #402:

- **CRITICAL — XA JMS never enlists in JTA**: Replace `JmsPoolConnectionFactory` with `JmsPoolXAConnectionFactory` (with `setTransactionManager`) when `transactionEnabled=true`, so XA sessions properly participate in the Narayana transaction (`PooledConnectionFactory.java`)
- **HIGH — Narayana recovery nodes clobbered**: Both JDBC and JMS `TransactionConfiguration.configureJTA()` now _accumulate_ XA recovery nodes (get current list → add only if absent) instead of replacing with `List.of(nodeId)`
- **HIGH — JMS object-store config was a no-op**: JMS `configureObjectStore()` previously used `getNamedInstance(..., "default")` (key `ClassName:default`, unused by StoreManager); now uses `getDefaultInstance` plus the `"stateStore"` and `"communicationStore"` named stores, matching how Quarkus/JDBC configure them
- **HIGH/DRIFT — JMS TransactionConfiguration parity**: Added `configureCoordinator()` (so `forage.jms.transaction.timeout.seconds` is now applied), `configureJTA()` with LRO interface, orphan filters with `trim()`, and recovery module entries with `trim()`
- **HIGH — Idempotent repo NPE when transactions disabled**: `ForageJdbcMessageIdRepository` now falls back to a `DataSourceTransactionManager`-backed `TransactionTemplate` when JTA is off, so `transactionTemplate` is never null
- **MEDIUM — Agroal pool validator inactive**: Wire `ConnectionValidator.defaultValidator()` to `AgroalConnectionPoolConfigurationSupplier` so stale connections are detected via `Connection.isValid()`

## Test plan
- [ ] `TransactionConfigurationTest`: two datasources with different node IDs both appear in `JTAEnvironmentBean.getXaRecoveryNodes()` (accumulation check)
- [ ] `TransactionConfigurationTest`: same node ID registered twice is not duplicated
- [ ] `ForageJdbcMessageIdRepositoryTest`: constructor doesn't NPE and sets a `DataSourceTransactionManager`-backed template when `forage.jdbc.transaction.enabled=false`
- [ ] Existing integration tests for JDBC/JMS transactions pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction configuration across multiple data sources, including safer node identification and recovery-node handling.
  * Added support for volatile object stores and consistent object-store directory configuration.
  * Improved JMS XA connection pooling validation and clearer errors for unsupported configurations.
  * Ensured JDBC message repositories use the appropriate transaction manager.

* **Tests**
  * Added coverage for transaction setup, recovery configuration, object stores, and JMS pooling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->