### PR TITLE
Work around CAMEL-24002: silent camel cmd send failures in integration tests — send by Running PID

### DIFF
--- a/integration-tests/common/pom.xml
+++ b/integration-tests/common/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>citrus-camel</artifactId>
             <version>${citrus.version}</version>
         </dependency>
+        <!-- provided-scope inside citrus-camel, needed at compile time by ForageCmdSendAction -->
+        <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-jbang-connector</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.citrusframework</groupId>
             <artifactId>citrus-junit5</artifactId>

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageCmdSendAction.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageCmdSendAction.java
@@ -1,0 +1,141 @@
+package io.kaoto.forage.integration.tests;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.citrusframework.AbstractTestActionBuilder;
+import org.citrusframework.actions.AbstractTestAction;
+import org.citrusframework.camel.jbang.CamelJBang;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.ProcessAndOutput;
+import org.citrusframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sends a message to a running Camel integration via {@code camel cmd send}, addressing the
+ * integration by the PID of its {@code Running} process instead of by name.
+ *
+ * <p>Workaround for Camel JBang 4.20: with exported runtimes (spring-boot, quarkus) the launcher
+ * process leaves a {@code Terminated} status entry under the same integration name, and
+ * {@code camel cmd send <name>} fails with "matches 2 running Camel integrations" while still
+ * exiting 0 — so the Citrus {@code CamelCmdSendAction} reports success although nothing was sent.
+ *
+ * <p>This action:
+ * <ul>
+ *   <li>waits until exactly the integration's {@code Running} process (ready 1/1) is visible,
+ *       which also protects against sending before an exported runtime finished starting;</li>
+ *   <li>sends by PID, so leftover {@code Terminated} entries cannot make the name ambiguous;</li>
+ *   <li>validates the command output and fails loudly on {@code Send timeout} or any output
+ *       without the {@code Sent} success marker, instead of trusting the exit code.</li>
+ * </ul>
+ */
+public class ForageCmdSendAction extends AbstractTestAction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForageCmdSendAction.class);
+
+    private static final long READY_TIMEOUT_MILLIS = 60_000;
+    private static final long READY_POLL_MILLIS = 1_000;
+
+    private final String integrationName;
+    private final String endpoint;
+    private final String body;
+    private final Map<String, String> headers;
+
+    private ForageCmdSendAction(Builder builder) {
+        super("forage-cmd-send", builder);
+        this.integrationName = builder.integrationName;
+        this.endpoint = builder.endpoint;
+        this.body = builder.body;
+        this.headers = builder.headers;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String name = context.replaceDynamicContentInString(integrationName);
+        long pid = waitForRunningPid(name);
+
+        List<String> args = new ArrayList<>();
+        args.add(String.valueOf(pid));
+        args.add("--endpoint=" + context.replaceDynamicContentInString(endpoint));
+        // JBangSupport re-splits arguments on whitespace, so values with spaces must be quoted
+        args.add("--body=" + StringUtils.quote(context.replaceDynamicContentInString(body), true));
+        headers.forEach((k, v) ->
+                args.add("--header=" + StringUtils.quote(k + "=" + context.replaceDynamicContentInString(v), true)));
+
+        LOG.info("Sending message to Camel integration '{}' (pid: {}) endpoint {}", name, pid, endpoint);
+        ProcessAndOutput result = CamelJBang.camel().send(args.toArray(String[]::new));
+        String output = result.getOutput();
+
+        // camel cmd send exits 0 even on failure, so validate the output instead
+        if (output == null || !output.contains("Sent") || output.contains("Send timeout")) {
+            throw new CitrusRuntimeException(
+                    "camel cmd send did not confirm delivery to integration '%s' (pid: %d). Output: %s"
+                            .formatted(name, pid, output));
+        }
+        LOG.info("Message delivered to Camel integration '{}' (pid: {})", name, pid);
+    }
+
+    /**
+     * Resolves the PID of the integration's process that is both {@code Running} and fully ready
+     * ({@code 1/1}), retrying until it appears. Leftover {@code Terminated} launcher entries with
+     * the same name are ignored.
+     */
+    private long waitForRunningPid(String name) {
+        long deadline = System.currentTimeMillis() + READY_TIMEOUT_MILLIS;
+        while (true) {
+            for (Map<String, String> row : CamelJBang.camel().getAll()) {
+                if (name.equals(row.get("name"))
+                        && "Running".equals(row.get("status"))
+                        && "1/1".equals(row.get("ready"))) {
+                    return Long.parseLong(row.get("pid"));
+                }
+            }
+            if (System.currentTimeMillis() > deadline) {
+                throw new CitrusRuntimeException("No running Camel integration named '%s' found within %d ms"
+                        .formatted(name, READY_TIMEOUT_MILLIS));
+            }
+            try {
+                Thread.sleep(READY_POLL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CitrusRuntimeException("Interrupted while waiting for integration '%s'".formatted(name), e);
+            }
+        }
+    }
+
+    public static final class Builder extends AbstractTestActionBuilder<ForageCmdSendAction, Builder> {
+
+        private String integrationName;
+        private String endpoint;
+        private String body;
+        private final Map<String, String> headers = new LinkedHashMap<>();
+
+        public Builder integration(String integrationName) {
+            this.integrationName = integrationName;
+            return this;
+        }
+
+        public Builder endpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder body(String body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder header(String name, String value) {
+            this.headers.put(name, value);
+            return this;
+        }
+
+        @Override
+        public ForageCmdSendAction build() {
+            return new ForageCmdSendAction(this);
+        }
+    }
+}

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageCmdSendAction.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageCmdSendAction.java
@@ -18,9 +18,9 @@ import org.slf4j.LoggerFactory;
  * Sends a message to a running Camel integration via {@code camel cmd send}, addressing the
  * integration by the PID of its {@code Running} process instead of by name.
  *
- * <p>Workaround for Camel JBang 4.20: with exported runtimes (spring-boot, quarkus) the launcher
- * process leaves a {@code Terminated} status entry under the same integration name, and
- * {@code camel cmd send <name>} fails with "matches 2 running Camel integrations" while still
+ * <p>Workaround for CAMEL-24002 (Camel JBang 4.20): with exported runtimes (spring-boot, quarkus)
+ * the launcher process leaves a {@code Terminated} status entry under the same integration name,
+ * and {@code camel cmd send <name>} fails with "matches 2 running Camel integrations" while still
  * exiting 0 — so the Citrus {@code CamelCmdSendAction} reports success although nothing was sent.
  *
  * <p>This action:

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageIntegrationTest.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageIntegrationTest.java
@@ -60,4 +60,15 @@ public interface ForageIntegrationTest extends TestActionSupport {
     default Resource classResource(String resourceRelativePath) {
         return Resources.fromClasspath(getClass().getSimpleName() + "/" + resourceRelativePath, getClass());
     }
+
+    /**
+     * Sends a message to a running integration via {@code camel cmd send}, addressing it by the
+     * PID of its {@code Running} process. Use this instead of {@code camel().jbang().cmd().send()},
+     * which addresses by name: with exported runtimes (spring-boot, quarkus) on Camel JBang 4.20
+     * the launcher's leftover {@code Terminated} entry makes the name ambiguous and the send is
+     * silently dropped (exit code 0). See {@link ForageCmdSendAction}.
+     */
+    default ForageCmdSendAction.Builder forageCmdSend(String integrationName) {
+        return new ForageCmdSendAction.Builder().integration(integrationName);
+    }
 }

--- a/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/JdbcTest.java
+++ b/integration-tests/jdbc/src/test/java/io/kaoto/forage/jdbc/JdbcTest.java
@@ -105,26 +105,18 @@ public class JdbcTest implements ForageIntegrationTest {
     @CitrusTest()
     public void aggregationTest(ForageTestCaseRunner runner) {
 
-        // send events to be aggregated together
-        runner.when(camel().jbang()
-                        .cmd()
-                        .send()
+        // send events to be aggregated together; sent by PID because name-addressed
+        // sends are silently dropped on exported runtimes (see ForageCmdSendAction)
+        runner.when(forageCmdSend(INTEGRATION_NAME)
                         .endpoint("direct:events")
-                        .integration(INTEGRATION_NAME)
                         .body("Hello 1!")
                         .header("eventId", "1"))
-                .and(camel().jbang()
-                        .cmd()
-                        .send()
+                .and(forageCmdSend(INTEGRATION_NAME)
                         .endpoint("direct:events")
-                        .integration(INTEGRATION_NAME)
                         .body("Hello 2!")
                         .header("eventId", "1"))
-                .and(camel().jbang()
-                        .cmd()
-                        .send()
+                .and(forageCmdSend(INTEGRATION_NAME)
                         .endpoint("direct:events")
-                        .integration(INTEGRATION_NAME)
                         .body("Hello 3!")
                         .header("eventId", "1"));
 


### PR DESCRIPTION
## Problem

`JdbcTest.aggregationTest` times out on the spring-boot and quarkus suites (passes on plain Camel) when running with Camel 4.20.0.

Root cause (reproduced and probed live): with exported runtimes, camel-jbang 4.20 leaves the launcher process's status entry visible as `Terminated` under the same integration name as the real application:

```
 PID   NAME         READY    STATUS    AGE
79082  jdbc-routes   0/1   Terminated  28s     <- launcher leftover
79153  jdbc-routes   1/1      Running  21s     <- actual app
```

`camel cmd send jdbc-routes ...` then fails with "Name or pid jdbc-routes matches 2 running Camel integrations" — **but exits 0**. Citrus's `CamelCmdSendAction` (4.10.1) trusts the exit code and logs "Successfully sent", so the messages are silently lost and the log verification times out. Reported upstream against camel-jbang (exit code + Terminated entries matching).

## Fix

New `ForageCmdSendAction` (exposed as `forageCmdSend(...)` on `ForageIntegrationTest`):
- waits until the integration's `Running` (ready 1/1) process is visible — also guards against sending before an exported runtime finished starting (first-run dependency downloads made `state=Running` appear ~90s before the app existed);
- sends by **PID**, so leftover `Terminated` entries cannot make the name ambiguous;
- validates the `camel cmd send` output (`Sent` marker, no `Send timeout`) instead of trusting the exit code, so a failed send fails the test immediately with a clear message.

`JdbcTest.aggregationTest` switched to the new action.

## Verification

Locally with Camel 4.20.0: `aggregationTest` now passes on **spring-boot** ("Batch complete with 3 event id: 1 and events: [Hello 1!, Hello 2!, Hello 3!]") and **quarkus**; plain Camel unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
