### PR TITLE
Fix #403 (backport to camel-latest): Quarkus adapter bugs — max-size copy-paste, STATIC_INIT connections, recorder null checks, IBM MQ bean naming, -1 sentinel

### DIFF
--- a/library/ai/agents/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/agent/deployment/ForageAgentProcessor.java
+++ b/library/ai/agents/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/agent/deployment/ForageAgentProcessor.java
@@ -75,9 +75,7 @@ public class ForageAgentProcessor {
                     name, agentItem.getConfig().modelKind());
 
             RuntimeValue<Agent> agent = recorder.createAgent(name, context.getCamelContext());
-            if (agent != null) {
-                beans.produce(new CamelRuntimeBeanBuildItem(name, Agent.class.getName(), agent));
-            }
+            beans.produce(new CamelRuntimeBeanBuildItem(name, Agent.class.getName(), agent));
         }
     }
 }

--- a/library/ai/agents/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/agent/ForageAgentRecorder.java
+++ b/library/ai/agents/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/agent/ForageAgentRecorder.java
@@ -38,9 +38,14 @@ public class ForageAgentRecorder {
             agent = AgentCreator.createAgent(config, name, cl);
         }
 
-        if (agent != null) {
-            return new RuntimeValue<>(agent);
+        if (agent == null) {
+            throw new IllegalStateException(
+                    ("Forage Agent '%s' could not be created: no ChatModel was found in the registry and no suitable "
+                                    + "ModelProvider was resolved via ServiceLoader. Ensure a Forage model artifact "
+                                    + "(e.g. forage-model-open-ai, forage-model-ollama) is on the classpath and the "
+                                    + "'forage.*' model properties for '%s' are configured.")
+                            .formatted(name, name));
         }
-        return null;
+        return new RuntimeValue<>(agent);
     }
 }

--- a/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
+++ b/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
@@ -104,9 +104,7 @@ public class ForageCxfProcessor {
         for (ForageCxfBuildItem item : cxfEndpoints) {
             LOG.infof("Registering CXF endpoint bean '%s'", item.getName());
             RuntimeValue<Object> endpoint = recorder.createCxfEndpoint(item.getPrefix());
-            if (endpoint != null) {
-                beans.produce(new CamelRuntimeBeanBuildItem(item.getName(), Object.class.getName(), endpoint));
-            }
+            beans.produce(new CamelRuntimeBeanBuildItem(item.getName(), Object.class.getName(), endpoint));
         }
     }
 

--- a/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfRecorder.java
+++ b/library/cxf/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/cxf/ForageCxfRecorder.java
@@ -33,20 +33,26 @@ public class ForageCxfRecorder {
                 ServiceLoaderHelper.findProviderByClassName(providers, providerClass);
 
         if (provider == null) {
-            LOG.warnf("No CXF endpoint provider found for class %s", providerClass);
-            return null;
+            throw new IllegalStateException(
+                    ("CXF endpoint '%s' could not be created: no CxfEndpointProvider of type %s was found via "
+                                    + "ServiceLoader. Ensure the Forage CXF provider artifact for kind '%s' "
+                                    + "(e.g. forage-cxf-soap-client or forage-cxf-soap-service) is on the classpath.")
+                            .formatted(id, providerClass, config.cxfKind()));
         }
 
         Object endpoint = provider.get().create(id);
+        if (endpoint == null) {
+            throw new IllegalStateException(
+                    ("CXF endpoint '%s' could not be created: provider %s returned no endpoint. Verify the "
+                                    + "'forage.cxf.*' configuration for '%s' (service class, address, etc.).")
+                            .formatted(id, providerClass, id));
+        }
         if (endpoint instanceof ForageCxfEndpoint forageCxfEndpoint) {
             String cxfServletPath = ConfigProvider.getConfig()
                     .getOptionalValue("quarkus.cxf.path", String.class)
                     .orElse(DEFAULT_CXF_SERVLET_PATH);
             forageCxfEndpoint.setServletContainerCxfPath(cxfServletPath, RuntimeType.quarkus);
         }
-        if (endpoint != null) {
-            return new RuntimeValue<>(endpoint);
-        }
-        return null;
+        return new RuntimeValue<>(endpoint);
     }
 }

