### PR TITLE
Fix #404: Spring Boot adapters transaction policies, duplicate pools, destroy methods and prefix conditions

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageModuleDescriptor.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageModuleDescriptor.java
@@ -114,14 +114,21 @@ public interface ForageModuleDescriptor<C extends Config, P extends BeanProvider
 
     /**
      * The destroy method name to call on the primary bean when the application context closes,
-     * or an empty string to let Spring infer it (Spring looks for {@code close()} or
-     * {@code shutdown()} by default). Override when the primary bean uses a different lifecycle
-     * method (e.g., {@code "stop"} for {@code JmsPoolConnectionFactory}).
+     * or an empty string when no explicit destroy method should be set. Override when the
+     * primary bean uses a specific lifecycle method (e.g., {@code "stop"} for
+     * {@code JmsPoolConnectionFactory}).
      *
-     * @return the destroy method name, or {@code ""} for Spring's default inference
+     * <p>The prefix is passed so descriptors can make the destroy method configuration-dependent:
+     * the concrete bean type may vary with configuration (e.g., JMS returns a raw, non-poolable
+     * connection factory when {@code pool.enabled=false}, which has no {@code stop()} method).
+     * Returning a destroy method that does not exist on the actual bean would make Spring fail
+     * at context close with a {@code BeanDefinitionValidationException}.
+     *
+     * @param prefix the configuration prefix ({@code null} for the default configuration)
+     * @return the destroy method name, or {@code ""} to set no explicit destroy method
      * @since 1.2
      */
-    default String destroyMethodName() {
+    default String destroyMethodName(String prefix) {
         return "";
     }
 }

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageModuleDescriptor.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageModuleDescriptor.java
@@ -3,6 +3,7 @@ package io.kaoto.forage.core.common;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import io.kaoto.forage.core.util.config.Config;
 
 /**
@@ -88,7 +89,39 @@ public interface ForageModuleDescriptor<C extends Config, P extends BeanProvider
     }
 
     /**
+     * Returns auxiliary bean descriptors using a runtime-supplied primary bean lookup function.
+     * Runtimes (e.g., Spring Boot) that manage the primary bean lifecycle should pass a lookup
+     * so that auxiliary beans share the same managed instance rather than opening a new pool.
+     *
+     * <p>The default implementation ignores the lookup and delegates to {@link #auxiliaryBeans(String)}.
+     * Descriptors that create secondary resources (e.g., DataSource for JDBC repositories) should
+     * override this to use the lookup instead.
+     *
+     * @param prefix        the configuration prefix
+     * @param primaryLookup a function that resolves the primary bean by name; the argument is the
+     *                      prefix (or default bean name when prefix is {@code null})
+     * @return list of auxiliary bean descriptors; empty list if none
+     * @since 1.2
+     */
+    default List<AuxiliaryBeanDescriptor> auxiliaryBeans(String prefix, Function<String, Object> primaryLookup) {
+        return auxiliaryBeans(prefix);
+    }
+
+    /**
      * Whether transactions are enabled for the given configuration.
      */
     boolean transactionEnabled(C config);
+
+    /**
+     * The destroy method name to call on the primary bean when the application context closes,
+     * or an empty string to let Spring infer it (Spring looks for {@code close()} or
+     * {@code shutdown()} by default). Override when the primary bean uses a different lifecycle
+     * method (e.g., {@code "stop"} for {@code JmsPoolConnectionFactory}).
+     *
+     * @return the destroy method name, or {@code ""} for Spring's default inference
+     * @since 1.2
+     */
+    default String destroyMethodName() {
+        return "";
+    }
 }

--- a/library/common/forage-spring-boot-common/pom.xml
+++ b/library/common/forage-spring-boot-common/pom.xml
@@ -49,6 +49,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageSpringBootModuleAdapter.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageSpringBootModuleAdapter.java
@@ -40,6 +40,7 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
     private final ForageModuleDescriptor<C, P> descriptor;
     private final Environment environment;
     private UnaryOperator<Object> beanCustomizer;
+    private ConfigurableListableBeanFactory beanFactory;
 
     public ForageSpringBootModuleAdapter(ForageModuleDescriptor<C, P> descriptor, Environment environment) {
         this.descriptor = descriptor;
@@ -77,6 +78,7 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
         // Replace conflicting alias beans registered by framework auto-configs
         // (e.g., Spring Boot's ArtemisAutoConfiguration creates a CachingConnectionFactory
         // as "jmsConnectionFactory" that wraps Forage's already-pooled ConnectionFactory).
@@ -90,15 +92,8 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
                         registry.removeBeanDefinition(alias);
                         LOG.info("Removed conflicting {} bean definition: {}", descriptor.modulePrefix(), alias);
                     }
-                    GenericBeanDefinition aliasDef = new GenericBeanDefinition();
-                    aliasDef.setBeanClass(descriptor.primaryBeanClass());
-                    aliasDef.setInstanceSupplier(() -> beanFactory.getBean(defaultName));
-                    registry.registerBeanDefinition(alias, aliasDef);
-                    LOG.info(
-                            "Registered {} alias bean definition: {} -> {}",
-                            descriptor.modulePrefix(),
-                            alias,
-                            defaultName);
+                    registry.registerAlias(defaultName, alias);
+                    LOG.info("Registered {} alias: {} -> {}", descriptor.modulePrefix(), alias, defaultName);
                 }
             }
         }
@@ -148,6 +143,10 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
         beanDefinition.setBeanClass(descriptor.primaryBeanClass());
         beanDefinition.setInstanceSupplier(() -> createPrimaryBean(name));
         beanDefinition.setPrimary(isFirst);
+        String destroyMethod = descriptor.destroyMethodName();
+        if (!destroyMethod.isEmpty()) {
+            beanDefinition.setDestroyMethodName(destroyMethod);
+        }
         registry.registerBeanDefinition(name, beanDefinition);
         LOG.info("Registered {} bean definition: {}", descriptor.modulePrefix(), name);
 
