### PR TITLE
Fix #405: AgentCreator config bridge - mistral/watsonx prefixes, embedding keys, system property snapshot/restore

### DIFF
--- a/library/ai/agents/forage-agent/pom.xml
+++ b/library/ai/agents/forage-agent/pom.xml
@@ -50,6 +50,75 @@
             <artifactId>langchain4j</artifactId>
         </dependency>
 
+        <!-- Chat model modules used by AgentCreatorTest to cross-check that
+             getProviderConfigPrefix() stays in sync with each module's ConfigEntries keys -->
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-anthropic</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-azure-openai</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-bedrock</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-dashscope</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-google-gemini</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-hugging-face</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-local-ai</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-mistral-ai</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-ollama</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-open-ai</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-model-watsonx-ai</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/library/ai/agents/forage-agent/pom.xml
+++ b/library/ai/agents/forage-agent/pom.xml
@@ -49,6 +49,17 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfig.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfig.java
@@ -11,6 +11,7 @@ import static io.kaoto.forage.agent.AgentConfigEntries.BASE_URL;
 import static io.kaoto.forage.agent.AgentConfigEntries.DEFAULT_RAG_MAX_RESULTS;
 import static io.kaoto.forage.agent.AgentConfigEntries.DEFAULT_RAG_MIN_SCORE;
 import static io.kaoto.forage.agent.AgentConfigEntries.DEPLOYMENT_NAME;
+import static io.kaoto.forage.agent.AgentConfigEntries.EMBEDDING_MODEL_API_KEY;
 import static io.kaoto.forage.agent.AgentConfigEntries.EMBEDDING_MODEL_BASE_URL;
 import static io.kaoto.forage.agent.AgentConfigEntries.EMBEDDING_MODEL_MAX_RETRIES;
 import static io.kaoto.forage.agent.AgentConfigEntries.EMBEDDING_MODEL_MODEL_NAME;
@@ -189,8 +190,12 @@ public class AgentConfig extends AbstractConfig {
 
     // RAG
 
+    public String embeddingModelApiKey() {
+        return get(EMBEDDING_MODEL_API_KEY).or(() -> get(API_KEY)).orElse(null);
+    }
+
     public String embeddingModelBaseUrl() {
-        return get(EMBEDDING_MODEL_BASE_URL).orElse(BASE_URL.defaultValue());
+        return get(EMBEDDING_MODEL_BASE_URL).or(() -> get(BASE_URL)).orElse(null);
     }
 
     public String embeddingModelName() {

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
@@ -284,9 +284,9 @@ public final class AgentConfigEntries extends ConfigEntries {
     // embedding model
     public static final ConfigModule EMBEDDING_MODEL_API_KEY = ConfigModule.of(
             AgentConfig.class,
-            "forage.agent.api.key",
-            "API key for authentication with the model provider",
-            "API Key",
+            "forage.agent.embedding.model.api.key",
+            "API key for the embedding model provider (falls back to forage.agent.api.key when not set)",
+            "Embedding API Key",
             null,
             "password",
             false,
@@ -294,9 +294,9 @@ public final class AgentConfigEntries extends ConfigEntries {
 
     public static final ConfigModule EMBEDDING_MODEL_BASE_URL = ConfigModule.of(
             AgentConfig.class,
-            "forage.agent.base.url",
-            "Base URL for the model provider API",
-            "Base URL",
+            "forage.agent.embedding.model.base.url",
+            "Base URL for the embedding model provider (falls back to forage.agent.base.url when not set)",
+            "Embedding Base URL",
             null,
             "string",
             false,

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
@@ -1,7 +1,9 @@
 package io.kaoto.forage.agent;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import org.apache.camel.component.langchain4j.agent.api.Agent;
@@ -43,6 +45,8 @@ public final class AgentCreator {
     private static final Logger LOG = LoggerFactory.getLogger(AgentCreator.class);
     public static final String DEFAULT_AGENT = "agent";
     private static final String FEATURE_MEMORY = "memory";
+
+    private static final Object CREATION_LOCK = new Object();
 
     private AgentCreator() {}
 
@@ -162,24 +166,32 @@ public final class AgentCreator {
                 String providerPrefix = getProviderConfigPrefix(modelKind);
                 String prefix = DEFAULT_AGENT.equals(agentName) ? null : agentName;
 
-                List<String> setKeys = new ArrayList<>();
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "api.key", config.apiKey());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "model.name", config.modelName());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "base.url", config.baseUrl());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "temperature", config.temperature());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "max.tokens", config.maxTokens());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "top.p", config.topP());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "top.k", config.topK());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "endpoint", config.endpoint());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "deployment.name", config.deploymentName());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "log.requests", config.logRequests());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "log.responses", config.logResponses());
-                setSystemPropertyIfNotNull(setKeys, prefix, providerPrefix, "timeout", config.timeout());
+                synchronized (CREATION_LOCK) {
+                    Map<String, String> previousValues = new LinkedHashMap<>();
+                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "api.key", config.apiKey());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, providerPrefix, "model.name", config.modelName());
+                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "base.url", config.baseUrl());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, providerPrefix, "temperature", config.temperature());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, providerPrefix, "max.tokens", config.maxTokens());
+                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "top.p", config.topP());
+                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "top.k", config.topK());
+                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "endpoint", config.endpoint());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, providerPrefix, "deployment.name", config.deploymentName());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, providerPrefix, "log.requests", config.logRequests());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, providerPrefix, "log.responses", config.logResponses());
+                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "timeout", config.timeout());
 
-                try {
-                    return modelProvider.create(prefix);
-                } finally {
-                    clearSystemProperties(setKeys);
+                    try {
+                        return modelProvider.create(prefix);
+                    } finally {
+                        restoreSystemProperties(previousValues);
+                    }
                 }
             }
         }