--- a/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/io/kaoto/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
+++ b/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/io/kaoto/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
@@ -91,7 +91,14 @@ public class ForageJdbcProcessor {
 
             if (isNotBlank(dsConfig.aggregationRepositoryName())) {
                 if (!dsConfig.transactionEnabled()) {
-                    LOG.warn("Transactions have to be enabled in order to create aggregation repositories");
+                    LOG.warnf(
+                            "Skipping aggregation repository '%s' for datasource '%s': transactions have to be "
+                                    + "enabled in order to create aggregation repositories. Set '%s' to true.",
+                            dsConfig.aggregationRepositoryName(),
+                            name,
+                            prefix == null
+                                    ? "forage.jdbc.transaction.enabled"
+                                    : "forage." + prefix + ".jdbc.transaction.enabled");
                 } else {
                     RuntimeValue<JdbcAggregationRepository> aggRepo =
                             recorder.createAggregationRepository(name, prefix, context.getCamelContext());

--- a/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/io/kaoto/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
+++ b/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/io/kaoto/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
@@ -77,7 +77,7 @@ public class ForageJdbcProcessor {
      * {@link ForageDataSourceBuildItem}s instead of reading ConfigStore directly.
      */
     @BuildStep
-    @Record(value = ExecutionTime.STATIC_INIT)
+    @Record(value = ExecutionTime.RUNTIME_INIT)
     void registerRepositories(
             CamelContextBuildItem context,
             ForageJdbcRecorder recorder,
@@ -90,9 +90,11 @@ public class ForageJdbcProcessor {
             DataSourceFactoryConfig dsConfig = ds.getConfig();
 
             if (isNotBlank(dsConfig.aggregationRepositoryName())) {
-                RuntimeValue<JdbcAggregationRepository> aggRepo =
-                        recorder.createAggregationRepository(name, prefix, context.getCamelContext());
-                if (aggRepo != null) {
+                if (!dsConfig.transactionEnabled()) {
+                    LOG.warn("Transactions have to be enabled in order to create aggregation repositories");
+                } else {
+                    RuntimeValue<JdbcAggregationRepository> aggRepo =
+                            recorder.createAggregationRepository(name, prefix, context.getCamelContext());
                     beans.produce(new CamelRuntimeBeanBuildItem(
                             dsConfig.aggregationRepositoryName(), JdbcAggregationRepository.class.getName(), aggRepo));
                 }
@@ -107,12 +109,8 @@ public class ForageJdbcProcessor {
                 if (isNotBlank(dsConfig.idempotentRepositoryTableName())) {
                     RuntimeValue<JdbcMessageIdRepository> idRepo =
                             recorder.createIdempotentRepository(name, prefix, context.getCamelContext());
-                    if (idRepo != null) {
-                        beans.produce(new CamelRuntimeBeanBuildItem(
-                                dsConfig.idempotentRepositoryTableName(),
-                                JdbcMessageIdRepository.class.getName(),
-                                idRepo));
-                    }
+                    beans.produce(new CamelRuntimeBeanBuildItem(
+                            dsConfig.idempotentRepositoryTableName(), JdbcMessageIdRepository.class.getName(), idRepo));
                 } else {
                     logMissingMandatoryProperty(
                             "idempotent",

--- a/library/jdbc/camel-quarkus/jdbc/runtime/src/main/java/io/kaoto/forage/quarkus/jdbc/ForageJdbcRecorder.java
+++ b/library/jdbc/camel-quarkus/jdbc/runtime/src/main/java/io/kaoto/forage/quarkus/jdbc/ForageJdbcRecorder.java
@@ -5,7 +5,6 @@ import javax.sql.DataSource;
 import org.apache.camel.CamelContext;
 import org.apache.camel.processor.aggregate.jdbc.JdbcAggregationRepository;
 import org.apache.camel.processor.idempotent.jdbc.JdbcMessageIdRepository;
-import org.jboss.logging.Logger;
 import io.kaoto.forage.jdbc.common.DataSourceFactoryConfig;
 import io.kaoto.forage.jdbc.common.aggregation.ForageAggregationRepository;
 import io.kaoto.forage.jdbc.common.idempotent.ForageIdRepository;
@@ -26,7 +25,6 @@ import io.quarkus.runtime.annotations.Recorder;
  */
 @Recorder
 public class ForageJdbcRecorder {
-    private static final Logger LOG = Logger.getLogger(ForageJdbcRecorder.class);
 
     public RuntimeValue<JdbcAggregationRepository> createAggregationRepository(
             String dsName, String prefix, RuntimeValue<CamelContext> camelContext) {
@@ -34,11 +32,7 @@ public class ForageJdbcRecorder {
         DataSourceFactoryConfig config = new DataSourceFactoryConfig(prefix);
         CamelContext context = camelContext.getValue();
         DataSource agroalDataSource = context.getRegistry().lookupByNameAndType(dsName, DataSource.class);
-        JdbcAggregationRepository ar = createAggregationRepository(config, agroalDataSource);
-        if (ar != null) {
-            return new RuntimeValue<>(ar);
-        }
-        return null;
+        return new RuntimeValue<>(createAggregationRepository(config, agroalDataSource));
     }
 
     public RuntimeValue<JdbcMessageIdRepository> createIdempotentRepository(
@@ -47,24 +41,13 @@ public class ForageJdbcRecorder {
         DataSourceFactoryConfig config = new DataSourceFactoryConfig(prefix);
         CamelContext context = camelContext.getValue();
         DataSource agroalDataSource = context.getRegistry().lookupByNameAndType(dsName, DataSource.class);
-        JdbcMessageIdRepository ir = createIdempotentRepository(config, agroalDataSource);
-        if (ir != null) {
-            return new RuntimeValue<>(ir);
-        }
-        return null;
+        return new RuntimeValue<>(createIdempotentRepository(config, agroalDataSource));
     }
 
     private JdbcAggregationRepository createAggregationRepository(
             DataSourceFactoryConfig dsFactoryConfig, DataSource agroalDataSource) {
-        if (!dsFactoryConfig.transactionEnabled() && dsFactoryConfig.aggregationRepositoryName() != null) {
-            LOG.warn("Transactions have to be enabled in order to create aggregation repositories");
-            return null;
-        }
-        if (dsFactoryConfig.aggregationRepositoryName() != null) {
-            return new ForageAggregationRepository(
-                    agroalDataSource, com.arjuna.ats.jta.TransactionManager.transactionManager(), dsFactoryConfig);
-        }
-        return null;
+        return new ForageAggregationRepository(
+                agroalDataSource, com.arjuna.ats.jta.TransactionManager.transactionManager(), dsFactoryConfig);
     }
 
     private JdbcMessageIdRepository createIdempotentRepository(
@@ -80,19 +63,11 @@ public class ForageJdbcRecorder {
                     case "mysql" -> new MysqlJdbc();
                     case "oracle" -> new OracleJdbc();
                     case "postgresql" -> new PostgresqlJdbc();
-                    default -> null;
+                    default ->
+                        throw new IllegalStateException(
+                                "Unsupported db kind '%s' for idempotent repository".formatted(config.dbKind()));
                 };
 
-        if (config.enableIdempotentRepository()) {
-            if (forageIdRepository == null) {
-                LOG.warn("Unsupported type of db ('%s') for the idempotent repository".formatted(config.dbKind()));
-                return null;
-            }
-            if (config.idempotentRepositoryTableName() != null) {
-                return new ForageJdbcMessageIdRepository(config, agroalDataSource, forageIdRepository);
-            }
-        }
-
-        return null;
+        return new ForageJdbcMessageIdRepository(config, agroalDataSource, forageIdRepository);
     }
 }

--- a/library/jdbc/forage-jdbc-common/pom.xml
+++ b/library/jdbc/forage-jdbc-common/pom.xml
@@ -70,11 +70,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/library/jdbc/forage-jdbc-common/pom.xml
+++ b/library/jdbc/forage-jdbc-common/pom.xml
@@ -65,6 +65,18 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
@@ -65,10 +65,10 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
         String effectivePrefix = prefix != null ? prefix : defaultBeanName();
         quarkusPrefix += "\"" + effectivePrefix + "\".";
 
-        props.put(quarkusPrefix + "db-kind", config.dbKind());
-        props.put(quarkusPrefix + "password", config.password());
-        props.put(quarkusPrefix + "username", config.username());
-        props.put(quarkusPrefix + "jdbc.url", config.jdbcUrl());
+        putIfNotEmpty(props, quarkusPrefix + "db-kind", config.dbKind());
+        putIfNotEmpty(props, quarkusPrefix + "password", config.password());
+        putIfNotEmpty(props, quarkusPrefix + "username", config.username());
+        putIfNotEmpty(props, quarkusPrefix + "jdbc.url", config.jdbcUrl());
         props.put(quarkusPrefix + "jdbc.initial-size", String.valueOf(config.initialSize()));
         props.put(quarkusPrefix + "jdbc.min-size", String.valueOf(config.minSize()));
         props.put(quarkusPrefix + "jdbc.max-size", String.valueOf(config.maxSize()));
@@ -81,31 +81,43 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
             props.put(
                     "quarkus.transaction-manager.default-transaction-timeout",
                     config.transactionTimeoutSeconds() + "S");
-            if (config.transactionNodeId() != null) {
-                props.put("quarkus.transaction-manager.node-name", config.transactionNodeId());
-            }
+            putIfNotEmpty(props, "quarkus.transaction-manager.node-name", config.transactionNodeId());
             props.put(
                     "quarkus.transaction-manager.enable-recovery", String.valueOf(config.transactionEnableRecovery()));
-            props.put("quarkus.transaction-manager.recovery-modules", config.transactionRecoveryModules());
-            props.put(
+            putIfNotEmpty(props, "quarkus.transaction-manager.recovery-modules", config.transactionRecoveryModules());
+            putIfNotEmpty(
+                    props,
                     "quarkus.transaction-manager.xa-resource-orphan-filters",
                     config.transactionXaResourceOrphanFilters());
-            props.put("quarkus.transaction-manager.object-store.directory", config.transactionObjectStoreDirectory());
-            props.put("quarkus.transaction-manager.object-store.type", config.transactionObjectStoreType());
-            if (config.transactionObjectStoreDataSource() != null) {
-                props.put(
-                        "quarkus.transaction-manager.object-store.datasource",
-                        config.transactionObjectStoreDataSource());
-            }
+            putIfNotEmpty(
+                    props,
+                    "quarkus.transaction-manager.object-store.directory",
+                    config.transactionObjectStoreDirectory());
+            putIfNotEmpty(props, "quarkus.transaction-manager.object-store.type", config.transactionObjectStoreType());
+            putIfNotEmpty(
+                    props,
+                    "quarkus.transaction-manager.object-store.datasource",
+                    config.transactionObjectStoreDataSource());
             props.put(
                     "quarkus.transaction-manager.object-store.drop-table",
                     String.valueOf(config.transactionObjectStoreDropTable()));
-            props.put(
+            putIfNotEmpty(
+                    props,
                     "quarkus.transaction-manager.object-store.table-prefix",
                     config.transactionObjectStoreTablePrefix());
         }
 
         return props;
+    }
+
+    /**
+     * Puts the value only when it is non-null and non-empty, so unset optional configuration
+     * never leaks into the translated Quarkus properties as {@code null} or empty values.
+     */
+    private static void putIfNotEmpty(Map<String, String> props, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            props.put(key, value);
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptor.java
@@ -71,7 +71,7 @@ public class JdbcModuleDescriptor implements ForageModuleDescriptor<DataSourceFa
         props.put(quarkusPrefix + "jdbc.url", config.jdbcUrl());
         props.put(quarkusPrefix + "jdbc.initial-size", String.valueOf(config.initialSize()));
         props.put(quarkusPrefix + "jdbc.min-size", String.valueOf(config.minSize()));
-        props.put(quarkusPrefix + "jdbc.max-size", String.valueOf(config.minSize()));
+        props.put(quarkusPrefix + "jdbc.max-size", String.valueOf(config.maxSize()));
         props.put(quarkusPrefix + "jdbc.acquisition-timeout", config.acquisitionTimeoutSeconds() + "S");
         props.put(quarkusPrefix + "jdbc.validation-query-timeout", config.validationTimeoutSeconds() + "S");
         props.put(quarkusPrefix + "jdbc.leak-detection-interval", config.leakTimeoutMinutes() + "M");

--- a/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptorTest.java
+++ b/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptorTest.java
@@ -37,4 +37,21 @@ class JdbcModuleDescriptorTest {
         assertThat(props.get("quarkus.datasource.\"dataSource\".jdbc.min-size")).isEqualTo("2");
         assertThat(props.get("quarkus.datasource.\"dataSource\".jdbc.max-size")).isEqualTo("20");
     }
+
+    @Test
+    void unsetOptionalPropertiesAreNotTranslated() {
+        System.setProperty("forage.jdbc.transaction.enabled", "true");
+        try {
+            DataSourceFactoryConfig config = new DataSourceFactoryConfig();
+            Map<String, String> props = new JdbcModuleDescriptor().translateProperties(null, config);
+
+            // Optional properties without a configured value must be absent from the
+            // translated map, not present as null or the literal string "null"
+            assertThat(props).doesNotContainKey("quarkus.transaction-manager.node-name");
+            assertThat(props).doesNotContainKey("quarkus.transaction-manager.object-store.datasource");
+            assertThat(props.values()).noneMatch(v -> v == null || v.isEmpty() || "null".equals(v));
+        } finally {
+            System.clearProperty("forage.jdbc.transaction.enabled");
+        }
+    }
 }

--- a/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptorTest.java
+++ b/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptorTest.java
@@ -1,0 +1,40 @@
+package io.kaoto.forage.jdbc.common;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JdbcModuleDescriptorTest {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty("forage.jdbc.db.kind", "postgresql");
+        System.setProperty("forage.jdbc.url", "jdbc:postgresql://localhost/test");
+        System.setProperty("forage.jdbc.username", "user");
+        System.setProperty("forage.jdbc.password", "pass");
+        System.setProperty("forage.jdbc.pool.min.size", "2");
+        System.setProperty("forage.jdbc.pool.max.size", "20");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("forage.jdbc.db.kind");
+        System.clearProperty("forage.jdbc.url");
+        System.clearProperty("forage.jdbc.username");
+        System.clearProperty("forage.jdbc.password");
+        System.clearProperty("forage.jdbc.pool.min.size");
+        System.clearProperty("forage.jdbc.pool.max.size");
+    }
+
+    @Test
+    void maxSizeComesFromMaxSizeNotMinSize() {
+        DataSourceFactoryConfig config = new DataSourceFactoryConfig();
+        Map<String, String> props = new JdbcModuleDescriptor().translateProperties(null, config);
+
+        assertThat(props.get("quarkus.datasource.\"dataSource\".jdbc.min-size")).isEqualTo("2");
+        assertThat(props.get("quarkus.datasource.\"dataSource\".jdbc.max-size")).isEqualTo("20");
+    }
+}

--- a/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptorTest.java
+++ b/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/JdbcModuleDescriptorTest.java
@@ -1,6 +1,7 @@
 package io.kaoto.forage.jdbc.common;
 
 import java.util.Map;
+import io.kaoto.forage.core.util.config.ConfigStore;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,11 @@ class JdbcModuleDescriptorTest {
         System.clearProperty("forage.jdbc.password");
         System.clearProperty("forage.jdbc.pool.min.size");
         System.clearProperty("forage.jdbc.pool.max.size");
+        // Constructing DataSourceFactoryConfig caches the system-property values (including
+        // forage.jdbc.transaction.enabled=true from unsetOptionalPropertiesAreNotTranslated)
+        // in the singleton ConfigStore; clearing the system properties alone leaves those
+        // stale values behind for later tests in the same JVM
+        ConfigStore.getInstance().reload();
     }
 
     @Test

--- a/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
+++ b/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
@@ -45,7 +45,7 @@ public class ForageJmsProcessor {
     }
 
     @BuildStep
-    @Record(value = ExecutionTime.STATIC_INIT)
+    @Record(value = ExecutionTime.RUNTIME_INIT)
     void registerIbmMqConnectionFactory(ForageJmsRecorder recorder, BuildProducer<CamelRuntimeBeanBuildItem> beans) {
 
         ConnectionFactoryConfig defaultConfig = DESCRIPTOR.createConfig(null);
@@ -69,17 +69,13 @@ public class ForageJmsProcessor {
 
         for (Map.Entry<String, ConnectionFactoryConfig> entry : configs.entrySet()) {
             if ("ibmmq".equals(entry.getValue().jmsKind())) {
-                LOG.info("Recording IBMMMQ connection factory for url: "
+                LOG.info("Recording IBM MQ connection factory for url: "
                         + entry.getValue().brokerUrl());
-                // create connection factory
+                String beanName = Optional.ofNullable(entry.getKey()).orElse(DESCRIPTOR.defaultBeanName());
                 RuntimeValue<ConnectionFactory> connectionFactory =
                         recorder.createIbmMQConnectionFactory(entry.getKey());
-                if (connectionFactory != null) {
-                    beans.produce(new CamelRuntimeBeanBuildItem(
-                            Optional.ofNullable(entry.getValue().name()).orElse(entry.getKey()),
-                            ConnectionFactory.class.getName(),
-                            connectionFactory));
-                }
+                beans.produce(
+                        new CamelRuntimeBeanBuildItem(beanName, ConnectionFactory.class.getName(), connectionFactory));
             }
         }
     }

--- a/library/jms/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/jms/ForageJmsRecorder.java
+++ b/library/jms/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/jms/ForageJmsRecorder.java
@@ -15,11 +15,10 @@ public class ForageJmsRecorder {
     private static final Logger LOG = Logger.getLogger(ForageJmsRecorder.class);
 
     public RuntimeValue<ConnectionFactory> createIbmMQConnectionFactory(String id) {
-
         ConnectionFactory cf = new IbmMqJms().create(id);
-        if (cf != null) {
-            return new RuntimeValue<>(cf);
+        if (cf == null) {
+            throw new IllegalStateException("IBM MQ ConnectionFactory could not be created for id '%s'".formatted(id));
         }
-        return null;
+        return new RuntimeValue<>(cf);
     }
 }

--- a/library/jms/forage-jms-common/pom.xml
+++ b/library/jms/forage-jms-common/pom.xml
@@ -61,6 +61,18 @@
             <artifactId>jboss-logging</artifactId>
             <version>3.6.3.Final</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/jms/forage-jms-common/pom.xml
+++ b/library/jms/forage-jms-common/pom.xml
@@ -66,11 +66,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
@@ -80,7 +80,8 @@ public class JmsModuleDescriptor implements ForageModuleDescriptor<ConnectionFac
 
             addIfNotEmpty(props, "quarkus.pooled-jms.max-connections", config::maxConnections);
             addIfNotEmpty(props, "quarkus.pooled-jms.max-sessions-per-connection", config::maxSessionsPerConnection);
-            addSecondsFromMillis(props, "quarkus.pooled-jms.connection-idle-timeout", config::idleTimeoutMillis);
+            // pooled-jms expects both timeouts in milliseconds - pass the configured millis through unchanged
+            addIfNotEmpty(props, "quarkus.pooled-jms.connection-idle-timeout", config::idleTimeoutMillis);
             addIfNotEmpty(props, "quarkus.pooled-jms.connection-check-interval", config::expiryTimeoutMillis);
             addIfNotEmpty(props, "quarkus.pooled-jms.block-if-session-pool-is-full", config::blockIfFull);
             addIfNotEmpty(
@@ -130,14 +131,6 @@ public class JmsModuleDescriptor implements ForageModuleDescriptor<ConnectionFac
         String stringValue = String.valueOf(value);
         if (value != null && !Strings.isNullOrEmpty(stringValue)) {
             config.put(key, stringValue);
-        }
-    }
-
-    private static void addSecondsFromMillis(Map<String, String> config, String key, Supplier<Long> method) {
-        Long value = method.get();
-        if (value != null) {
-            int intValue = (int) (value / 1000);
-            config.put(key, String.valueOf(intValue));
         }
     }
 }

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/JmsModuleDescriptor.java
@@ -83,7 +83,7 @@ public class JmsModuleDescriptor implements ForageModuleDescriptor<ConnectionFac
             addSecondsFromMillis(props, "quarkus.pooled-jms.connection-idle-timeout", config::idleTimeoutMillis);
             addIfNotEmpty(props, "quarkus.pooled-jms.connection-check-interval", config::expiryTimeoutMillis);
             addIfNotEmpty(props, "quarkus.pooled-jms.block-if-session-pool-is-full", config::blockIfFull);
-            addSecondsFromMillis(
+            addIfNotEmpty(
                     props,
                     "quarkus.pooled-jms.block-if-session-pool-is-full-timeout",
                     config::blockIfFullTimeoutMillis);

--- a/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/JmsModuleDescriptorTest.java
+++ b/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/JmsModuleDescriptorTest.java
@@ -1,0 +1,35 @@
+package io.kaoto.forage.jms.common;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JmsModuleDescriptorTest {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty("forage.jms.kind", "artemis");
+        System.setProperty("forage.jms.broker.url", "tcp://localhost:61616");
+        System.setProperty("forage.jms.pool.block.if.full.timeout.millis", "-1");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("forage.jms.kind");
+        System.clearProperty("forage.jms.broker.url");
+        System.clearProperty("forage.jms.pool.block.if.full.timeout.millis");
+    }
+
+    @Test
+    void blockIfFullTimeoutSentinelNotCorrupted() {
+        ConnectionFactoryConfig config = new ConnectionFactoryConfig();
+        Map<String, String> props = new JmsModuleDescriptor().translateProperties(null, config);
+
+        // -1 (infinite sentinel) must not be divided by 1000 and must be passed through as-is
+        assertThat(props.get("quarkus.pooled-jms.block-if-session-pool-is-full-timeout"))
+                .isEqualTo("-1");
+    }
+}

--- a/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/JmsModuleDescriptorTest.java
+++ b/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/JmsModuleDescriptorTest.java
@@ -14,6 +14,8 @@ class JmsModuleDescriptorTest {
         System.setProperty("forage.jms.kind", "artemis");
         System.setProperty("forage.jms.broker.url", "tcp://localhost:61616");
         System.setProperty("forage.jms.pool.block.if.full.timeout.millis", "-1");
+        System.setProperty("forage.jms.pool.idle.timeout.millis", "60000");
+        System.setProperty("forage.jms.pool.expiry.timeout.millis", "45000");
     }
 
     @AfterEach
@@ -21,6 +23,8 @@ class JmsModuleDescriptorTest {
         System.clearProperty("forage.jms.kind");
         System.clearProperty("forage.jms.broker.url");
         System.clearProperty("forage.jms.pool.block.if.full.timeout.millis");
+        System.clearProperty("forage.jms.pool.idle.timeout.millis");
+        System.clearProperty("forage.jms.pool.expiry.timeout.millis");
     }
 
     @Test
@@ -31,5 +35,19 @@ class JmsModuleDescriptorTest {
         // -1 (infinite sentinel) must not be divided by 1000 and must be passed through as-is
         assertThat(props.get("quarkus.pooled-jms.block-if-session-pool-is-full-timeout"))
                 .isEqualTo("-1");
+    }
+
+    @Test
+    void pooledJmsTimeoutsArePassedThroughAsMillis() {
+        ConnectionFactoryConfig config = new ConnectionFactoryConfig();
+        Map<String, String> props = new JmsModuleDescriptor().translateProperties(null, config);
+
+        // quarkus-pooled-jms passes connection-idle-timeout raw to pooled-jms setConnectionIdleTimeout(int),
+        // which expects MILLISECONDS. The old seconds conversion would have produced "60" (i.e. 60 ms).
+        assertThat(props.get("quarkus.pooled-jms.connection-idle-timeout")).isEqualTo("60000");
+        assertThat(props.get("quarkus.pooled-jms.connection-idle-timeout")).isNotEqualTo("60");
+
+        // connection-check-interval is also a millis value and must be passed through unchanged
+        assertThat(props.get("quarkus.pooled-jms.connection-check-interval")).isEqualTo("45000");
     }
 }

--- a/library/messaging/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/deployment/ForageSpringRabbitMQProcessor.java
+++ b/library/messaging/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/deployment/ForageSpringRabbitMQProcessor.java
@@ -2,10 +2,12 @@ package io.kaoto.forage.quarkus.messaging.springrabbitmq.deployment;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.camel.quarkus.core.deployment.spi.CamelRegistryBuildItem;
+import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
 import org.jboss.logging.Logger;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
@@ -15,10 +17,12 @@ import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConfig;
 import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConstants;
 import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQModuleDescriptor;
 import io.kaoto.forage.quarkus.messaging.springrabbitmq.ForageSpringRabbitMQRecorder;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 
 /**
  * Quarkus deployment processor for Forage Spring RabbitMQ.
@@ -49,9 +53,9 @@ public class ForageSpringRabbitMQProcessor {
     }
 
     @BuildStep
-    @Record(value = ExecutionTime.STATIC_INIT)
-    void registerIbmMqConnectionFactory(
-            ForageSpringRabbitMQRecorder recorder, CamelRegistryBuildItem camelRegistryBuildItem) {
+    @Record(value = ExecutionTime.RUNTIME_INIT)
+    void registerRabbitConnectionFactories(
+            ForageSpringRabbitMQRecorder recorder, BuildProducer<CamelRuntimeBeanBuildItem> beans) {
         LOG.debug("ForageSpringRabbitMQProcessor.registerRabbitConnectionFactories() called at build time");
         SpringRabbitMQConfig defaultConfig = DESCRIPTOR.createConfig(null);
         Set<String> named = ConfigStore.getInstance()
@@ -73,12 +77,12 @@ public class ForageSpringRabbitMQProcessor {
         }
 
         for (Map.Entry<String, SpringRabbitMQConfig> entry : configs.entrySet()) {
-            LOG.infof(
-                    "Recording Spring RabbitMQ connection factory for bean: %s",
-                    entry.getKey() == null ? SpringRabbitMQConstants.DEFAULT_BEAN_NAME : entry.getKey());
-
-            // create connection factory
-            recorder.createRabbitConnectionFactory(entry.getKey(), camelRegistryBuildItem.getRegistry());
+            String beanName = Optional.ofNullable(entry.getKey()).orElse(SpringRabbitMQConstants.DEFAULT_BEAN_NAME);
+            LOG.infof("Recording Spring RabbitMQ connection factory for bean: %s", beanName);
+            RuntimeValue<CachingConnectionFactory> connectionFactory =
+                    recorder.createRabbitConnectionFactory(entry.getKey());
+            beans.produce(new CamelRuntimeBeanBuildItem(
+                    beanName, CachingConnectionFactory.class.getName(), connectionFactory));
         }
     }
 }

--- a/library/messaging/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/ForageSpringRabbitMQRecorder.java
+++ b/library/messaging/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/ForageSpringRabbitMQRecorder.java
@@ -1,11 +1,9 @@
 package io.kaoto.forage.quarkus.messaging.springrabbitmq;
 
-import org.apache.camel.spi.Registry;
 import org.jboss.logging.Logger;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConfig;
 import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConnectionFactoryHelper;
-import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConstants;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -18,12 +16,10 @@ import io.quarkus.runtime.annotations.Recorder;
 public class ForageSpringRabbitMQRecorder {
     private static final Logger LOG = Logger.getLogger(ForageSpringRabbitMQRecorder.class);
 
-    public void createRabbitConnectionFactory(String id, RuntimeValue<Registry> registryRuntimeValue) {
+    public RuntimeValue<CachingConnectionFactory> createRabbitConnectionFactory(String id) {
         SpringRabbitMQConfig config = id == null ? new SpringRabbitMQConfig() : new SpringRabbitMQConfig(id);
         CachingConnectionFactory cachingConnectionFactory =
                 SpringRabbitMQConnectionFactoryHelper.createCachingConnectionFactory(config);
-        registryRuntimeValue
-                .getValue()
-                .bind(id == null ? SpringRabbitMQConstants.DEFAULT_BEAN_NAME : id, cachingConnectionFactory);
+        return new RuntimeValue<>(cachingConnectionFactory);
     }
 }


### PR DESCRIPTION
## Summary

Backport of #419 to `camel-latest` (Quarkus 3.35), as required by the issue's task list. Cherry-picked cleanly; Quarkus/JMS/JDBC module tests re-run on this branch.

Fixes from #403 (see #419 for details):
- Quarkus pool `max-size` translated from `config.maxSize()` instead of `minSize()`
- JMS/RabbitMQ/JDBC recorders moved from `STATIC_INIT` to `RUNTIME_INIT`
- Recorders throw descriptive `IllegalStateException` instead of returning null `RuntimeValue`s (JDBC, JMS, Agent, CXF)
- IBM MQ connection factory registered under its prefix/default bean name so `connectionFactory=#myMq` lookups resolve
- `-1` sentinel preserved and all three quarkus-pooled-jms timeout properties passed through as milliseconds
- Null guards in JDBC property translation; aggregation-repo skip warning now names the datasource and the property to set
- Copy-paste `registerIbmMqConnectionFactory` method renamed in the RabbitMQ processor

Part of #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