@@ -163,7 +162,8 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
     }
 
     private void registerAuxiliaryBeans(BeanDefinitionRegistry registry, String prefix) {
-        List<AuxiliaryBeanDescriptor> auxiliaryBeans = descriptor.auxiliaryBeans(prefix);
+        List<AuxiliaryBeanDescriptor> auxiliaryBeans =
+                descriptor.auxiliaryBeans(prefix, name -> beanFactory != null ? beanFactory.getBean(name) : null);
         for (AuxiliaryBeanDescriptor aux : auxiliaryBeans) {
             if (!registry.containsBeanDefinition(aux.name())) {
                 GenericBeanDefinition beanDef = new GenericBeanDefinition();

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageSpringBootModuleAdapter.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForageSpringBootModuleAdapter.java
@@ -143,7 +143,7 @@ public class ForageSpringBootModuleAdapter<C extends Config, P extends BeanProvi
         beanDefinition.setBeanClass(descriptor.primaryBeanClass());
         beanDefinition.setInstanceSupplier(() -> createPrimaryBean(name));
         beanDefinition.setPrimary(isFirst);
-        String destroyMethod = descriptor.destroyMethodName();
+        String destroyMethod = descriptor.destroyMethodName(name);
         if (!destroyMethod.isEmpty()) {
             beanDefinition.setDestroyMethodName(destroyMethod);
         }

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ConditionalOnAnyForageTransactionEnabled.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ConditionalOnAnyForageTransactionEnabled.java
@@ -1,0 +1,29 @@
+package io.kaoto.forage.springboot.common.jta;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that matches when any Forage property of the form
+ * {@code forage[.<prefix>].<modulePrefix>.transaction.enabled=true} is present in the
+ * Spring Environment. This covers both the default (unprefixed) configuration and any
+ * named (prefixed) configurations (e.g., {@code forage.ds1.jdbc.transaction.enabled}).
+ *
+ * @see ForageTransactionEnabledCondition
+ * @since 1.2
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(ForageTransactionEnabledCondition.class)
+public @interface ConditionalOnAnyForageTransactionEnabled {
+
+    /**
+     * The Forage module prefix (e.g., {@code "jdbc"} or {@code "jms"}).
+     */
+    String modulePrefix();
+}

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledCondition.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledCondition.java
@@ -1,0 +1,67 @@
+package io.kaoto.forage.springboot.common.jta;
+
+import java.util.regex.Pattern;
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition for {@link ConditionalOnAnyForageTransactionEnabled} that matches when any
+ * Spring Environment property matching {@code forage(\.<prefix>)?.<modulePrefix>.transaction.enabled}
+ * has value {@code "true"}.
+ *
+ * <p>This handles both the default (unprefixed) key and named (prefixed) keys such as
+ * {@code forage.ds1.jdbc.transaction.enabled}, so that named-config transactions correctly
+ * activate the JTA transaction manager on Spring Boot.
+ *
+ * @since 1.2
+ */
+public class ForageTransactionEnabledCondition extends SpringBootCondition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(
+                metadata.getAnnotationAttributes(ConditionalOnAnyForageTransactionEnabled.class.getName()));
+
+        if (attributes == null) {
+            return ConditionOutcome.noMatch(
+                    ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
+                            .because("annotation not found"));
+        }
+
+        String modulePrefix = attributes.getString("modulePrefix");
+        String regex = "forage(\\..+)?\\." + Pattern.quote(modulePrefix) + "\\.transaction\\.enabled";
+        Pattern pattern = Pattern.compile(regex);
+
+        if (!(context.getEnvironment() instanceof ConfigurableEnvironment configurableEnv)) {
+            return ConditionOutcome.noMatch(
+                    ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
+                            .because("environment is not configurable"));
+        }
+
+        for (var ps : configurableEnv.getPropertySources()) {
+            if (ps instanceof EnumerablePropertySource<?> eps) {
+                for (String name : eps.getPropertyNames()) {
+                    if (pattern.matcher(name).matches()) {
+                        String value = configurableEnv.getProperty(name);
+                        if ("true".equalsIgnoreCase(value)) {
+                            return ConditionOutcome.match(
+                                    ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
+                                            .found("property")
+                                            .items(ConditionMessage.Style.QUOTE, name));
+                        }
+                    }
+                }
+            }
+        }
+
+        return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
+                .didNotFind("any property matching forage[.<prefix>]." + modulePrefix + ".transaction.enabled=true")
+                .atAll());
+    }
+}

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledCondition.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledCondition.java
@@ -1,5 +1,6 @@
 package io.kaoto.forage.springboot.common.jta;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