@@ -202,20 +214,44 @@ public final class AgentCreator {
                 String providerPrefix = getProviderConfigPrefix(modelKind);
                 String prefix = DEFAULT_AGENT.equals(agentName) ? null : agentName;
 
-                List<String> setKeys = new ArrayList<>();
-                setSystemPropertyIfNotNull(
-                        setKeys, prefix, providerPrefix, "embedding.model.name", config.embeddingModelName());
-                setSystemPropertyIfNotNull(
-                        setKeys, prefix, providerPrefix, "embedding.model.timeout", config.embeddingModelTimeout());
-                setSystemPropertyIfNotNull(
-                        setKeys, prefix, providerPrefix, "embedding.max.retries", config.embeddingModelMaxRetries());
-                setSystemPropertyIfNotNull(
-                        setKeys, prefix, providerPrefix, "embedding.base.url", config.embeddingModelBaseUrl());
+                synchronized (CREATION_LOCK) {
+                    Map<String, String> previousValues = new LinkedHashMap<>();
+                    setSystemPropertyIfNotNull(
+                            previousValues,
+                            prefix,
+                            providerPrefix,
+                            "embedding.model.api.key",
+                            config.embeddingModelApiKey());
+                    setSystemPropertyIfNotNull(
+                            previousValues,
+                            prefix,
+                            providerPrefix,
+                            "embedding.model.name",
+                            config.embeddingModelName());
+                    setSystemPropertyIfNotNull(
+                            previousValues,
+                            prefix,
+                            providerPrefix,
+                            "embedding.model.timeout",
+                            config.embeddingModelTimeout());
+                    setSystemPropertyIfNotNull(
+                            previousValues,
+                            prefix,
+                            providerPrefix,
+                            "embedding.model.max.retries",
+                            config.embeddingModelMaxRetries());
+                    setSystemPropertyIfNotNull(
+                            previousValues,
+                            prefix,
+                            providerPrefix,
+                            "embedding.model.base.url",
+                            config.embeddingModelBaseUrl());
 
-                try {
-                    return modelProvider.create(prefix);
-                } finally {
-                    clearSystemProperties(setKeys);
+                    try {
+                        return modelProvider.create(prefix);
+                    } finally {
+                        restoreSystemProperties(previousValues);
+                    }
                 }
             }
         }
