### PR TITLE
Fix #406 (security subset): disable AI request/response logging by default, mask Weaviate API key

### DIFF
--- a/library/ai/models/chat/forage-model-azure-openai/pom.xml
+++ b/library/ai/models/chat/forage-model-azure-openai/pom.xml
@@ -31,6 +31,17 @@
             <artifactId>langchain4j-azure-open-ai</artifactId>
             <version>${langchain4j.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/library/ai/models/chat/forage-model-azure-openai/src/main/java/io/kaoto/forage/models/chat/azureopenai/AzureOpenAiProvider.java
+++ b/library/ai/models/chat/forage-model-azure-openai/src/main/java/io/kaoto/forage/models/chat/azureopenai/AzureOpenAiProvider.java
@@ -70,10 +70,20 @@ public class AzureOpenAiProvider implements ModelProvider {
             builder.maxRetries(config.maxRetries());
         }
 
-        // Configure logging settings
-        boolean logRequestsAndResponses = config.logRequestsAndResponses() == null || config.logRequestsAndResponses();
-        builder.logRequestsAndResponses(logRequestsAndResponses);
+        // Configure logging settings (disabled by default to avoid leaking sensitive data)
+        builder.logRequestsAndResponses(resolveLogRequestsAndResponses(config.logRequestsAndResponses()));
 
         return builder.build();
+    }
+
+    /**
+     * Resolves the effective request/response logging flag. Logging is disabled unless
+     * explicitly enabled, since it may expose sensitive data (prompts, completions, PII).
+     *
+     * @param configured the configured value, or null if not configured
+     * @return true only if logging was explicitly enabled
+     */
+    static boolean resolveLogRequestsAndResponses(Boolean configured) {
+        return Boolean.TRUE.equals(configured);
     }
 }