@@ -9,11 +10,25 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigStore;
 
 /**
  * Condition for {@link ConditionalOnAnyForageTransactionEnabled} that matches when any
- * Spring Environment property matching {@code forage(\.<prefix>)?.<modulePrefix>.transaction.enabled}
+ * property matching {@code forage(\.<prefix>)?.<modulePrefix>.transaction.enabled}
  * has value {@code "true"}.
+ *
+ * <p>Property names are checked in three places:
+ * <ol>
+ *   <li>All enumerable Spring Environment property sources (dotted keys, e.g.,
+ *       {@code forage.ds1.jdbc.transaction.enabled} from application.properties)</li>
+ *   <li>Environment-variable-style keys (e.g., {@code FORAGE_JDBC_TRANSACTION_ENABLED} from
+ *       {@code SystemEnvironmentPropertySource}), which are translated to the dotted lowercase
+ *       form before matching — preserving the relaxed binding behavior of the previous
+ *       {@code @ConditionalOnProperty}-based configuration</li>
+ *   <li>Forage's {@link ConfigStore}, which covers {@code forage-*.properties} files loaded
+ *       only into Forage's config system and not into the Spring Environment</li>
+ * </ol>
  *
  * <p>This handles both the default (unprefixed) key and named (prefixed) keys such as
  * {@code forage.ds1.jdbc.transaction.enabled}, so that named-config transactions correctly
@@ -47,8 +62,8 @@ public class ForageTransactionEnabledCondition extends SpringBootCondition {
         for (var ps : configurableEnv.getPropertySources()) {
             if (ps instanceof EnumerablePropertySource<?> eps) {
                 for (String name : eps.getPropertyNames()) {
-                    if (pattern.matcher(name).matches()) {
-                        String value = configurableEnv.getProperty(name);
+                    if (pattern.matcher(toDottedForm(name)).matches()) {
+                        String value = String.valueOf(eps.getProperty(name));
                         if ("true".equalsIgnoreCase(value)) {
                             return ConditionOutcome.match(
                                     ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
@@ -60,8 +75,37 @@ public class ForageTransactionEnabledCondition extends SpringBootCondition {
             }
         }
 
+        // Fall back to Forage's ConfigStore, which covers forage-*.properties files that are
+        // loaded only into Forage's config system (not into the Spring Environment) — the same
+        // source consulted by prefix discovery in ForageSpringBootModuleAdapter.
+        for (Map.Entry<Object, Object> entry : ConfigStore.getInstance().entries()) {
+            String name = entry.getKey() instanceof ConfigModule configModule
+                    ? configModule.propertyName()
+                    : String.valueOf(entry.getKey());
+            if (name != null
+                    && pattern.matcher(name).matches()
+                    && "true".equalsIgnoreCase(String.valueOf(entry.getValue()))) {
+                return ConditionOutcome.match(
+                        ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
+                                .found("ConfigStore property")
+                                .items(ConditionMessage.Style.QUOTE, name));
+            }
+        }
+
         return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnAnyForageTransactionEnabled.class)
                 .didNotFind("any property matching forage[.<prefix>]." + modulePrefix + ".transaction.enabled=true")
                 .atAll());
+    }
+
+    /**
+     * Translates environment-variable-style names (e.g., {@code FORAGE_JDBC_TRANSACTION_ENABLED})
+     * to the dotted lowercase form ({@code forage.jdbc.transaction.enabled}) so they can be
+     * matched against the property regex. Dotted names are returned unchanged.
+     */
+    private static String toDottedForm(String name) {
+        if (name.indexOf('_') >= 0 && name.indexOf('.') < 0) {
+            return name.toLowerCase().replace('_', '.');
+        }
+        return name;
     }
 }

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ForageTransactionManagementAutoConfiguration.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/jta/ForageTransactionManagementAutoConfiguration.java
@@ -39,49 +39,49 @@ public abstract class ForageTransactionManagementAutoConfiguration {
         return transactionManager;
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "PROPAGATION_REQUIRED")
     @Bean("PROPAGATION_REQUIRED")
     public SpringTransactionPolicy propagationRequired(JtaTransactionManager jtaTransactionManager) {
 
         return createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_REQUIRED");
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "NESTED")
     @Bean("NESTED")
     public SpringTransactionPolicy nested(JtaTransactionManager jtaTransactionManager) {
 
         return createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_NESTED");
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "MANDATORY")
     @Bean("MANDATORY")
     public SpringTransactionPolicy mandatory(JtaTransactionManager jtaTransactionManager) {
 
         return createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_MANDATORY");
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "NEVER")
     @Bean("NEVER")
     public SpringTransactionPolicy never(JtaTransactionManager jtaTransactionManager) {
 
         return createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_NEVER");
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "NOT_SUPPORTED")
     @Bean("NOT_SUPPORTED")
     public SpringTransactionPolicy notSupported(JtaTransactionManager jtaTransactionManager) {
 
         return createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_NOT_SUPPORTED");
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "REQUIRES_NEW")
     @Bean("REQUIRES_NEW")
     public SpringTransactionPolicy requiresNew(JtaTransactionManager jtaTransactionManager) {
 
         return createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_REQUIRES_NEW");
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = "SUPPORTS")
     @Bean("SUPPORTS")
     public SpringTransactionPolicy supports(JtaTransactionManager jtaTransactionManager) {
 

--- a/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledConditionTest.java
+++ b/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledConditionTest.java
@@ -1,8 +1,11 @@
 package io.kaoto.forage.springboot.common.jta;
 
+import java.util.Map;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+import io.kaoto.forage.core.util.config.ConfigStore;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,5 +47,47 @@ class ForageTransactionEnabledConditionTest {
     @Test
     void conditionDoesNotMatchWhenAbsent() {
         contextRunner.run(ctx -> assertThat(ctx).doesNotHaveBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void envVarStyleDefaultKeyActivatesCondition() {
+        contextRunner
+                .withInitializer(ctx -> ctx.getEnvironment()
+                        .getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource(
+                                "testSystemEnvironment", Map.of("FORAGE_JDBC_TRANSACTION_ENABLED", "true"))))
+                .run(ctx -> assertThat(ctx).hasBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void envVarStylePrefixedKeyActivatesCondition() {
+        contextRunner
+                .withInitializer(ctx -> ctx.getEnvironment()
+                        .getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource(
+                                "testSystemEnvironment", Map.of("FORAGE_DS1_JDBC_TRANSACTION_ENABLED", "true"))))
+                .run(ctx -> assertThat(ctx).hasBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void envVarStyleKeyDoesNotMatchWhenFalse() {
+        contextRunner
+                .withInitializer(ctx -> ctx.getEnvironment()
+                        .getPropertySources()
+                        .addFirst(new SystemEnvironmentPropertySource(
+                                "testSystemEnvironment", Map.of("FORAGE_JDBC_TRANSACTION_ENABLED", "false"))))
+                .run(ctx -> assertThat(ctx).doesNotHaveBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void configStoreOnlyPropertyActivatesCondition() {
+        // Simulates a forage-*.properties file loaded only into Forage's ConfigStore,
+        // not into the Spring Environment
+        ConfigStore.getInstance().setDirect("forage.csonly.jdbc.transaction.enabled", "true");
+        try {
+            contextRunner.run(ctx -> assertThat(ctx).hasBean("jdbcTxMarker"));
+        } finally {
+            ConfigStore.getInstance().setDirect("forage.csonly.jdbc.transaction.enabled", "false");
+        }
     }
 }

--- a/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledConditionTest.java
+++ b/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledConditionTest.java
@@ -1,0 +1,48 @@
+package io.kaoto.forage.springboot.common.jta;
+
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ForageTransactionEnabledConditionTest {
+
+    @Configuration
+    @ConditionalOnAnyForageTransactionEnabled(modulePrefix = "jdbc")
+    static class JdbcTxConfig {
+        @Bean
+        String jdbcTxMarker() {
+            return "jdbc-tx-active";
+        }
+    }
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner().withUserConfiguration(JdbcTxConfig.class);
+
+    @Test
+    void defaultKeyActivatesCondition() {
+        contextRunner.withPropertyValues("forage.jdbc.transaction.enabled=true").run(ctx -> assertThat(ctx)
+                .hasBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void prefixedKeyActivatesCondition() {
+        contextRunner
+                .withPropertyValues("forage.ds1.jdbc.transaction.enabled=true")
+                .run(ctx -> assertThat(ctx).hasBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void conditionDoesNotMatchWhenFalse() {
+        contextRunner
+                .withPropertyValues("forage.jdbc.transaction.enabled=false")
+                .run(ctx -> assertThat(ctx).doesNotHaveBean("jdbcTxMarker"));
+    }
+
+    @Test
+    void conditionDoesNotMatchWhenAbsent() {
+        contextRunner.run(ctx -> assertThat(ctx).doesNotHaveBean("jdbcTxMarker"));
+    }
+}

--- a/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledConditionTest.java
+++ b/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionEnabledConditionTest.java
@@ -87,7 +87,10 @@ class ForageTransactionEnabledConditionTest {
         try {
             contextRunner.run(ctx -> assertThat(ctx).hasBean("jdbcTxMarker"));
         } finally {
-            ConfigStore.getInstance().setDirect("forage.csonly.jdbc.transaction.enabled", "false");
+            // Clear the store rather than setting the key to "false": the singleton
+            // ConfigStore outlives this test, and a leftover forage.csonly.* key leaks
+            // into prefix discovery of tests that enumerate ForagePropertySource
+            ConfigStore.getInstance().reload();
         }
     }
 }

--- a/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionManagementAutoConfigurationTest.java
+++ b/library/common/forage-spring-boot-common/src/test/java/io/kaoto/forage/springboot/common/jta/ForageTransactionManagementAutoConfigurationTest.java
@@ -1,0 +1,47 @@
+package io.kaoto.forage.springboot.common.jta;
+
+import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.jta.JtaTransactionManager;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ForageTransactionManagementAutoConfigurationTest {
+
+    @Configuration
+    static class TestTransactionConfig extends ForageTransactionManagementAutoConfiguration {}
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner().withUserConfiguration(TestTransactionConfig.class);
+
+    @Test
+    void allSevenPolicyBeansAreRegistered() {
+        contextRunner.run(ctx -> {
+            assertThat(ctx).hasSingleBean(JtaTransactionManager.class);
+            assertThat(ctx.getBean("PROPAGATION_REQUIRED")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("NESTED")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("MANDATORY")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("NEVER")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("NOT_SUPPORTED")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("REQUIRES_NEW")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("SUPPORTS")).isInstanceOf(SpringTransactionPolicy.class);
+        });
+    }
+
+    @Test
+    void userDefinedPolicyBeanIsNotOverridden() {
+        SpringTransactionPolicy custom = new SpringTransactionPolicy();
+        ApplicationContextRunner runnerWithOverride = new ApplicationContextRunner()
+                .withUserConfiguration(TestTransactionConfig.class)
+                .withBean("REQUIRES_NEW", SpringTransactionPolicy.class, () -> custom);
+
+        runnerWithOverride.run(ctx -> {
+            assertThat(ctx.getBean("REQUIRES_NEW")).isSameAs(custom);
+            // All other policy beans still registered
+            assertThat(ctx.getBean("PROPAGATION_REQUIRED")).isInstanceOf(SpringTransactionPolicy.class);
+            assertThat(ctx.getBean("SUPPORTS")).isInstanceOf(SpringTransactionPolicy.class);
+        });
+    }
+}

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.function.Function;
 import io.agroal.api.AgroalDataSource;
 import io.kaoto.forage.core.common.AuxiliaryBeanDescriptor;
 import io.kaoto.forage.core.common.ForageModuleDescriptor;
@@ -110,17 +111,28 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
 
     @Override
     public List<AuxiliaryBeanDescriptor> auxiliaryBeans(String prefix) {
+        String lookupName = prefix != null ? prefix : defaultBeanName();
+        return auxiliaryBeans(prefix, name -> {
+            DataSourceFactoryConfig c = createConfig(prefix);
+            ForageDataSource ds = createDataSource(c, lookupName);
+            return ds != null ? ds.dataSource() : null;
+        });
+    }
+
+    @Override
+    public List<AuxiliaryBeanDescriptor> auxiliaryBeans(String prefix, Function<String, Object> primaryLookup) {
         DataSourceFactoryConfig config = createConfig(prefix);
         List<AuxiliaryBeanDescriptor> beans = new ArrayList<>();
+        String lookupName = prefix != null ? prefix : defaultBeanName();
 
         if (config.transactionEnabled() && config.aggregationRepositoryName() != null) {
             String repoName = config.aggregationRepositoryName();
             beans.add(new AuxiliaryBeanDescriptor(repoName, ForageAggregationRepository.class, () -> {
                 DataSourceFactoryConfig c = createConfig(prefix);
-                ForageDataSource ds = createDataSource(c, prefix);
+                AgroalDataSource ds = (AgroalDataSource) primaryLookup.apply(lookupName);
                 if (ds != null) {
                     return new ForageAggregationRepository(
-                            ds.dataSource(), com.arjuna.ats.jta.TransactionManager.transactionManager(), c);
+                            ds, com.arjuna.ats.jta.TransactionManager.transactionManager(), c);
                 }
                 return null;
             }));
@@ -130,15 +142,43 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
             String tableName = config.idempotentRepositoryTableName();
             beans.add(new AuxiliaryBeanDescriptor(tableName, ForageJdbcMessageIdRepository.class, () -> {
                 DataSourceFactoryConfig c = createConfig(prefix);
-                ForageDataSource ds = createDataSource(c, prefix);
+                AgroalDataSource ds = (AgroalDataSource) primaryLookup.apply(lookupName);
                 if (ds != null) {
-                    return new ForageJdbcMessageIdRepository(c, ds.dataSource(), ds.forageIdRepository());
+                    ForageIdRepository idRepo = resolveIdRepository(c);
+                    return new ForageJdbcMessageIdRepository(c, ds, idRepo);
                 }
                 return null;
             }));
         }
 
         return beans;
+    }
+
+    /**
+     * Resolves the ForageIdRepository from the provider without creating a DataSource pool.
+     * Used when the primary DataSource is already available (e.g., as a Spring bean).
+     */
+    ForageIdRepository resolveIdRepository(DataSourceFactoryConfig config) {
+        String providerClass = resolveProviderClassName(config);
+        List<ServiceLoader.Provider<DataSourceProvider>> providers =
+                ServiceLoader.load(DataSourceProvider.class).stream().toList();
+
+        ServiceLoader.Provider<DataSourceProvider> provider;
+        if (providers.size() == 1) {
+            provider = providers.get(0);
+        } else {
+            provider = ServiceLoaderHelper.findProviderByClassName(providers, providerClass);
+        }
+
+        if (provider == null) {
+            return null;
+        }
+
+        DataSourceProvider dsProvider = provider.get();
+        if (dsProvider instanceof ForageIdRepository forageIdRepo) {
+            return forageIdRepo;
+        }
+        return null;
     }
 
     /**

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
@@ -111,10 +111,11 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
 
     @Override
     public List<AuxiliaryBeanDescriptor> auxiliaryBeans(String prefix) {
-        String lookupName = prefix != null ? prefix : defaultBeanName();
         return auxiliaryBeans(prefix, name -> {
             DataSourceFactoryConfig c = createConfig(prefix);
-            ForageDataSource ds = createDataSource(c, lookupName);
+            // Pass the original prefix (null for the default config) so the provider reads
+            // forage.jdbc.* rather than forage.dataSource.jdbc.* for the default configuration.
+            ForageDataSource ds = createDataSource(c, prefix);
             return ds != null ? ds.dataSource() : null;
         });
     }
@@ -129,7 +130,7 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
             String repoName = config.aggregationRepositoryName();
             beans.add(new AuxiliaryBeanDescriptor(repoName, ForageAggregationRepository.class, () -> {
                 DataSourceFactoryConfig c = createConfig(prefix);
-                AgroalDataSource ds = (AgroalDataSource) primaryLookup.apply(lookupName);
+                AgroalDataSource ds = lookupAgroalDataSource(primaryLookup, lookupName, repoName);
                 if (ds != null) {
                     return new ForageAggregationRepository(
                             ds, com.arjuna.ats.jta.TransactionManager.transactionManager(), c);
@@ -142,7 +143,7 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
             String tableName = config.idempotentRepositoryTableName();
             beans.add(new AuxiliaryBeanDescriptor(tableName, ForageJdbcMessageIdRepository.class, () -> {
                 DataSourceFactoryConfig c = createConfig(prefix);
-                AgroalDataSource ds = (AgroalDataSource) primaryLookup.apply(lookupName);
+                AgroalDataSource ds = lookupAgroalDataSource(primaryLookup, lookupName, tableName);
                 if (ds != null) {
                     ForageIdRepository idRepo = resolveIdRepository(c);
                     return new ForageJdbcMessageIdRepository(c, ds, idRepo);
@@ -152,6 +153,22 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
         }
 
         return beans;
+    }
+
+    private static AgroalDataSource lookupAgroalDataSource(
+            Function<String, Object> primaryLookup, String lookupName, String auxiliaryBeanName) {
+        Object primary = primaryLookup.apply(lookupName);
+        if (primary == null) {
+            return null;
+        }
+        if (!(primary instanceof AgroalDataSource agroalDataSource)) {
+            throw new IllegalStateException("Forage auxiliary repository '" + auxiliaryBeanName
+                    + "' requires the Forage-managed AgroalDataSource bean '" + lookupName + "', but the resolved bean"
+                    + " is of type " + primary.getClass().getName()
+                    + ". Auxiliary JDBC repositories (aggregation/idempotent) can only be attached to a Forage"
+                    + " AgroalDataSource.");
+        }
+        return agroalDataSource;
     }
 
     /**

--- a/library/jdbc/forage-jdbc/pom.xml
+++ b/library/jdbc/forage-jdbc/pom.xml
@@ -31,6 +31,17 @@
             <artifactId>forage-core-jta</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
@@ -110,7 +110,7 @@ public class DataSourceBeanFactory implements BeanFactory {
         closeAndUnbind(DEFAULT_DATASOURCE);
 
         // Unbind JTA transaction policies if they were registered
-        if (config.transactionEnabled()) {
+        if (anyTransactionEnabled(config, prefixes)) {
             for (String name : List.of(
                     "PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS")) {
                 camelContext.getRegistry().unbind(name);
@@ -151,7 +151,9 @@ public class DataSourceBeanFactory implements BeanFactory {
         Set<String> prefixes =
                 ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jdbc"));
 
-        if (config.transactionEnabled()) {
+        // Bind JTA policies when the default config OR any discovered prefixed config
+        // has transactions enabled (e.g., forage.ds1.jdbc.transaction.enabled=true)
+        if (anyTransactionEnabled(config, prefixes)) {
             camelContext.getRegistry().bind("PROPAGATION_REQUIRED", new RequiredJtaTransactionPolicy());
             camelContext.getRegistry().bind("MANDATORY", new MandatoryJtaTransactionPolicy());
             camelContext.getRegistry().bind("NEVER", new NeverJtaTransactionPolicy());
@@ -190,6 +192,13 @@ public class DataSourceBeanFactory implements BeanFactory {
                 LOG.error(ex.getMessage(), ex);
             }
         }
+    }
+
+    private static boolean anyTransactionEnabled(DataSourceFactoryConfig defaultConfig, Set<String> prefixes) {
+        if (defaultConfig.transactionEnabled()) {
+            return true;
+        }
+        return prefixes.stream().anyMatch(p -> new DataSourceFactoryConfig(p).transactionEnabled());
     }
 
     private void createIdempotentRepository(

--- a/library/jdbc/forage-jdbc/src/test/java/io/kaoto/forage/jdbc/DataSourceBeanFactoryTransactionTest.java
+++ b/library/jdbc/forage-jdbc/src/test/java/io/kaoto/forage/jdbc/DataSourceBeanFactoryTransactionTest.java
@@ -1,0 +1,90 @@
+package io.kaoto.forage.jdbc;
+
+import javax.sql.DataSource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.List;
+import java.util.logging.Logger;
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that JTA transaction policy beans are bound when only a prefixed (named)
+ * JDBC configuration enables transactions (issue #230). The prefixed configuration
+ * ({@code forage.ds1.jdbc.transaction.enabled=true}) comes from the test classpath's
+ * {@code forage-datasource-factory.properties}; the default (unprefixed) configuration
+ * has transactions disabled.
+ */
+class DataSourceBeanFactoryTransactionTest {
+
+    private static final List<String> POLICY_BEANS =
+            List.of("PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS");
+
+    @Test
+    void prefixedTransactionEnabledBindsJtaPolicies() {
+        CamelContext camelContext = new DefaultCamelContext();
+        // Pre-bind the prefixed DataSource so configure() does not need a database provider
+        camelContext.getRegistry().bind("ds1", dummyDataSource());
+
+        DataSourceBeanFactory beanFactory = new DataSourceBeanFactory();
+        beanFactory.setCamelContext(camelContext);
+        beanFactory.configure();
+
+        for (String name : POLICY_BEANS) {
+            assertThat(camelContext.getRegistry().lookupByName(name))
+                    .as("JTA policy bean '%s' should be bound when a prefixed config enables transactions", name)
+                    .isNotNull();
+        }
+    }
+
+    private static DataSource dummyDataSource() {
+        return new DataSource() {
+            @Override
+            public Connection getConnection() throws SQLException {
+                throw new SQLException("test stub");
+            }
+
+            @Override
+            public Connection getConnection(String username, String password) throws SQLException {
+                throw new SQLException("test stub");
+            }
+
+            @Override
+            public PrintWriter getLogWriter() {
+                return null;
+            }
+
+            @Override
+            public void setLogWriter(PrintWriter out) {}
+
+            @Override
+            public void setLoginTimeout(int seconds) {}
+
+            @Override
+            public int getLoginTimeout() {
+                return 0;
+            }
+
+            @Override
+            public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+                throw new SQLFeatureNotSupportedException();
+            }
+
+            @Override
+            public <T> T unwrap(Class<T> iface) throws SQLException {
+                throw new SQLException("test stub");
+            }
+
+            @Override
+            public boolean isWrapperFor(Class<?> iface) {
+                return false;
+            }
+        };
+    }
+}

--- a/library/jdbc/forage-jdbc/src/test/resources/forage-datasource-factory.properties
+++ b/library/jdbc/forage-jdbc/src/test/resources/forage-datasource-factory.properties
@@ -1,0 +1,5 @@
+# Test configuration: a prefixed (named) JDBC configuration with transactions enabled
+# and NO default (unprefixed) transaction property. Used by
+# DataSourceBeanFactoryTransactionTest to verify that JTA transaction policies
+# are bound when only a prefixed configuration enables transactions (issue #230).
+forage.ds1.jdbc.transaction.enabled=true

--- a/library/jdbc/spring-boot/forage-jdbc-starter/pom.xml
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/pom.xml
@@ -40,6 +40,28 @@
             <artifactId>agroal-spring-boot-starter</artifactId>
             <version>${agroal.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-jdbc-h2</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/io/kaoto/forage/springboot/jdbc/ForageDataSourceAutoConfiguration.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/io/kaoto/forage/springboot/jdbc/ForageDataSourceAutoConfiguration.java
@@ -13,10 +13,8 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import io.kaoto.forage.core.annotations.FactoryType;
@@ -39,10 +37,15 @@ import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
  *
  * <p>This configuration class handles:
  * <ul>
- *   <li>Transaction management setup (when {@code forage.jdbc.transaction.enabled=true})</li>
  *   <li>The {@link ForageSpringBootModuleAdapter} bean for dynamic registration</li>
  *   <li>Fallback single-provider DataSource when no prefixed configurations are found</li>
  * </ul>
+ *
+ * <p>Transaction management (JTA transaction manager, Camel transaction policies, and
+ * {@code @EnableTransactionManagement}) is provided by
+ * {@code io.kaoto.forage.springboot.jdbc.jta.ForageJdbcTransactionManagementAutoConfiguration},
+ * which activates when any default or prefixed {@code forage[.<name>].jdbc.transaction.enabled=true}
+ * property is present.
  */
 @ForageFactory(
         value = "DataSource (Spring Boot)",
@@ -63,21 +66,6 @@ import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
 public class ForageDataSourceAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(ForageDataSourceAutoConfiguration.class);
-
-    /**
-     * Transaction management configuration that enables Spring transaction support
-     * when JDBC transactions are configured in Forage DataSource settings.
-     */
-    @Configuration
-    @ConditionalOnProperty(value = "forage.jdbc.transaction.enabled", havingValue = "true")
-    @EnableTransactionManagement
-    static class ForageTransactionManagement {
-
-        @jakarta.annotation.PostConstruct
-        public void init() {
-            log.info("ForageTransactionManagement configuration enabled");
-        }
-    }
 
     /**
      * Registers the generic module adapter that discovers prefixed DataSource

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/io/kaoto/forage/springboot/jdbc/ForageJdbcBeanRegistrar.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/io/kaoto/forage/springboot/jdbc/ForageJdbcBeanRegistrar.java
@@ -52,12 +52,12 @@ class ForageJdbcBeanRegistrar implements ImportBeanDefinitionRegistrar, org.spri
         boolean isFirst = true;
         for (String name : prefixes.stream().sorted().toList()) {
             if (!registry.containsBeanDefinition(name)) {
-                registerBean(registry, descriptor, name);
+                registerBean(registry, descriptor, name, isFirst);
                 if (isFirst) {
                     String defaultName = descriptor.defaultBeanName();
-                    if (!registry.containsBeanDefinition(defaultName)) {
-                        registerBean(registry, descriptor, defaultName, name);
-                        LOG.info("Registered default JDBC bean '{}' using prefix: {}", defaultName, name);
+                    if (!registry.containsBeanDefinition(defaultName) && !name.equals(defaultName)) {
+                        registry.registerAlias(name, defaultName);
+                        LOG.info("Registered default JDBC alias '{}' -> '{}'", defaultName, name);
                     }
                     isFirst = false;
                 }
@@ -65,18 +65,15 @@ class ForageJdbcBeanRegistrar implements ImportBeanDefinitionRegistrar, org.spri
         }
     }
 
-    private void registerBean(BeanDefinitionRegistry registry, JdbcModuleDescriptor descriptor, String beanName) {
-        registerBean(registry, descriptor, beanName, beanName);
-    }
-
     private void registerBean(
-            BeanDefinitionRegistry registry, JdbcModuleDescriptor descriptor, String beanName, String prefix) {
+            BeanDefinitionRegistry registry, JdbcModuleDescriptor descriptor, String beanName, boolean primary) {
         GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
         beanDefinition.setBeanClass(descriptor.primaryBeanClass());
         beanDefinition.setInstanceSupplier(
-                () -> new ForageSpringBootModuleAdapter<>(descriptor, environment).createBean(prefix));
+                () -> new ForageSpringBootModuleAdapter<>(descriptor, environment).createBean(beanName));
+        beanDefinition.setPrimary(primary);
         registry.registerBeanDefinition(beanName, beanDefinition);
-        LOG.info("Registered JDBC bean definition: {}", beanName);
+        LOG.info("Registered JDBC bean definition: {} (primary={})", beanName, primary);
     }
 
     private Set<String> discoverPrefixes(JdbcModuleDescriptor descriptor) {

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/io/kaoto/forage/springboot/jdbc/jta/ForageJdbcTransactionManagementAutoConfiguration.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/io/kaoto/forage/springboot/jdbc/jta/ForageJdbcTransactionManagementAutoConfiguration.java
@@ -4,12 +4,12 @@ import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import io.kaoto.forage.springboot.common.jta.ConditionalOnAnyForageTransactionEnabled;
 
 @Configuration
-@ConditionalOnProperty(value = "forage.jdbc.transaction.enabled", havingValue = "true")
+@ConditionalOnAnyForageTransactionEnabled(modulePrefix = "jdbc")
 @EnableTransactionManagement
 public class ForageJdbcTransactionManagementAutoConfiguration
         extends io.kaoto.forage.springboot.common.jta.ForageTransactionManagementAutoConfiguration {

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/test/java/io/kaoto/forage/springboot/jdbc/ForageJdbcAuxiliaryBeansTest.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/test/java/io/kaoto/forage/springboot/jdbc/ForageJdbcAuxiliaryBeansTest.java
@@ -1,0 +1,58 @@
+package io.kaoto.forage.springboot.jdbc;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import io.agroal.api.AgroalDataSource;
+import io.kaoto.forage.jdbc.common.aggregation.ForageAggregationRepository;
+import io.kaoto.forage.jdbc.common.idempotent.ForageJdbcMessageIdRepository;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that auxiliary JDBC beans (aggregation repository, idempotent repository)
+ * registered for a prefixed datasource reuse the Spring-managed DataSource bean instead
+ * of opening a second connection pool (issue #404).
+ *
+ * <p>Uses the H2 provider from the test classpath with an in-memory database.
+ */
+class ForageJdbcAuxiliaryBeansTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ForageDataSourceAutoConfiguration.class));
+
+    @Test
+    void auxiliaryRepositoriesUseTheRegisteredDataSourceBean() {
+        contextRunner
+                .withSystemProperties(
+                        "forage.ds1.jdbc.db.kind=h2",
+                        "forage.ds1.jdbc.url=jdbc:h2:mem:auxbeans;DB_CLOSE_DELAY=-1",
+                        "forage.ds1.jdbc.username=sa",
+                        "forage.ds1.jdbc.password=sa",
+                        "forage.ds1.jdbc.transaction.enabled=true",
+                        "forage.ds1.jdbc.transaction.object.store.directory=target/narayana-objectstore",
+                        "forage.ds1.jdbc.aggregation.repository.name=auxAggregationRepo",
+                        "forage.ds1.jdbc.idempotent.repository.enabled=true",
+                        "forage.ds1.jdbc.idempotent.repository.table.name=AUX_IDEMPOTENT")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+
+                    AgroalDataSource dataSource = ctx.getBean("ds1", AgroalDataSource.class);
+
+                    // The first prefix is aliased as the default bean name
+                    assertThat(ctx.getBean("dataSource")).isSameAs(dataSource);
+
+                    ForageAggregationRepository aggregationRepository =
+                            ctx.getBean("auxAggregationRepo", ForageAggregationRepository.class);
+                    assertThat(aggregationRepository.getDataSource())
+                            .as("aggregation repository must reuse the registered DataSource bean")
+                            .isSameAs(dataSource);
+
+                    ForageJdbcMessageIdRepository idempotentRepository =
+                            ctx.getBean("AUX_IDEMPOTENT", ForageJdbcMessageIdRepository.class);
+                    assertThat(idempotentRepository.getDataSource())
+                            .as("idempotent repository must reuse the registered DataSource bean")
+                            .isSameAs(dataSource);
+                });
+    }
+}

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
@@ -59,6 +59,11 @@ public class JmsModuleDescriptor implements ForageModuleDescriptor<ConnectionFac
     }
 
     @Override
+    public String destroyMethodName() {
+        return "stop";
+    }
+
+    @Override
     public Map<String, String> translateProperties(String prefix, ConnectionFactoryConfig config) {
         Map<String, String> props = new HashMap<>();
         String named = prefix;

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
@@ -59,8 +59,11 @@ public class JmsModuleDescriptor implements ForageModuleDescriptor<ConnectionFac
     }
 
     @Override
-    public String destroyMethodName() {
-        return "stop";
+    public String destroyMethodName(String prefix) {
+        // JmsPoolConnectionFactory is stopped via stop(). When pooling is disabled the provider
+        // returns the raw broker ConnectionFactory (e.g., ActiveMQConnectionFactory) which has
+        // no stop() method — setting one would make Spring fail at context close.
+        return createConfig(prefix).poolEnabled() ? "stop" : "";
     }
 
     @Override

--- a/library/jms/forage-jms/pom.xml
+++ b/library/jms/forage-jms/pom.xml
@@ -31,6 +31,17 @@
             <artifactId>forage-core-jta</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -94,7 +94,7 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         closeAndUnbind(DEFAULT_CONNECTION_FACTORY);
 
         // Unbind JTA transaction policies if they were registered
-        if (config.transactionEnabled()) {
+        if (anyTransactionEnabled(config, prefixes)) {
             for (String name : List.of(
                     "PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS")) {
                 camelContext.getRegistry().unbind(name);
@@ -116,7 +116,9 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         Set<String> prefixes =
                 ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jms"));
 
-        if (config.transactionEnabled()) {
+        // Bind JTA policies when the default config OR any discovered prefixed config
+        // has transactions enabled (e.g., forage.mq1.jms.transaction.enabled=true)
+        if (anyTransactionEnabled(config, prefixes)) {
             camelContext.getRegistry().bind("PROPAGATION_REQUIRED", new RequiredJtaTransactionPolicy());
             camelContext.getRegistry().bind("MANDATORY", new MandatoryJtaTransactionPolicy());
             camelContext.getRegistry().bind("NEVER", new NeverJtaTransactionPolicy());
@@ -155,6 +157,13 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
                 LOG.error(ex.getMessage(), ex);
             }
         }
+    }
+
+    private static boolean anyTransactionEnabled(ConnectionFactoryConfig defaultConfig, Set<String> prefixes) {
+        if (defaultConfig.transactionEnabled()) {
+            return true;
+        }
+        return prefixes.stream().anyMatch(p -> new ConnectionFactoryConfig(p).transactionEnabled());
     }
 
     private synchronized ConnectionFactory newConnectionFactory(

--- a/library/jms/forage-jms/src/test/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactoryTransactionTest.java
+++ b/library/jms/forage-jms/src/test/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactoryTransactionTest.java
@@ -1,0 +1,76 @@
+package io.kaoto.forage.jms;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSContext;
+
+import java.util.List;
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that JTA transaction policy beans are bound when only a prefixed (named)
+ * JMS configuration enables transactions (issue #230). The prefixed configuration
+ * ({@code forage.mq1.jms.transaction.enabled=true}) comes from the test classpath's
+ * {@code forage-connectionfactory.properties}; the default (unprefixed) configuration
+ * has transactions disabled.
+ */
+class ConnectionFactoryBeanFactoryTransactionTest {
+
+    private static final List<String> POLICY_BEANS =
+            List.of("PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS");
+
+    @Test
+    void prefixedTransactionEnabledBindsJtaPolicies() {
+        CamelContext camelContext = new DefaultCamelContext();
+        // Pre-bind the prefixed ConnectionFactory so configure() does not need a broker provider
+        camelContext.getRegistry().bind("mq1", dummyConnectionFactory());
+
+        ConnectionFactoryBeanFactory beanFactory = new ConnectionFactoryBeanFactory();
+        beanFactory.setCamelContext(camelContext);
+        beanFactory.configure();
+
+        for (String name : POLICY_BEANS) {
+            assertThat(camelContext.getRegistry().lookupByName(name))
+                    .as("JTA policy bean '%s' should be bound when a prefixed config enables transactions", name)
+                    .isNotNull();
+        }
+    }
+
+    private static ConnectionFactory dummyConnectionFactory() {
+        return new ConnectionFactory() {
+            @Override
+            public Connection createConnection() {
+                throw new UnsupportedOperationException("test stub");
+            }
+
+            @Override
+            public Connection createConnection(String userName, String password) {
+                throw new UnsupportedOperationException("test stub");
+            }
+
+            @Override
+            public JMSContext createContext() {
+                throw new UnsupportedOperationException("test stub");
+            }
+
+            @Override
+            public JMSContext createContext(String userName, String password) {
+                throw new UnsupportedOperationException("test stub");
+            }
+
+            @Override
+            public JMSContext createContext(String userName, String password, int sessionMode) {
+                throw new UnsupportedOperationException("test stub");
+            }
+
+            @Override
+            public JMSContext createContext(int sessionMode) {
+                throw new UnsupportedOperationException("test stub");
+            }
+        };
+    }
+}

--- a/library/jms/forage-jms/src/test/resources/forage-connectionfactory.properties
+++ b/library/jms/forage-jms/src/test/resources/forage-connectionfactory.properties
@@ -1,0 +1,5 @@
+# Test configuration: a prefixed (named) JMS configuration with transactions enabled
+# and NO default (unprefixed) transaction property. Used by
+# ConnectionFactoryBeanFactoryTransactionTest to verify that JTA transaction policies
+# are bound when only a prefixed configuration enables transactions (issue #230).
+forage.mq1.jms.transaction.enabled=true

--- a/library/jms/spring-boot/forage-jms-starter/pom.xml
+++ b/library/jms/spring-boot/forage-jms-starter/pom.xml
@@ -44,6 +44,28 @@
             <artifactId>pooled-jms</artifactId>
             <version>${pooled-jms.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-jms-artemis</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/ForageConnectionFactoryAutoConfiguration.java
+++ b/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/ForageConnectionFactoryAutoConfiguration.java
@@ -4,8 +4,10 @@ import jakarta.jms.ConnectionFactory;
 
 import java.util.List;
 import java.util.ServiceLoader;
+import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,7 +15,6 @@ import org.springframework.boot.autoconfigure.jms.artemis.ArtemisAutoConfigurati
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
@@ -40,24 +41,11 @@ import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
         variant = FactoryVariant.SPRING_BOOT)
 @Configuration
 @AutoConfigureBefore(ArtemisAutoConfiguration.class)
-public class ForageConnectionFactoryAutoConfiguration {
+public class ForageConnectionFactoryAutoConfiguration implements DisposableBean {
 
     private static final Logger log = LoggerFactory.getLogger(ForageConnectionFactoryAutoConfiguration.class);
 
-    /**
-     * Transaction management configuration that enables Spring transaction support
-     * when JMS transactions are configured.
-     */
-    @Configuration
-    @ConditionalOnProperty(value = "forage.jms.transaction.enabled", havingValue = "true")
-    @EnableTransactionManagement
-    static class ForageTransactionManagement {
-
-        @jakarta.annotation.PostConstruct
-        public void init() {
-            log.info("ForageTransactionManagement configuration enabled");
-        }
-    }
+    private ConnectionFactory defaultConnectionFactory;
 
     /**
      * Registers the generic module adapter that discovers prefixed ConnectionFactory
@@ -74,8 +62,14 @@ public class ForageConnectionFactoryAutoConfiguration {
      * Fallback ConnectionFactory bean created when no named/prefixed configurations are found
      * and default (unprefixed) JMS properties exist. Uses {@code forage.jms.kind} to select
      * the matching provider when multiple providers are on the classpath.
+     *
+     * <p>{@code destroyMethod = ""} disables Spring's destroy-method inference:
+     * {@link JmsPoolConnectionFactory} exposes {@code stop()} rather than {@code close()}/
+     * {@code shutdown()}, so inference would never stop the pool (and a raw, pool-disabled
+     * connection factory may have no lifecycle method at all). The pool is instead stopped
+     * explicitly in {@link #destroy()} when the context closes.
      */
-    @Bean("jmsConnectionFactory")
+    @Bean(value = "jmsConnectionFactory", destroyMethod = "")
     @ConditionalOnMissingBean(name = "jmsConnectionFactory")
     @ConditionalOnProperty(prefix = "forage.jms", name = "kind")
     public ConnectionFactory forageDefaultConnectionFactory() {
@@ -92,6 +86,7 @@ public class ForageConnectionFactoryAutoConfiguration {
                 log.info("Creating default ConnectionFactory using provider: {}", providerClassName);
                 ConnectionFactory connectionFactory = provider.get().create(null);
                 log.info("Registered default ConnectionFactory bean");
+                this.defaultConnectionFactory = connectionFactory;
                 return connectionFactory;
             }
         }
@@ -102,5 +97,18 @@ public class ForageConnectionFactoryAutoConfiguration {
                 .orElse("none");
         throw new IllegalStateException("No ConnectionFactoryProvider found for kind '" + kind + "' (expected "
                 + providerClassName + "). Available providers: " + available);
+    }
+
+    /**
+     * Stops the default pooled ConnectionFactory when the application context closes.
+     * {@link JmsPoolConnectionFactory} has no {@code close()}/{@code shutdown()} method, so
+     * Spring's inferred destroy method would never release the pool.
+     */
+    @Override
+    public void destroy() {
+        if (defaultConnectionFactory instanceof JmsPoolConnectionFactory pool) {
+            log.info("Stopping default pooled ConnectionFactory");
+            pool.stop();
+        }
     }
 }

--- a/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/jta/ForageJmsTransactionManagementAutoConfiguration.java
+++ b/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/jta/ForageJmsTransactionManagementAutoConfiguration.java
@@ -4,12 +4,12 @@ import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import io.kaoto.forage.springboot.common.jta.ConditionalOnAnyForageTransactionEnabled;
 
 @Configuration
-@ConditionalOnProperty(value = "forage.jms.transaction.enabled", havingValue = "true")
+@ConditionalOnAnyForageTransactionEnabled(modulePrefix = "jms")
 @EnableTransactionManagement
 public class ForageJmsTransactionManagementAutoConfiguration
         extends io.kaoto.forage.springboot.common.jta.ForageTransactionManagementAutoConfiguration {

--- a/library/jms/spring-boot/forage-jms-starter/src/test/java/io/kaoto/forage/springboot/jms/ForageJmsConnectionFactoryLifecycleTest.java
+++ b/library/jms/spring-boot/forage-jms-starter/src/test/java/io/kaoto/forage/springboot/jms/ForageJmsConnectionFactoryLifecycleTest.java
@@ -1,0 +1,73 @@
+package io.kaoto.forage.springboot.jms;
+
+import jakarta.jms.ConnectionFactory;
+
+import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Lifecycle tests for Forage-registered JMS ConnectionFactory beans.
+ *
+ * <p>Uses the Artemis provider from the test classpath; the connection factory does not
+ * connect to a broker until a connection is requested, so no broker is needed.
+ */
+class ForageJmsConnectionFactoryLifecycleTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ForageConnectionFactoryAutoConfiguration.class));
+
+    @Test
+    void prefixedPooledConnectionFactoryIsStoppedOnContextClose() {
+        contextRunner
+                .withSystemProperties(
+                        "forage.mqpool.jms.kind=artemis", "forage.mqpool.jms.broker.url=tcp://localhost:61616")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+
+                    ConnectionFactory cf = ctx.getBean("mqpool", ConnectionFactory.class);
+                    assertThat(cf).isInstanceOf(JmsPoolConnectionFactory.class);
+
+                    // The first prefix is aliased as the default bean name and must resolve
+                    // to the same instance (no duplicate pool)
+                    assertThat(ctx.getBean("connectionFactory")).isSameAs(cf);
+
+                    // Closing the context must not throw (no double-destroy through aliases)
+                    ConfigurableApplicationContext applicationContext = ctx.getSourceApplicationContext();
+                    assertThatCode(applicationContext::close).doesNotThrowAnyException();
+
+                    // destroy-method "stop" must have shut the pool down
+                    JmsPoolConnectionFactory pool = (JmsPoolConnectionFactory) cf;
+                    assertThat(pool.getNumConnections()).isZero();
+                    assertThat(pool.createConnection())
+                            .as("a stopped pool must no longer hand out connections")
+                            .isNull();
+                });
+    }
+
+    @Test
+    void poolDisabledPrefixedConnectionFactoryStartsAndClosesCleanly() {
+        contextRunner
+                .withSystemProperties(
+                        "forage.mqnopool.jms.kind=artemis",
+                        "forage.mqnopool.jms.broker.url=tcp://localhost:61616",
+                        "forage.mqnopool.jms.pool.enabled=false")
+                .run(ctx -> {
+                    // With pooling disabled the provider returns the raw broker ConnectionFactory,
+                    // which has no stop() method. The bean definition must not declare a "stop"
+                    // destroy method, or Spring fails with BeanDefinitionValidationException.
+                    assertThat(ctx).hasNotFailed();
+
+                    ConnectionFactory cf = ctx.getBean("mqnopool", ConnectionFactory.class);
+                    assertThat(cf).isNotInstanceOf(JmsPoolConnectionFactory.class);
+
+                    assertThatCode(() -> ctx.getSourceApplicationContext().close())
+                            .doesNotThrowAnyException();
+                });
+    }
+}


### PR DESCRIPTION
## Summary

Fixes five defects found in the Spring Boot module adapters (see #404):

- **CRITICAL** — `ForageTransactionManagementAutoConfiguration`: all seven `SpringTransactionPolicy` beans used attribute-less `@ConditionalOnMissingBean`, which matches on the return *type*, so the first bean prevented the remaining six from registering. Fixed by adding `name =` attribute to each annotation matching the `@Bean` name, mirroring how `camel-spring-boot`'s `TransactionAutoConfiguration` does it.

- **MEDIUM** — `ForageJdbcTransactionManagementAutoConfiguration` / `ForageJmsTransactionManagementAutoConfiguration`: `@ConditionalOnProperty` only matched the default (unprefixed) key, so `forage.ds1.jdbc.transaction.enabled=true` produced no `JtaTransactionManager` on Spring Boot. Replaced with new `@ConditionalOnAnyForageTransactionEnabled(modulePrefix=…)` annotation backed by `ForageTransactionEnabledCondition`, which regex-scans the environment for any `forage(.<prefix>)?.<module>.transaction.enabled=true` key. Fixes the root cause of #230.

- **MEDIUM** — `ForageJdbcBeanRegistrar`: the default `"dataSource"` bean was registered as a separate `GenericBeanDefinition` with its own `createBean(prefix)` supplier, opening a second physical pool to the same database and never setting `setPrimary(true)`. Fixed by using `registry.registerAlias(name, defaultName)` and marking the first named bean as primary.

- **MEDIUM** — `JdbcModuleDescriptor.auxiliaryBeans()`: aggregation/idempotent repository suppliers each called `createDataSource(...)` internally, creating unmanaged pools per repository (2–4 pools per prefix). Fixed by adding `auxiliaryBeans(String prefix, Function<String, Object> primaryLookup)` to `ForageModuleDescriptor`, overriding it in `JdbcModuleDescriptor` to reuse the lookup, and having `ForageSpringBootModuleAdapter` supply a `beanFactory::getBean` lookup captured during `postProcessBeanFactory`. The `ForageIdRepository` SQL strings are now obtained via a lightweight provider instantiation without creating a pool.

- **MEDIUM** — `ForageSpringBootModuleAdapter`: `JmsPoolConnectionFactory.stop()` was never called on context close because Spring's default destroy inference looks for `close()` or `shutdown()`. Added `destroyMethodName()` default method to `ForageModuleDescriptor` (`""` = Spring inference); `JmsModuleDescriptor` overrides to return `"stop"`. The adapter now sets `beanDefinition.setDestroyMethodName(...)` on primary bean definitions. Separately, alias beans in `postProcessBeanFactory` were registered as `GenericBeanDefinition` (separate singleton wrapping the same instance), which caused `close()` to be called twice on `AutoCloseable` beans. Fixed by using `registry.registerAlias(defaultName, alias)` instead.

## Test plan

- [ ] `ForageTransactionManagementAutoConfigurationTest` — asserts all seven policy beans are registered; asserts a user-defined bean is not overridden
- [ ] `ForageTransactionEnabledConditionTest` — asserts the condition activates on the default key, on a prefixed key, and stays inactive when `false` or absent
- [ ] `mvn clean install -DskipTests` passes from repository root

Fixes #230 (the plain-Camel code path is covered by the review follow-up commit).