@@ -234,23 +270,26 @@ public final class AgentCreator {
             LOG.debug("Found embedding store provider for kind '{}': {}", modelKind, providerClass.getName());
             EmbeddingStoreProvider storeProvider = provider.get();
 
-            String providerPrefix = getProviderConfigPrefix(modelKind);
             String prefix = DEFAULT_AGENT.equals(agentName) ? null : agentName;
-
-            List<String> setKeys = new ArrayList<>();
-            setSystemPropertyIfNotNull(setKeys, prefix, "in.memory.store", "file.source", config.fileSource());
-            setSystemPropertyIfNotNull(setKeys, prefix, "in.memory.store", "max.size", config.embeddingStoreMaxSize());
-            setSystemPropertyIfNotNull(
-                    setKeys, prefix, "in.memory.store", "overlap.size", config.embeddingStoreOverlapSize());
 
             if (storeProvider instanceof EmbeddingModelAware modelAware) {
                 modelAware.withEmbeddingModel(model);
             }
 
-            try {
-                return storeProvider.create(prefix);
-            } finally {
-                clearSystemProperties(setKeys);
+            synchronized (CREATION_LOCK) {
+                Map<String, String> previousValues = new LinkedHashMap<>();
+                setSystemPropertyIfNotNull(
+                        previousValues, prefix, "in.memory.store", "file.source", config.fileSource());
+                setSystemPropertyIfNotNull(
+                        previousValues, prefix, "in.memory.store", "max.size", config.embeddingStoreMaxSize());
+                setSystemPropertyIfNotNull(
+                        previousValues, prefix, "in.memory.store", "overlap.size", config.embeddingStoreOverlapSize());
+
+                try {
+                    return storeProvider.create(prefix);
+                } finally {
+                    restoreSystemProperties(previousValues);
+                }
             }
         }
 
@@ -274,12 +313,7 @@ public final class AgentCreator {
             LOG.debug("Found retrieval augmentor provider for kind '{}': {}", modelKind, providerClass.getName());
             RetrievalAugmentorProvider retrievalAugmentorProvider = provider.get();
 
-            String providerPrefix = getProviderConfigPrefix(modelKind);
             String prefix = DEFAULT_AGENT.equals(agentName) ? null : agentName;
-
-            List<String> setKeys = new ArrayList<>();
-            setSystemPropertyIfNotNull(setKeys, prefix, "rag", "max.results", config.defaultRagMaxResults());
-            setSystemPropertyIfNotNull(setKeys, prefix, "rag", "min.score", config.defaultRagMinScore());
 
             if (retrievalAugmentorProvider instanceof EmbeddingModelAware modelAware) {
                 modelAware.withEmbeddingModel(embeddingModel);
@@ -288,10 +322,16 @@ public final class AgentCreator {
                 storeAware.withEmbeddingStore(embeddingStore);
             }
 
-            try {
-                return retrievalAugmentorProvider.create(prefix);
-            } finally {
-                clearSystemProperties(setKeys);
+            synchronized (CREATION_LOCK) {
+                Map<String, String> previousValues = new LinkedHashMap<>();
+                setSystemPropertyIfNotNull(previousValues, prefix, "rag", "max.results", config.defaultRagMaxResults());
+                setSystemPropertyIfNotNull(previousValues, prefix, "rag", "min.score", config.defaultRagMinScore());
+
+                try {
+                    return retrievalAugmentorProvider.create(prefix);
+                } finally {
+                    restoreSystemProperties(previousValues);
+                }
             }
         }
 
@@ -399,21 +439,25 @@ public final class AgentCreator {
     }
 
     static void setSystemPropertyIfNotNull(
-            List<String> setKeys, String prefix, String providerPrefix, String key, Object value) {
+            Map<String, String> previousValues, String prefix, String providerPrefix, String key, Object value) {
         if (value != null) {
             String fullKey = prefix != null
                     ? "forage." + prefix + "." + providerPrefix + "." + key
                     : "forage." + providerPrefix + "." + key;
+            previousValues.put(fullKey, System.getProperty(fullKey));
             System.setProperty(fullKey, String.valueOf(value));
-            setKeys.add(fullKey);
             LOG.trace("Set system property: {}={}", fullKey, value);
         }
     }
 
-    private static void clearSystemProperties(List<String> keys) {
-        for (String key : keys) {
-            System.clearProperty(key);
-            LOG.trace("Cleared system property: {}", key);
+    static void restoreSystemProperties(Map<String, String> previousValues) {
+        for (Map.Entry<String, String> entry : previousValues.entrySet()) {
+            if (entry.getValue() == null) {
+                System.clearProperty(entry.getKey());
+            } else {
+                System.setProperty(entry.getKey(), entry.getValue());
+            }
+            LOG.trace("Restored system property: {}", entry.getKey());
         }
     }
 
@@ -424,9 +468,9 @@ public final class AgentCreator {
             case "openai" -> "openai";
             case "ollama" -> "ollama";
             case "anthropic" -> "anthropic";
-            case "mistral-ai" -> "mistral";
+            case "mistral-ai" -> "mistralai";
             case "hugging-face" -> "huggingface";
-            case "watsonx-ai" -> "watsonx";
+            case "watsonx-ai" -> "watsonxai";
             case "local-ai" -> "localai";
             case "dashscope" -> "dashscope";
             default -> modelKind.replace("-", ".");

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
@@ -39,6 +39,11 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
  * <p>Extracted from {@link AgentBeanFactory} so that both the plain Camel factory,
  * the Quarkus recorder, and the Spring Boot auto-configuration can share the same
  * agent composition logic.
+ *
+ * <p>Note: the {@code forage.agent.*} to {@code forage.<provider>.*} property bridge (see
+ * {@link #getProviderConfigPrefix(String)}) covers common model properties only. Provider-specific
+ * required properties — e.g. {@code forage.watsonxai.url} and {@code forage.watsonxai.project.id}
+ * for watsonx-ai — must still be set directly and cannot be expressed as {@code forage.agent.*}.
  */
 public final class AgentCreator {
 
@@ -168,26 +173,31 @@ public final class AgentCreator {
 
                 synchronized (CREATION_LOCK) {
                     Map<String, String> previousValues = new LinkedHashMap<>();
-                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "api.key", config.apiKey());
-                    setSystemPropertyIfNotNull(
-                            previousValues, prefix, providerPrefix, "model.name", config.modelName());
-                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "base.url", config.baseUrl());
-                    setSystemPropertyIfNotNull(
-                            previousValues, prefix, providerPrefix, "temperature", config.temperature());
-                    setSystemPropertyIfNotNull(
-                            previousValues, prefix, providerPrefix, "max.tokens", config.maxTokens());
-                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "top.p", config.topP());
-                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "top.k", config.topK());
-                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "endpoint", config.endpoint());
-                    setSystemPropertyIfNotNull(
-                            previousValues, prefix, providerPrefix, "deployment.name", config.deploymentName());
-                    setSystemPropertyIfNotNull(
-                            previousValues, prefix, providerPrefix, "log.requests", config.logRequests());
-                    setSystemPropertyIfNotNull(
-                            previousValues, prefix, providerPrefix, "log.responses", config.logResponses());
-                    setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "timeout", config.timeout());
-
+                    // The set calls run inside the try so that the finally block restores any
+                    // already-set properties even when an argument (e.g. a malformed
+                    // forage.agent.temperature) throws mid-sequence.
                     try {
+                        setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "api.key", config.apiKey());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "model.name", config.modelName());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "base.url", config.baseUrl());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "temperature", config.temperature());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "max.tokens", config.maxTokens());
+                        setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "top.p", config.topP());
+                        setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "top.k", config.topK());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "endpoint", config.endpoint());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "deployment.name", config.deploymentName());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "log.requests", config.logRequests());
+                        setSystemPropertyIfNotNull(
+                                previousValues, prefix, providerPrefix, "log.responses", config.logResponses());
+                        setSystemPropertyIfNotNull(previousValues, prefix, providerPrefix, "timeout", config.timeout());
+
                         return modelProvider.create(prefix);
                     } finally {
                         restoreSystemProperties(previousValues);
@@ -216,38 +226,40 @@ public final class AgentCreator {
 
                 synchronized (CREATION_LOCK) {
                     Map<String, String> previousValues = new LinkedHashMap<>();
-                    setSystemPropertyIfNotNull(
-                            previousValues,
-                            prefix,
-                            providerPrefix,
-                            "embedding.model.api.key",
-                            config.embeddingModelApiKey());
-                    setSystemPropertyIfNotNull(
-                            previousValues,
-                            prefix,
-                            providerPrefix,
-                            "embedding.model.name",
-                            config.embeddingModelName());
-                    setSystemPropertyIfNotNull(
-                            previousValues,
-                            prefix,
-                            providerPrefix,
-                            "embedding.model.timeout",
-                            config.embeddingModelTimeout());
-                    setSystemPropertyIfNotNull(
-                            previousValues,
-                            prefix,
-                            providerPrefix,
-                            "embedding.model.max.retries",
-                            config.embeddingModelMaxRetries());
-                    setSystemPropertyIfNotNull(
-                            previousValues,
-                            prefix,
-                            providerPrefix,
-                            "embedding.model.base.url",
-                            config.embeddingModelBaseUrl());
-
+                    // Set calls run inside the try so partially-set properties are always restored
+                    // even when an argument (e.g. a malformed embedding.model.timeout) throws.
                     try {
+                        setSystemPropertyIfNotNull(
+                                previousValues,
+                                prefix,
+                                providerPrefix,
+                                "embedding.model.api.key",
+                                config.embeddingModelApiKey());
+                        setSystemPropertyIfNotNull(
+                                previousValues,
+                                prefix,
+                                providerPrefix,
+                                "embedding.model.name",
+                                config.embeddingModelName());
+                        setSystemPropertyIfNotNull(
+                                previousValues,
+                                prefix,
+                                providerPrefix,
+                                "embedding.model.timeout",
+                                config.embeddingModelTimeout());
+                        setSystemPropertyIfNotNull(
+                                previousValues,
+                                prefix,
+                                providerPrefix,
+                                "embedding.model.max.retries",
+                                config.embeddingModelMaxRetries());
+                        setSystemPropertyIfNotNull(
+                                previousValues,
+                                prefix,
+                                providerPrefix,
+                                "embedding.model.base.url",
+                                config.embeddingModelBaseUrl());
+
                         return modelProvider.create(prefix);
                     } finally {
                         restoreSystemProperties(previousValues);
@@ -278,14 +290,20 @@ public final class AgentCreator {
 
             synchronized (CREATION_LOCK) {
                 Map<String, String> previousValues = new LinkedHashMap<>();
-                setSystemPropertyIfNotNull(
-                        previousValues, prefix, "in.memory.store", "file.source", config.fileSource());
-                setSystemPropertyIfNotNull(
-                        previousValues, prefix, "in.memory.store", "max.size", config.embeddingStoreMaxSize());
-                setSystemPropertyIfNotNull(
-                        previousValues, prefix, "in.memory.store", "overlap.size", config.embeddingStoreOverlapSize());
-
+                // Set calls run inside the try so partially-set properties are always restored
+                // even when an argument (e.g. a malformed max.size) throws.
                 try {
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, "in.memory.store", "file.source", config.fileSource());
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, "in.memory.store", "max.size", config.embeddingStoreMaxSize());
+                    setSystemPropertyIfNotNull(
+                            previousValues,
+                            prefix,
+                            "in.memory.store",
+                            "overlap.size",
+                            config.embeddingStoreOverlapSize());
+
                     return storeProvider.create(prefix);
                 } finally {
                     restoreSystemProperties(previousValues);
@@ -324,10 +342,13 @@ public final class AgentCreator {
 
             synchronized (CREATION_LOCK) {
                 Map<String, String> previousValues = new LinkedHashMap<>();
-                setSystemPropertyIfNotNull(previousValues, prefix, "rag", "max.results", config.defaultRagMaxResults());
-                setSystemPropertyIfNotNull(previousValues, prefix, "rag", "min.score", config.defaultRagMinScore());
-
+                // Set calls run inside the try so partially-set properties are always restored
+                // even when an argument (e.g. a malformed min.score) throws.
                 try {
+                    setSystemPropertyIfNotNull(
+                            previousValues, prefix, "rag", "max.results", config.defaultRagMaxResults());
+                    setSystemPropertyIfNotNull(previousValues, prefix, "rag", "min.score", config.defaultRagMinScore());
+
                     return retrievalAugmentorProvider.create(prefix);
                 } finally {
                     restoreSystemProperties(previousValues);
@@ -461,6 +482,19 @@ public final class AgentCreator {
         }
     }
 
+    /**
+     * Maps a model kind (the value of {@code forage.agent.model.kind}) to the configuration
+     * prefix used by the corresponding provider module's ConfigEntries class, so that
+     * {@code forage.agent.*} properties can be bridged to {@code forage.<prefix>.*} ones.
+     *
+     * <p><strong>Limitation:</strong> only the common properties handled by the bridge sites in
+     * this class are mapped. Provider-specific required properties have no {@code forage.agent.*}
+     * counterpart and must be set directly. Notably, watsonx-ai still requires
+     * {@code forage.watsonxai.url} and {@code forage.watsonxai.project.id} to be configured
+     * directly — they cannot be bridged from {@code forage.agent.*} configuration.
+     *
+     * <p>Package-private (rather than private) for testability.
+     */
     static String getProviderConfigPrefix(String modelKind) {
         return switch (modelKind) {
             case "google-gemini" -> "google";

--- a/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/AgentCreatorTest.java
+++ b/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/AgentCreatorTest.java
@@ -2,12 +2,34 @@ package io.kaoto.forage.agent;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigStore;
+import io.kaoto.forage.models.chat.anthropic.AnthropicConfigEntries;
+import io.kaoto.forage.models.chat.azureopenai.AzureOpenAiConfigEntries;
+import io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries;
+import io.kaoto.forage.models.chat.dashscope.DashscopeConfigEntries;
+import io.kaoto.forage.models.chat.google.GoogleConfigEntries;
+import io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries;
+import io.kaoto.forage.models.chat.localai.LocalAiConfigEntries;
+import io.kaoto.forage.models.chat.mistralai.MistralAiConfigEntries;
+import io.kaoto.forage.models.chat.ollama.OllamaConfigEntries;
+import io.kaoto.forage.models.chat.openai.OpenAIConfigEntries;
+import io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @DisplayName("AgentCreator Tests")
 class AgentCreatorTest {
@@ -25,29 +47,36 @@ class AgentCreatorTest {
     @DisplayName("getProviderConfigPrefix() — drift-prevention")
     class PrefixMappingTests {
 
-        @Test
-        @DisplayName("Every model kind maps to the prefix used by its ConfigEntries class")
-        void everyModelKindMapsToCorrectConfigEntriesPrefix() {
-            // openai → OpenAIConfigEntries: forage.openai.*
-            assertThat(AgentCreator.getProviderConfigPrefix("openai")).isEqualTo("openai");
-            // ollama → OllamaConfigEntries: forage.ollama.*
-            assertThat(AgentCreator.getProviderConfigPrefix("ollama")).isEqualTo("ollama");
-            // google-gemini → GoogleConfigEntries: forage.google.*
-            assertThat(AgentCreator.getProviderConfigPrefix("google-gemini")).isEqualTo("google");
-            // azure-openai → AzureOpenAiConfigEntries: forage.azure.openai.*
-            assertThat(AgentCreator.getProviderConfigPrefix("azure-openai")).isEqualTo("azure.openai");
-            // anthropic → AnthropicConfigEntries: forage.anthropic.*
-            assertThat(AgentCreator.getProviderConfigPrefix("anthropic")).isEqualTo("anthropic");
-            // mistral-ai → MistralAiConfigEntries: forage.mistralai.*
-            assertThat(AgentCreator.getProviderConfigPrefix("mistral-ai")).isEqualTo("mistralai");
-            // hugging-face → HuggingFaceConfigEntries: forage.huggingface.*
-            assertThat(AgentCreator.getProviderConfigPrefix("hugging-face")).isEqualTo("huggingface");
-            // watsonx-ai → WatsonxAiConfigEntries: forage.watsonxai.*
-            assertThat(AgentCreator.getProviderConfigPrefix("watsonx-ai")).isEqualTo("watsonxai");
-            // local-ai → LocalAiConfigEntries: forage.localai.*
-            assertThat(AgentCreator.getProviderConfigPrefix("local-ai")).isEqualTo("localai");
-            // dashscope → DashscopeConfigEntries: forage.dashscope.*
-            assertThat(AgentCreator.getProviderConfigPrefix("dashscope")).isEqualTo("dashscope");
+        /**
+         * Cross-checks each model kind's mapped prefix against the actual configuration keys
+         * registered by the corresponding module's ConfigEntries class, instead of hardcoded
+         * string literals. If a module ever renames its keys (e.g. {@code forage.mistralai.*}
+         * to {@code forage.mistral.ai.*}) this test fails until the switch in
+         * {@code AgentCreator#getProviderConfigPrefix} is updated.
+         */
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("io.kaoto.forage.agent.AgentCreatorTest#modelKindToConfigEntries")
+        @DisplayName("Model kind prefix matches the keys registered by the module's ConfigEntries")
+        void modelKindPrefixMatchesModuleConfigEntries(String modelKind, Class<? extends ConfigEntries> entriesClass)
+                throws ClassNotFoundException {
+            // getModules() does not force static initialization of the subclass on all branches,
+            // so initialize the registry explicitly before reading it
+            Class.forName(entriesClass.getName(), true, entriesClass.getClassLoader());
+
+            String prefix = AgentCreator.getProviderConfigPrefix(modelKind);
+
+            Set<String> propertyNames = ConfigEntries.getModules(entriesClass).keySet().stream()
+                    .map(ConfigModule::propertyName)
+                    .collect(Collectors.toSet());
+            assertThat(propertyNames).isNotEmpty();
+
+            // The bridge writes keys of the form forage.<prefix>.<key>; the module must actually
+            // read at least one of them ("temperature" is defined by every chat model module)
+            assertThat(propertyNames).contains("forage." + prefix + ".temperature");
+
+            // ...and every key registered by the module must live under the same prefix,
+            // so a partial prefix (e.g. "azure" instead of "azure.openai") cannot pass
+            assertThat(propertyNames).allSatisfy(name -> assertThat(name).startsWith("forage." + prefix + "."));
         }
 
         @Test
@@ -56,6 +85,22 @@ class AgentCreatorTest {
             assertThat(AgentCreator.getProviderConfigPrefix("some-new-provider"))
                     .isEqualTo("some.new.provider");
         }
+    }
+
+    static Stream<Arguments> modelKindToConfigEntries() {
+        return Stream.of(
+                arguments("openai", OpenAIConfigEntries.class),
+                arguments("ollama", OllamaConfigEntries.class),
+                arguments("google-gemini", GoogleConfigEntries.class),
+                arguments("azure-openai", AzureOpenAiConfigEntries.class),
+                arguments("anthropic", AnthropicConfigEntries.class),
+                arguments("mistral-ai", MistralAiConfigEntries.class),
+                arguments("hugging-face", HuggingFaceConfigEntries.class),
+                arguments("watsonx-ai", WatsonxAiConfigEntries.class),
+                arguments("local-ai", LocalAiConfigEntries.class),
+                arguments("dashscope", DashscopeConfigEntries.class),
+                // not in the switch: exercises the dash-to-dot fallback against a real module
+                arguments("bedrock", BedrockConfigEntries.class));
     }
 
     @Nested
@@ -121,48 +166,115 @@ class AgentCreatorTest {
     }
 
     @Nested
-    @DisplayName("Embedding bridge key correctness")
-    class EmbeddingBridgeKeyTests {
+    @DisplayName("createChatModel() bridge — real call site")
+    class ChatModelBridgeTests {
 
-        @Test
-        @DisplayName(
-                "Embedding bridge sets forage.ollama.embedding.model.base.url not forage.ollama.embedding.base.url")
-        void embeddingBridgeUsesModelBaseUrlKey() {
-            String correctKey = "forage.ollama.embedding.model.base.url";
-            String wrongKey = "forage.ollama.embedding.base.url";
-            try {
-                Map<String, String> snapshot = new LinkedHashMap<>();
-                AgentCreator.setSystemPropertyIfNotNull(
-                        snapshot, null, "ollama", "embedding.model.base.url", "http://remote:11434");
+        private final ClassLoader classLoader = getClass().getClassLoader();
 
-                assertThat(System.getProperty(correctKey)).isEqualTo("http://remote:11434");
-                assertThat(System.getProperty(wrongKey)).isNull();
-
-                AgentCreator.restoreSystemProperties(snapshot);
-            } finally {
-                System.clearProperty(correctKey);
-                System.clearProperty(wrongKey);
-            }
+        @AfterEach
+        void cleanup() {
+            System.clearProperty("forage.agent.api.key");
+            System.clearProperty("forage.agent.model.name");
+            System.clearProperty("forage.agent.temperature");
+            System.clearProperty(CapturingChatModelProvider.PROPERTY_PREFIX + "api.key");
+            System.clearProperty(CapturingChatModelProvider.PROPERTY_PREFIX + "model.name");
+            CapturingChatModelProvider.reset();
+            ConfigStore.getInstance().reload();
         }
 
         @Test
-        @DisplayName(
-                "Embedding bridge sets forage.ollama.embedding.model.max.retries not forage.ollama.embedding.max.retries")
-        void embeddingBridgeUsesModelMaxRetriesKey() {
-            String correctKey = "forage.ollama.embedding.model.max.retries";
-            String wrongKey = "forage.ollama.embedding.max.retries";
-            try {
-                Map<String, String> snapshot = new LinkedHashMap<>();
-                AgentCreator.setSystemPropertyIfNotNull(snapshot, null, "ollama", "embedding.model.max.retries", 3);
+        @DisplayName("forage.agent.* properties are bridged to the provider's keys during create()")
+        void bridgesAgentPropertiesToProviderKeys() {
+            System.setProperty("forage.agent.api.key", "bridged-key");
+            System.setProperty("forage.agent.model.name", "bridged-model");
+            ConfigStore.getInstance().reload();
+            AgentConfig config = new AgentConfig();
+            CapturingChatModelProvider.reset();
 
-                assertThat(System.getProperty(correctKey)).isEqualTo("3");
-                assertThat(System.getProperty(wrongKey)).isNull();
+            AgentCreator.createChatModel(
+                    config, CapturingChatModelProvider.KIND, AgentCreator.DEFAULT_AGENT, classLoader);
 
-                AgentCreator.restoreSystemProperties(snapshot);
-            } finally {
-                System.clearProperty(correctKey);
-                System.clearProperty(wrongKey);
-            }
+            Map<String, String> seen = CapturingChatModelProvider.captured();
+            assertThat(seen)
+                    .containsEntry("forage.test.chat.api.key", "bridged-key")
+                    .containsEntry("forage.test.chat.model.name", "bridged-model");
+
+            // bridged properties are restored (cleared) once creation completes
+            assertThat(System.getProperty("forage.test.chat.api.key")).isNull();
+            assertThat(System.getProperty("forage.test.chat.model.name")).isNull();
+        }
+
+        @Test
+        @DisplayName("A malformed config value does not leak already-bridged system properties")
+        void malformedConfigValueDoesNotLeakBridgedProperties() {
+            // simulate a user-supplied -D value that must survive the failed bridge
+            System.setProperty("forage.test.chat.api.key", "user-supplied");
+            System.setProperty("forage.agent.api.key", "bridged-key");
+            System.setProperty("forage.agent.temperature", "not-a-number");
+            ConfigStore.getInstance().reload();
+            AgentConfig config = new AgentConfig();
+
+            // api.key is bridged before temperature is evaluated; parsing "not-a-number" throws
+            assertThatThrownBy(() -> AgentCreator.createChatModel(
+                            config, CapturingChatModelProvider.KIND, AgentCreator.DEFAULT_AGENT, classLoader))
+                    .isInstanceOf(NumberFormatException.class);
+
+            // the pre-existing user value must be restored, not clobbered by "bridged-key"
+            assertThat(System.getProperty("forage.test.chat.api.key")).isEqualTo("user-supplied");
+            assertThat(System.getProperty("forage.test.chat.model.name")).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("createEmbeddingModel() bridge — real call site")
+    class EmbeddingBridgeTests {
+
+        private final ClassLoader classLoader = getClass().getClassLoader();
+
+        @AfterEach
+        void cleanup() {
+            System.clearProperty("forage.agent.embedding.model.base.url");
+            System.clearProperty("forage.agent.embedding.model.name");
+            System.clearProperty("forage.agent.embedding.model.max.retries");
+            System.clearProperty("forage.agent.embedding.model.timeout");
+            CapturingEmbeddingModelProvider.reset();
+            ConfigStore.getInstance().reload();
+        }
+
+        @Test
+        @DisplayName("Embedding bridge sets embedding.model.* keys, not the shorter embedding.* keys")
+        void embeddingBridgePassesModelKeysToProvider() {
+            System.setProperty("forage.agent.embedding.model.base.url", "http://captured:1234");
+            System.setProperty("forage.agent.embedding.model.name", "bridged-embed-model");
+            System.setProperty("forage.agent.embedding.model.max.retries", "7");
+            System.setProperty("forage.agent.embedding.model.timeout", "PT30S");
+            ConfigStore.getInstance().reload();
+            AgentConfig config = new AgentConfig();
+            CapturingEmbeddingModelProvider.reset();
+
+            AgentCreator.createEmbeddingModel(
+                    config, CapturingEmbeddingModelProvider.KIND, AgentCreator.DEFAULT_AGENT, classLoader);
+
+            Map<String, String> seen = CapturingEmbeddingModelProvider.captured();
+            // the provider must observe the bridged embedding.model.* keys at creation time
+            assertThat(seen)
+                    .containsEntry("forage.test.embed.embedding.model.base.url", "http://captured:1234")
+                    .containsEntry("forage.test.embed.embedding.model.name", "bridged-embed-model")
+                    .containsEntry("forage.test.embed.embedding.model.max.retries", "7")
+                    .containsEntry("forage.test.embed.embedding.model.timeout", "PT30S");
+
+            // regression guard: the historically wrong (shorter) keys must NOT be set
+            assertThat(seen)
+                    .doesNotContainKey("forage.test.embed.embedding.base.url")
+                    .doesNotContainKey("forage.test.embed.embedding.name")
+                    .doesNotContainKey("forage.test.embed.embedding.max.retries")
+                    .doesNotContainKey("forage.test.embed.embedding.timeout");
+
+            // bridged properties are restored (cleared) once creation completes
+            assertThat(System.getProperty("forage.test.embed.embedding.model.base.url"))
+                    .isNull();
+            assertThat(System.getProperty("forage.test.embed.embedding.model.name"))
+                    .isNull();
         }
     }
 }

--- a/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/AgentCreatorTest.java
+++ b/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/AgentCreatorTest.java
@@ -1,0 +1,168 @@
+package io.kaoto.forage.agent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AgentCreator Tests")
+class AgentCreatorTest {
+
+    private static final String TEST_PROVIDER = "test.provider";
+    private static final String TEST_KEY = "test.key";
+    private static final String FULL_KEY = "forage." + TEST_PROVIDER + "." + TEST_KEY;
+
+    @AfterEach
+    void clearTestProperty() {
+        System.clearProperty(FULL_KEY);
+    }
+
+    @Nested
+    @DisplayName("getProviderConfigPrefix() — drift-prevention")
+    class PrefixMappingTests {
+
+        @Test
+        @DisplayName("Every model kind maps to the prefix used by its ConfigEntries class")
+        void everyModelKindMapsToCorrectConfigEntriesPrefix() {
+            // openai → OpenAIConfigEntries: forage.openai.*
+            assertThat(AgentCreator.getProviderConfigPrefix("openai")).isEqualTo("openai");
+            // ollama → OllamaConfigEntries: forage.ollama.*
+            assertThat(AgentCreator.getProviderConfigPrefix("ollama")).isEqualTo("ollama");
+            // google-gemini → GoogleConfigEntries: forage.google.*
+            assertThat(AgentCreator.getProviderConfigPrefix("google-gemini")).isEqualTo("google");
+            // azure-openai → AzureOpenAiConfigEntries: forage.azure.openai.*
+            assertThat(AgentCreator.getProviderConfigPrefix("azure-openai")).isEqualTo("azure.openai");
+            // anthropic → AnthropicConfigEntries: forage.anthropic.*
+            assertThat(AgentCreator.getProviderConfigPrefix("anthropic")).isEqualTo("anthropic");
+            // mistral-ai → MistralAiConfigEntries: forage.mistralai.*
+            assertThat(AgentCreator.getProviderConfigPrefix("mistral-ai")).isEqualTo("mistralai");
+            // hugging-face → HuggingFaceConfigEntries: forage.huggingface.*
+            assertThat(AgentCreator.getProviderConfigPrefix("hugging-face")).isEqualTo("huggingface");
+            // watsonx-ai → WatsonxAiConfigEntries: forage.watsonxai.*
+            assertThat(AgentCreator.getProviderConfigPrefix("watsonx-ai")).isEqualTo("watsonxai");
+            // local-ai → LocalAiConfigEntries: forage.localai.*
+            assertThat(AgentCreator.getProviderConfigPrefix("local-ai")).isEqualTo("localai");
+            // dashscope → DashscopeConfigEntries: forage.dashscope.*
+            assertThat(AgentCreator.getProviderConfigPrefix("dashscope")).isEqualTo("dashscope");
+        }
+
+        @Test
+        @DisplayName("Unknown model kinds fall back to dash-to-dot conversion")
+        void unknownModelKindFallsBackToDashDotConversion() {
+            assertThat(AgentCreator.getProviderConfigPrefix("some-new-provider"))
+                    .isEqualTo("some.new.provider");
+        }
+    }
+
+    @Nested
+    @DisplayName("setSystemPropertyIfNotNull() + restoreSystemProperties()")
+    class SnapshotRestoreTests {
+
+        @Test
+        @DisplayName("Previous property value is restored after set")
+        void previousPropertyValueRestoredAfterSet() {
+            System.setProperty(FULL_KEY, "original-value");
+
+            Map<String, String> snapshot = new LinkedHashMap<>();
+            AgentCreator.setSystemPropertyIfNotNull(snapshot, null, TEST_PROVIDER, TEST_KEY, "overridden-value");
+
+            assertThat(System.getProperty(FULL_KEY)).isEqualTo("overridden-value");
+
+            AgentCreator.restoreSystemProperties(snapshot);
+
+            assertThat(System.getProperty(FULL_KEY)).isEqualTo("original-value");
+        }
+
+        @Test
+        @DisplayName("Property is cleared when it was not previously set")
+        void propertyIsClearedWhenNotPreviouslySet() {
+            assertThat(System.getProperty(FULL_KEY)).isNull();
+
+            Map<String, String> snapshot = new LinkedHashMap<>();
+            AgentCreator.setSystemPropertyIfNotNull(snapshot, null, TEST_PROVIDER, TEST_KEY, "new-value");
+
+            assertThat(System.getProperty(FULL_KEY)).isEqualTo("new-value");
+
+            AgentCreator.restoreSystemProperties(snapshot);
+
+            assertThat(System.getProperty(FULL_KEY)).isNull();
+        }
+
+        @Test
+        @DisplayName("Null value does not set property and snapshot stays empty")
+        void nullValueDoesNotSetProperty() {
+            Map<String, String> snapshot = new LinkedHashMap<>();
+            AgentCreator.setSystemPropertyIfNotNull(snapshot, null, TEST_PROVIDER, TEST_KEY, null);
+
+            assertThat(System.getProperty(FULL_KEY)).isNull();
+            assertThat(snapshot).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Prefixed key is built correctly")
+        void prefixedKeyIsBuiltCorrectly() {
+            String prefixedKey = "forage.myagent." + TEST_PROVIDER + "." + TEST_KEY;
+            try {
+                Map<String, String> snapshot = new LinkedHashMap<>();
+                AgentCreator.setSystemPropertyIfNotNull(snapshot, "myagent", TEST_PROVIDER, TEST_KEY, "val");
+
+                assertThat(System.getProperty(prefixedKey)).isEqualTo("val");
+
+                AgentCreator.restoreSystemProperties(snapshot);
+                assertThat(System.getProperty(prefixedKey)).isNull();
+            } finally {
+                System.clearProperty(prefixedKey);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Embedding bridge key correctness")
+    class EmbeddingBridgeKeyTests {
+
+        @Test
+        @DisplayName(
+                "Embedding bridge sets forage.ollama.embedding.model.base.url not forage.ollama.embedding.base.url")
+        void embeddingBridgeUsesModelBaseUrlKey() {
+            String correctKey = "forage.ollama.embedding.model.base.url";
+            String wrongKey = "forage.ollama.embedding.base.url";
+            try {
+                Map<String, String> snapshot = new LinkedHashMap<>();
+                AgentCreator.setSystemPropertyIfNotNull(
+                        snapshot, null, "ollama", "embedding.model.base.url", "http://remote:11434");
+
+                assertThat(System.getProperty(correctKey)).isEqualTo("http://remote:11434");
+                assertThat(System.getProperty(wrongKey)).isNull();
+
+                AgentCreator.restoreSystemProperties(snapshot);
+            } finally {
+                System.clearProperty(correctKey);
+                System.clearProperty(wrongKey);
+            }
+        }
+
+        @Test
+        @DisplayName(
+                "Embedding bridge sets forage.ollama.embedding.model.max.retries not forage.ollama.embedding.max.retries")
+        void embeddingBridgeUsesModelMaxRetriesKey() {
+            String correctKey = "forage.ollama.embedding.model.max.retries";
+            String wrongKey = "forage.ollama.embedding.max.retries";
+            try {
+                Map<String, String> snapshot = new LinkedHashMap<>();
+                AgentCreator.setSystemPropertyIfNotNull(snapshot, null, "ollama", "embedding.model.max.retries", 3);
+
+                assertThat(System.getProperty(correctKey)).isEqualTo("3");
+                assertThat(System.getProperty(wrongKey)).isNull();
+
+                AgentCreator.restoreSystemProperties(snapshot);
+            } finally {
+                System.clearProperty(correctKey);
+                System.clearProperty(wrongKey);
+            }
+        }
+    }
+}

--- a/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/CapturingChatModelProvider.java
+++ b/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/CapturingChatModelProvider.java
@@ -1,0 +1,47 @@
+package io.kaoto.forage.agent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import io.kaoto.forage.core.ai.ModelProvider;
+import io.kaoto.forage.core.annotations.ForageBean;
+import dev.langchain4j.model.chat.ChatModel;
+
+/**
+ * Test-only {@link ModelProvider} registered via {@code META-INF/services} so that
+ * {@code AgentCreatorTest} can exercise the real {@code AgentCreator#createChatModel} bridge:
+ * at creation time it captures every {@code forage.test.chat.*} system property (the keys the
+ * bridge is expected to set for the {@code test-chat} kind) into a static holder.
+ */
+@ForageBean(value = CapturingChatModelProvider.KIND, description = "Test-only capturing chat model provider")
+public class CapturingChatModelProvider implements ModelProvider {
+
+    public static final String KIND = "test-chat";
+    public static final String PROPERTY_PREFIX = "forage.test.chat.";
+
+    private static final Map<String, String> CAPTURED = new LinkedHashMap<>();
+    private static String capturedId;
+
+    @Override
+    public ChatModel create(String id) {
+        capturedId = id;
+        CAPTURED.clear();
+        System.getProperties().stringPropertyNames().stream()
+                .filter(name -> name.startsWith(PROPERTY_PREFIX))
+                .forEach(name -> CAPTURED.put(name, System.getProperty(name)));
+        // No real model is needed: tests only assert on the captured properties
+        return null;
+    }
+
+    public static Map<String, String> captured() {
+        return new LinkedHashMap<>(CAPTURED);
+    }
+
+    public static String capturedId() {
+        return capturedId;
+    }
+
+    public static void reset() {
+        CAPTURED.clear();
+        capturedId = null;
+    }
+}

--- a/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/CapturingEmbeddingModelProvider.java
+++ b/library/ai/agents/forage-agent/src/test/java/io/kaoto/forage/agent/CapturingEmbeddingModelProvider.java
@@ -1,0 +1,47 @@
+package io.kaoto.forage.agent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import io.kaoto.forage.core.ai.EmbeddingModelProvider;
+import io.kaoto.forage.core.annotations.ForageBean;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+
+/**
+ * Test-only {@link EmbeddingModelProvider} registered via {@code META-INF/services} so that
+ * {@code AgentCreatorTest} can exercise the real {@code AgentCreator#createEmbeddingModel} bridge:
+ * at creation time it captures every {@code forage.test.embed.*} system property (the keys the
+ * bridge is expected to set for the {@code test-embed} kind) into a static holder.
+ */
+@ForageBean(value = CapturingEmbeddingModelProvider.KIND, description = "Test-only capturing embedding model provider")
+public class CapturingEmbeddingModelProvider implements EmbeddingModelProvider {
+
+    public static final String KIND = "test-embed";
+    public static final String PROPERTY_PREFIX = "forage.test.embed.";
+
+    private static final Map<String, String> CAPTURED = new LinkedHashMap<>();
+    private static String capturedId;
+
+    @Override
+    public EmbeddingModel create(String id) {
+        capturedId = id;
+        CAPTURED.clear();
+        System.getProperties().stringPropertyNames().stream()
+                .filter(name -> name.startsWith(PROPERTY_PREFIX))
+                .forEach(name -> CAPTURED.put(name, System.getProperty(name)));
+        // No real model is needed: tests only assert on the captured properties
+        return null;
+    }
+
+    public static Map<String, String> captured() {
+        return new LinkedHashMap<>(CAPTURED);
+    }
+
+    public static String capturedId() {
+        return capturedId;
+    }
+
+    public static void reset() {
+        CAPTURED.clear();
+        capturedId = null;
+    }
+}

--- a/library/ai/agents/forage-agent/src/test/resources/META-INF/services/io.kaoto.forage.core.ai.EmbeddingModelProvider
+++ b/library/ai/agents/forage-agent/src/test/resources/META-INF/services/io.kaoto.forage.core.ai.EmbeddingModelProvider
@@ -1,0 +1,1 @@
+io.kaoto.forage.agent.CapturingEmbeddingModelProvider

--- a/library/ai/agents/forage-agent/src/test/resources/META-INF/services/io.kaoto.forage.core.ai.ModelProvider
+++ b/library/ai/agents/forage-agent/src/test/resources/META-INF/services/io.kaoto.forage.core.ai.ModelProvider
@@ -1,0 +1,1 @@
+io.kaoto.forage.agent.CapturingChatModelProvider


### PR DESCRIPTION
## Summary

Main-branch counterpart of #416 (which targets `camel-latest`). Cherry-picked cleanly; `forage-agent` tests re-run on this branch.

Fixes from #405 (see #416 for details):
- `mistral-ai` → `forage.mistralai.*` and `watsonx-ai` → `forage.watsonxai.*` prefix mappings corrected, with a drift-prevention test that cross-checks every `getProviderConfigPrefix()` mapping against the actual module `ConfigEntries` keys
- Embedding bridge writes `embedding.model.base.url` / `embedding.model.max.retries` (the keys the Ollama embedding module actually reads), verified by a propagation test using a capturing test provider
- System properties are snapshotted and restored (exception-safe, serialized under a creation lock) instead of cleared — user `-D` values survive agent creation
- Dedicated `forage.agent.embedding.model.api.key` / `forage.agent.embedding.model.base.url` ConfigModules with fallback to the chat values

Fixes #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