--- a/library/ai/models/chat/forage-model-azure-openai/src/test/java/io/kaoto/forage/models/chat/azureopenai/AzureOpenAiConfigTest.java
+++ b/library/ai/models/chat/forage-model-azure-openai/src/test/java/io/kaoto/forage/models/chat/azureopenai/AzureOpenAiConfigTest.java
@@ -1,0 +1,85 @@
+package io.kaoto.forage.models.chat.azureopenai;
+
+import io.kaoto.forage.core.util.config.ConfigStore;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for Azure OpenAI request/response logging configuration.
+ *
+ * <p>Logging must be disabled by default: when the configuration is unset, no
+ * request/response data (prompts, completions, potentially PII) may be logged.
+ */
+@DisplayName("AzureOpenAiConfig Logging Configuration Tests")
+class AzureOpenAiConfigTest {
+
+    private static final String LOG_PROPERTY = "forage.azure.openai.log.requests.and.responses";
+
+    @BeforeEach
+    void resetConfigStore() {
+        // The ConfigStore is a JVM-wide singleton that retains previously resolved
+        // values; clear it so each test observes a fresh configuration state.
+        ConfigStore.getInstance().reload();
+    }
+
+    @AfterEach
+    void clearSystemProperties() {
+        System.clearProperty(LOG_PROPERTY);
+        ConfigStore.getInstance().reload();
+    }
+
+    @Test
+    @DisplayName("Should return null when logging configuration is unset")
+    void shouldReturnNullWhenLoggingConfigurationIsUnset() {
+        AzureOpenAiConfig config = new AzureOpenAiConfig();
+
+        assertThat(config.logRequestsAndResponses()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should resolve unset logging configuration to disabled")
+    void shouldResolveUnsetLoggingConfigurationToDisabled() {
+        AzureOpenAiConfig config = new AzureOpenAiConfig();
+
+        assertThat(AzureOpenAiProvider.resolveLogRequestsAndResponses(config.logRequestsAndResponses()))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("Should resolve logging flag defensively")
+    void shouldResolveLoggingFlagDefensively() {
+        assertThat(AzureOpenAiProvider.resolveLogRequestsAndResponses(null)).isFalse();
+        assertThat(AzureOpenAiProvider.resolveLogRequestsAndResponses(Boolean.FALSE))
+                .isFalse();
+        assertThat(AzureOpenAiProvider.resolveLogRequestsAndResponses(Boolean.TRUE))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Should enable logging only when explicitly configured")
+    void shouldEnableLoggingOnlyWhenExplicitlyConfigured() {
+        System.setProperty(LOG_PROPERTY, "true");
+
+        AzureOpenAiConfig config = new AzureOpenAiConfig();
+
+        assertThat(config.logRequestsAndResponses()).isTrue();
+        assertThat(AzureOpenAiProvider.resolveLogRequestsAndResponses(config.logRequestsAndResponses()))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Should keep logging disabled when explicitly disabled")
+    void shouldKeepLoggingDisabledWhenExplicitlyDisabled() {
+        System.setProperty(LOG_PROPERTY, "false");
+
+        AzureOpenAiConfig config = new AzureOpenAiConfig();
+
+        assertThat(config.logRequestsAndResponses()).isFalse();
+        assertThat(AzureOpenAiProvider.resolveLogRequestsAndResponses(config.logRequestsAndResponses()))
+                .isFalse();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-chroma/src/main/java/io/kaoto/forage/vectordb/chroma/ChromaConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/src/main/java/io/kaoto/forage/vectordb/chroma/ChromaConfig.java
@@ -171,15 +171,15 @@ public class ChromaConfig extends AbstractConfig {
      *   <li>CHROMA_LOG_REQUESTS environment variable</li>
      *   <li>chroma.log.requests system property</li>
      *   <li>log-requests property in forage-vectordb-chroma.properties</li>
-     *   <li>default value is true</li>
+     *   <li>default value is false</li>
      * </ol>
      *
      * <p><strong>Valid Values:</strong> "true" or "false" (case-insensitive)
      *
-     * @return true if request logging is enabled, false if disabled, null if not configured
+     * @return true if request logging is enabled, false if disabled or not configured
      */
     public Boolean logRequests() {
-        return get(LOG_REQUESTS).map(Boolean::parseBoolean).orElse(true);
+        return get(LOG_REQUESTS).map(Boolean::parseBoolean).orElse(false);
     }
 
     /**
@@ -194,14 +194,14 @@ public class ChromaConfig extends AbstractConfig {
      *   <li>CHROMA_LOG_RESPONSES environment variable</li>
      *   <li>chroma.log.responses system property</li>
      *   <li>log-responses property in forage-vectordb-chroma.properties</li>
-     *   <li>default value is true</li>
+     *   <li>default value is false</li>
      * </ol>
      *
      * <p><strong>Valid Values:</strong> "true" or "false" (case-insensitive)
      *
-     * @return true if response logging is enabled, false if disabled, null if not configured
+     * @return true if response logging is enabled, false if disabled or not configured
      */
     public Boolean logResponses() {
-        return get(LOG_RESPONSES).map(Boolean::parseBoolean).orElse(true);
+        return get(LOG_RESPONSES).map(Boolean::parseBoolean).orElse(false);
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-chroma/src/main/java/io/kaoto/forage/vectordb/chroma/ChromaConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/src/main/java/io/kaoto/forage/vectordb/chroma/ChromaConfigEntries.java
@@ -37,7 +37,7 @@ public final class ChromaConfigEntries extends ConfigEntries {
             "forage.chroma.log.requests",
             "Enable request logging",
             "Log Requests",
-            "true",
+            "false",
             "boolean",
             false,
             ConfigTag.ADVANCED);
@@ -46,7 +46,7 @@ public final class ChromaConfigEntries extends ConfigEntries {
             "forage.chroma.log.responses",
             "Enable response logging",
             "Log Responses",
-            "true",
+            "false",
             "boolean",
             false,
             ConfigTag.ADVANCED);

--- a/library/ai/vector-dbs/forage-vectordb-chroma/src/test/java/io/kaoto/forage/vectordb/chroma/ChromaConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/src/test/java/io/kaoto/forage/vectordb/chroma/ChromaConfigTest.java
@@ -1,0 +1,69 @@
+package io.kaoto.forage.vectordb.chroma;
+
+import io.kaoto.forage.core.util.config.ConfigStore;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for Chroma request/response logging configuration.
+ *
+ * <p>Logging must be disabled by default: when the configuration is unset, no
+ * request/response data may be logged.
+ */
+@DisplayName("ChromaConfig Logging Configuration Tests")
+class ChromaConfigTest {
+
+    private static final String LOG_REQUESTS_PROPERTY = "forage.chroma.log.requests";
+    private static final String LOG_RESPONSES_PROPERTY = "forage.chroma.log.responses";
+
+    @BeforeEach
+    void resetConfigStore() {
+        // The ConfigStore is a JVM-wide singleton that retains previously resolved
+        // values; clear it so each test observes a fresh configuration state.
+        ConfigStore.getInstance().reload();
+    }
+
+    @AfterEach
+    void clearSystemProperties() {
+        System.clearProperty(LOG_REQUESTS_PROPERTY);
+        System.clearProperty(LOG_RESPONSES_PROPERTY);
+        ConfigStore.getInstance().reload();
+    }
+
+    @Test
+    @DisplayName("Should disable request and response logging by default")
+    void shouldDisableRequestAndResponseLoggingByDefault() {
+        ChromaConfig config = new ChromaConfig();
+
+        assertThat(config.logRequests()).isFalse();
+        assertThat(config.logResponses()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should enable logging only when explicitly configured")
+    void shouldEnableLoggingOnlyWhenExplicitlyConfigured() {
+        System.setProperty(LOG_REQUESTS_PROPERTY, "true");
+        System.setProperty(LOG_RESPONSES_PROPERTY, "true");
+
+        ChromaConfig config = new ChromaConfig();
+
+        assertThat(config.logRequests()).isTrue();
+        assertThat(config.logResponses()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should keep logging disabled when explicitly disabled")
+    void shouldKeepLoggingDisabledWhenExplicitlyDisabled() {
+        System.setProperty(LOG_REQUESTS_PROPERTY, "false");
+        System.setProperty(LOG_RESPONSES_PROPERTY, "false");
+
+        ChromaConfig config = new ChromaConfig();
+
+        assertThat(config.logRequests()).isFalse();
+        assertThat(config.logResponses()).isFalse();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-chroma/test-configuration/forage-vectordb-chroma.properties
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/test-configuration/forage-vectordb-chroma.properties
@@ -9,6 +9,6 @@ forage.chroma.collection.name=test_collection_from_file
 # Request timeout in seconds (default: 5)
 forage.chroma.timeout=30
 
-# Logging configuration (default: true for both)
+# Logging configuration (default: false for both)
 forage.chroma.log.requests=false
 forage.chroma.log.responses=false

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfig.java
@@ -96,7 +96,7 @@ public class WeaviateConfig extends AbstractConfig {
     public String toString() {
         return "apiKey: %s, scheme %s, host %s, port %s, useGrpcForInserts %s, securedGrpc %s, objectClass %s, avoidDups %s, consistencyLevel %s"
                 .formatted(
-                        apiKey(),
+                        apiKey() != null ? "***" : null,
                         scheme(),
                         host(),
                         port().toString(),

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/test/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/test/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfigTest.java
@@ -1,0 +1,70 @@
+package io.kaoto.forage.vectordb.weaviate;
+
+import io.kaoto.forage.core.util.config.ConfigStore;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for WeaviateConfig, focusing on ensuring sensitive values such as the
+ * API key are never exposed through {@link WeaviateConfig#toString()}.
+ */
+@DisplayName("WeaviateConfig Tests")
+class WeaviateConfigTest {
+
+    private static final String API_KEY_PROPERTY = "forage.weaviate.api.key";
+    private static final String SECRET_API_KEY = "super-secret-api-key-value";
+
+    @BeforeEach
+    void setUpRequiredProperties() {
+        // The ConfigStore is a JVM-wide singleton that retains previously resolved
+        // values; clear it so each test observes a fresh configuration state.
+        ConfigStore.getInstance().reload();
+
+        System.setProperty("forage.weaviate.scheme", "http");
+        System.setProperty("forage.weaviate.host", "localhost");
+        System.setProperty("forage.weaviate.port", "8080");
+        System.setProperty("forage.weaviate.use.grpc.for.inserts", "false");
+        System.setProperty("forage.weaviate.secured.grpc", "false");
+        System.setProperty("forage.weaviate.object.class", "TestVectors");
+    }
+
+    @AfterEach
+    void clearSystemProperties() {
+        System.clearProperty(API_KEY_PROPERTY);
+        System.clearProperty("forage.weaviate.scheme");
+        System.clearProperty("forage.weaviate.host");
+        System.clearProperty("forage.weaviate.port");
+        System.clearProperty("forage.weaviate.use.grpc.for.inserts");
+        System.clearProperty("forage.weaviate.secured.grpc");
+        System.clearProperty("forage.weaviate.object.class");
+        ConfigStore.getInstance().reload();
+    }
+
+    @Test
+    @DisplayName("Should mask the API key in toString")
+    void shouldMaskApiKeyInToString() {
+        System.setProperty(API_KEY_PROPERTY, SECRET_API_KEY);
+
+        WeaviateConfig config = new WeaviateConfig();
+
+        assertThat(config.apiKey()).isEqualTo(SECRET_API_KEY);
+        assertThat(config.toString())
+                .doesNotContain(SECRET_API_KEY)
+                .contains("apiKey: ***")
+                .contains("host localhost")
+                .contains("objectClass TestVectors");
+    }
+
+    @Test
+    @DisplayName("Should print null for an unset API key in toString")
+    void shouldPrintNullForUnsetApiKeyInToString() {
+        WeaviateConfig config = new WeaviateConfig();
+
+        assertThat(config.apiKey()).isNull();
+        assertThat(config.toString()).contains("apiKey: null");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the security-relevant subset of #406:

- **Azure OpenAI**: request/response logging is now OFF when `forage.azure.openai.log.requests.and.responses` is unset — the previous inverted null-check turned full prompt/completion logging on by default (PII into production logs)
- **Chroma**: `logRequests`/`logResponses` default changed from `true` to `false` (config metadata and javadoc updated to match)
- **Weaviate**: `WeaviateConfig.toString()` masks the API key (`***`) instead of printing the raw secret

Unit tests added in all three modules (unset ⇒ logging off; toString never contains the key).

The remaining #406 findings (InMemoryStore null-safety/description, Pinecone index creation, HuggingFace/Watsonx dead options, stale default model names, Milvus/Weaviate cleanups) are left for a follow-up PR.

Part of #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
