### PR TITLE
Fix #427: JMS XA — wire JtaTransactionManager into the Camel JMS component so XA sessions enlist in JTA

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageIntegrationTest.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/ForageIntegrationTest.java
@@ -2,6 +2,7 @@ package io.kaoto.forage.integration.tests;
 
 import java.util.function.Consumer;
 import org.apache.camel.tooling.model.Strings;
+import org.citrusframework.TestAction;
 import org.citrusframework.TestActionSupport;
 import org.citrusframework.actions.camel.CamelIntegrationRunCustomizedActionBuilder;
 import org.citrusframework.spi.Resource;
@@ -59,6 +60,24 @@ public interface ForageIntegrationTest extends TestActionSupport {
 
     default Resource classResource(String resourceRelativePath) {
         return Resources.fromClasspath(getClass().getSimpleName() + "/" + resourceRelativePath, getClass());
+    }
+
+    /**
+     * Registers process cleanup for an integration started in {@link #runBeforeAll}. Call this right
+     * after each run action: the extension only registers cleanup for the integration name returned
+     * from {@code runBeforeAll}, and only when it returns normally — an integration started before a
+     * later action fails would otherwise keep running (and, on Quarkus, keep its HTTP port bound)
+     * into the following tests.
+     */
+    default void registerIntegrationCleanup(
+            ForageTestCaseRunner runner, String integrationName, Consumer<AutoCloseable> afterAll) {
+        runner.run((TestAction) context -> {
+            Object pidValue = context.getVariables().get(integrationName + ":pid");
+            if (pidValue != null) {
+                long pid = Long.parseLong(pidValue.toString());
+                afterAll.accept(() -> IntegrationTestSetupExtension.destroyProcess(integrationName, pid));
+            }
+        });
     }
 
     /**

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  */
 public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterAllCallback, ParameterResolver {
 
-    private final Logger LOG = LoggerFactory.getLogger(IntegrationTestSetupExtension.class);
+    private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestSetupExtension.class);
 
     public static final String RUNTIME_PROPERTY = "INTEGRATION_TEST_RUNTIME";
 
@@ -115,7 +115,13 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
                         "forage-test-cleanup"));
     }
 
-    private void destroyProcess(String integrationName, long pid) {
+    /**
+     * Destroys a Camel integration process tree. Public so tests that start additional
+     * integrations beyond the one returned from
+     * {@link ForageIntegrationTest#runBeforeAll(ForageTestCaseRunner, java.util.function.Consumer)}
+     * can register their cleanup via the {@code afterAll} consumer.
+     */
+    public static void destroyProcess(String integrationName, long pid) {
         ProcessHandle.of(pid)
                 .ifPresentOrElse(
                         handle -> {

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/PropertiesTemplateHelper.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/PropertiesTemplateHelper.java
@@ -94,4 +94,30 @@ public final class PropertiesTemplateHelper {
         return createFromTemplate(
                 templateResource, Map.of(propertyPattern, Matcher.quoteReplacement(replacementValue)), afterAll);
     }
+
+    /**
+     * Copy a resource into the directory of an already-templated properties file, i.e. into the
+     * integration's working directory. Files passed to the run action as resources become Camel
+     * properties-component locations; files that must be picked up as camel-jbang run
+     * configuration (e.g. {@code application.properties} carrying runtime settings such as
+     * {@code quarkus.http.port}) have to sit in the working directory instead.
+     *
+     * @param anchor a temp-file resource previously returned by {@link #createFromTemplate}
+     * @param resource the resource to copy next to it (keeps its file name)
+     * @param afterAll cleanup callback to register temp file deletion
+     */
+    public static void copyIntoSameDirectory(Resource anchor, Resource resource, Consumer<AutoCloseable> afterAll) {
+        try {
+            Path targetFile = anchor.getFile()
+                    .toPath()
+                    .getParent()
+                    .resolve(resource.getFile().getName());
+            try (var inputStream = resource.getInputStream()) {
+                Files.copy(inputStream, targetFile);
+            }
+            afterAll.accept(() -> Files.deleteIfExists(targetFile));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to copy resource next to " + anchor.getLocation(), e);
+        }
+    }
 }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
@@ -3,7 +3,6 @@ package io.kaoto.forage.jms;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
-import org.citrusframework.TestAction;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
@@ -51,6 +50,10 @@ public class JmsArtemisTest implements ForageIntegrationTest {
                 classResource("forage-connectionfactory.properties.template"), replacements, afterAll);
         Resource producerProperties = PropertiesTemplateHelper.createFromTemplate(
                 classResource("producer/forage-connectionfactory.properties.template"), replacements, afterAll);
+        // must be in the working directory (not passed as a resource) to act as camel-jbang run
+        // config: it moves the producer's Quarkus HTTP server off 8080, which the consumer app owns
+        PropertiesTemplateHelper.copyIntoSameDirectory(
+                producerProperties, classResource("producer/application.properties"), afterAll);
 
         // consumer application (the system under test): XA transactions enabled
         runner.when(camel().jbang()
@@ -59,6 +62,7 @@ public class JmsArtemisTest implements ForageIntegrationTest {
                 .addResource(consumerProperties)
                 .addResource(classResource("route-artemis.camel.yaml"))
                 .dumpIntegrationOutput(true));
+        registerIntegrationCleanup(runner, INTEGRATION_NAME, afterAll);
 
         // producer application: an independent process with a plain (non-XA) connection
         // factory, modeling an external system publishing to the broker (#427)
@@ -68,16 +72,7 @@ public class JmsArtemisTest implements ForageIntegrationTest {
                 .addResource(producerProperties)
                 .addResource(classResource("producer/route-artemis-producer.camel.yaml"))
                 .dumpIntegrationOutput(true));
-
-        // the extension only stops the integration returned below; register the
-        // producer application's cleanup manually
-        runner.run((TestAction) context -> {
-            Object pidValue = context.getVariables().get(PRODUCER_INTEGRATION_NAME + ":pid");
-            if (pidValue != null) {
-                long pid = Long.parseLong(pidValue.toString());
-                afterAll.accept(() -> IntegrationTestSetupExtension.destroyProcess(PRODUCER_INTEGRATION_NAME, pid));
-            }
-        });
+        registerIntegrationCleanup(runner, PRODUCER_INTEGRATION_NAME, afterAll);
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
@@ -68,10 +68,23 @@ public class JmsArtemisTest implements ForageIntegrationTest {
     @CitrusTest()
     public void artemisTransactional(ForageTestCaseRunner runner) {
 
-        // validation of logged message
+        // the successful message commits through to the output queue
         runner.then(camel().jbang()
                 .verify()
                 .integration(INTEGRATION_NAME)
                 .waitForLogMessage("Successfully processed message: Transactional message"));
+
+        // the failing messages are dead-lettered to DLQ within the XA transaction
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .waitForLogMessage("Message sent to DLQ after max redeliveries"));
+
+        // an XA rollback returns the message to the broker: the broker redelivers it with
+        // JMSRedelivered=true; with broken XA enlistment the message would be lost (#427)
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .waitForLogMessage("Message redelivered after XA rollback"));
     }
 }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsArtemisTest.java
@@ -3,6 +3,7 @@ package io.kaoto.forage.jms;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
+import org.citrusframework.TestAction;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
@@ -30,6 +31,7 @@ public class JmsArtemisTest implements ForageIntegrationTest {
     static final String ARTEMIS_IMAGE_NAME =
             ConfigProvider.getConfig().getValue("activemq.artemis.container.image", String.class);
     public static final String INTEGRATION_NAME = "jms-routes";
+    public static final String PRODUCER_INTEGRATION_NAME = "jms-producer";
 
     @Container
     static ArtemisContainer artemis = new ArtemisContainer(
@@ -43,20 +45,39 @@ public class JmsArtemisTest implements ForageIntegrationTest {
     public String runBeforeAll(ForageTestCaseRunner runner, Consumer<AutoCloseable> afterAll) {
         // Load template properties and replace testcontainer-specific values
         String brokerUrl = "tcp://" + artemis.getHost() + ":" + artemis.getMappedPort(61616);
-        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
-                classResource("forage-connectionfactory.properties.template"),
-                Map.of(
-                        "forage\\.jms\\.broker\\.url=.*",
-                        Matcher.quoteReplacement("forage.jms.broker.url=" + brokerUrl)),
-                afterAll);
+        Map<String, String> replacements = Map.of(
+                "forage\\.jms\\.broker\\.url=.*", Matcher.quoteReplacement("forage.jms.broker.url=" + brokerUrl));
+        Resource consumerProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-connectionfactory.properties.template"), replacements, afterAll);
+        Resource producerProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("producer/forage-connectionfactory.properties.template"), replacements, afterAll);
 
-        // running jbang forage run with dynamically modified properties
+        // consumer application (the system under test): XA transactions enabled
         runner.when(camel().jbang()
                 .custom("forage", "run")
                 .processName(INTEGRATION_NAME)
-                .addResource(dynamicProperties)
+                .addResource(consumerProperties)
                 .addResource(classResource("route-artemis.camel.yaml"))
                 .dumpIntegrationOutput(true));
+
+        // producer application: an independent process with a plain (non-XA) connection
+        // factory, modeling an external system publishing to the broker (#427)
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(PRODUCER_INTEGRATION_NAME)
+                .addResource(producerProperties)
+                .addResource(classResource("producer/route-artemis-producer.camel.yaml"))
+                .dumpIntegrationOutput(true));
+
+        // the extension only stops the integration returned below; register the
+        // producer application's cleanup manually
+        runner.run((TestAction) context -> {
+            Object pidValue = context.getVariables().get(PRODUCER_INTEGRATION_NAME + ":pid");
+            if (pidValue != null) {
+                long pid = Long.parseLong(pidValue.toString());
+                afterAll.accept(() -> IntegrationTestSetupExtension.destroyProcess(PRODUCER_INTEGRATION_NAME, pid));
+            }
+        });
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
@@ -77,7 +77,6 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
         destinations.createQueue("input.queue");
         destinations.createQueue("output.queue");
         destinations.createQueue("DLQ");
-        destinations.createQueue("DLQ2");
 
         // Load template properties and replace testcontainer-specific values
         String brokerUrl = "mq://%s:%d/%s/%s"
@@ -103,10 +102,16 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
     @Test
     @CitrusTest()
     public void ibmMqTransactional(ForageTestCaseRunner runner) {
-        // validation of logged message
+        // the successful message commits through to the output queue via XA
         runner.then(camel().jbang()
                 .verify()
                 .integration(INTEGRATION_NAME)
                 .waitForLogMessage("Successfully processed message: Transactional message"));
+
+        // the failing messages are dead-lettered to DLQ within the XA transaction
+        runner.then(camel().jbang()
+                .verify()
+                .integration(INTEGRATION_NAME)
+                .waitForLogMessage("Message sent to DLQ after max redeliveries"));
     }
 }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
@@ -3,7 +3,6 @@ package io.kaoto.forage.jms;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
-import org.citrusframework.TestAction;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
@@ -89,6 +88,10 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
                 classResource("forage-connectionfactory.properties.template"), replacements, afterAll);
         Resource producerProperties = PropertiesTemplateHelper.createFromTemplate(
                 classResource("producer/forage-connectionfactory.properties.template"), replacements, afterAll);
+        // must be in the working directory (not passed as a resource) to act as camel-jbang run
+        // config: it moves the producer's Quarkus HTTP server off 8080, which the consumer app owns
+        PropertiesTemplateHelper.copyIntoSameDirectory(
+                producerProperties, classResource("producer/application.properties"), afterAll);
 
         // consumer application (the system under test): XA transactions enabled
         runner.when(camel().jbang()
@@ -97,6 +100,7 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
                 .addResource(consumerProperties)
                 .addResource(classResource("route-ibm.camel.yaml"))
                 .dumpIntegrationOutput(true));
+        registerIntegrationCleanup(runner, INTEGRATION_NAME, afterAll);
 
         // producer application: an independent process with a plain (non-XA) connection
         // factory, modeling an external system publishing to the broker (#427)
@@ -106,16 +110,7 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
                 .addResource(producerProperties)
                 .addResource(classResource("producer/route-ibm-producer.camel.yaml"))
                 .dumpIntegrationOutput(true));
-
-        // the extension only stops the integration returned below; register the
-        // producer application's cleanup manually
-        runner.run((TestAction) context -> {
-            Object pidValue = context.getVariables().get(PRODUCER_INTEGRATION_NAME + ":pid");
-            if (pidValue != null) {
-                long pid = Long.parseLong(pidValue.toString());
-                afterAll.accept(() -> IntegrationTestSetupExtension.destroyProcess(PRODUCER_INTEGRATION_NAME, pid));
-            }
-        });
+        registerIntegrationCleanup(runner, PRODUCER_INTEGRATION_NAME, afterAll);
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
+++ b/integration-tests/jms/src/test/java/io/kaoto/forage/jms/JmsIbmMqTest.java
@@ -3,6 +3,7 @@ package io.kaoto.forage.jms;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
+import org.citrusframework.TestAction;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.junit.jupiter.CitrusSupport;
 import org.citrusframework.spi.Resource;
@@ -35,6 +36,7 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
     private static final String IBMMQ_IMAGE_NAME =
             ConfigProvider.getConfig().getValue("ibmmq.container.image", String.class);
     public static final String INTEGRATION_NAME = "jms-routes";
+    public static final String PRODUCER_INTEGRATION_NAME = "jms-producer";
     private static final int IBMMQ_PORT = 1414;
     private static final String QUEUE_MANAGER_NAME = "QM1";
     private static final String USER = "app";
@@ -81,20 +83,39 @@ public class JmsIbmMqTest implements ForageIntegrationTest {
         // Load template properties and replace testcontainer-specific values
         String brokerUrl = "mq://%s:%d/%s/%s"
                 .formatted(ibmmq.getHost(), ibmmq.getMappedPort(1414), MESSAGING_CHANNEL, QUEUE_MANAGER_NAME);
-        Resource dynamicProperties = PropertiesTemplateHelper.createFromTemplate(
-                classResource("forage-connectionfactory.properties.template"),
-                Map.of(
-                        "forage\\.jms\\.broker\\.url=.*",
-                        Matcher.quoteReplacement("forage.jms.broker.url=" + brokerUrl)),
-                afterAll);
+        Map<String, String> replacements = Map.of(
+                "forage\\.jms\\.broker\\.url=.*", Matcher.quoteReplacement("forage.jms.broker.url=" + brokerUrl));
+        Resource consumerProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("forage-connectionfactory.properties.template"), replacements, afterAll);
+        Resource producerProperties = PropertiesTemplateHelper.createFromTemplate(
+                classResource("producer/forage-connectionfactory.properties.template"), replacements, afterAll);
 
-        // running jbang forage run with dynamically modified properties
+        // consumer application (the system under test): XA transactions enabled
         runner.when(camel().jbang()
                 .custom("forage", "run")
                 .processName(INTEGRATION_NAME)
-                .addResource(dynamicProperties)
+                .addResource(consumerProperties)
                 .addResource(classResource("route-ibm.camel.yaml"))
                 .dumpIntegrationOutput(true));
+
+        // producer application: an independent process with a plain (non-XA) connection
+        // factory, modeling an external system publishing to the broker (#427)
+        runner.when(camel().jbang()
+                .custom("forage", "run")
+                .processName(PRODUCER_INTEGRATION_NAME)
+                .addResource(producerProperties)
+                .addResource(classResource("producer/route-ibm-producer.camel.yaml"))
+                .dumpIntegrationOutput(true));
+
+        // the extension only stops the integration returned below; register the
+        // producer application's cleanup manually
+        runner.run((TestAction) context -> {
+            Object pidValue = context.getVariables().get(PRODUCER_INTEGRATION_NAME + ":pid");
+            if (pidValue != null) {
+                long pid = Long.parseLong(pidValue.toString());
+                afterAll.accept(() -> IntegrationTestSetupExtension.destroyProcess(PRODUCER_INTEGRATION_NAME, pid));
+            }
+        });
 
         return INTEGRATION_NAME;
     }

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/producer/application.properties
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/producer/application.properties
@@ -1,0 +1,4 @@
+# The producer app runs alongside the consumer app. On the Quarkus runtime both
+# would bind the default HTTP port 8080 - use a random port to avoid the clash.
+# Ignored by the plain and Spring Boot runtimes.
+quarkus.http.port=0

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/producer/forage-connectionfactory.properties.template
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/producer/forage-connectionfactory.properties.template
@@ -1,0 +1,16 @@
+# Producer application: models an independent external system publishing to the
+# broker. It uses a plain (non-XA) connection factory - no transaction settings -
+# so its sends commit normally, exactly like a producer that knows nothing about
+# the consumer's XA setup. See #427.
+forage.jms.kind=artemis
+forage.jms.broker.url=tcp://localhost:61616  # Overridden by test with testcontainer URL
+forage.jms.username=artemis
+forage.jms.password=artemis
+
+# Connection pool settings
+forage.jms.pool.enabled=true
+forage.jms.pool.max.connections=5
+forage.jms.pool.max.sessions.per.connection=500
+forage.jms.pool.idle.timeout.millis=30000
+forage.jms.pool.connection.timeout.millis=30000
+forage.jms.pool.block.if.full=true

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/producer/route-artemis-producer.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/producer/route-artemis-producer.camel.yaml
@@ -1,0 +1,36 @@
+# Producer application: an independent process with a plain (non-XA) connection
+# factory, decoupled from the XA consumer application. Its sends need no
+# transaction because the connection factory is not XA - this models an external
+# system publishing to the broker.
+- route:
+    id: producer-route
+    from:
+      id: timer-producer
+      uri: timer
+      parameters:
+        includeMetadata: true
+        period: "5000"
+        repeatCount: 3
+        timerName: producer
+      steps:
+        - setBody:
+            id: set-message
+            simple:
+              expression: Transactional message ${exchangeProperty.CamelTimerCounter}
+        - setHeader:
+            id: set-counter
+            name: counter
+            simple:
+              expression: ${exchangeProperty.CamelTimerCounter}
+        - log:
+            id: log-message
+            message: "Message sent: ${body}"
+        - to:
+            id: send-to-input
+            uri: jms
+            parameters:
+              destinationName: input.queue
+              destinationType: queue
+        - log:
+            id: log-sent
+            message: Sent message to input queue

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
@@ -1,42 +1,9 @@
-- route:
-    id: producer-route
-    from:
-      id: timer-producer
-      uri: timer
-      parameters:
-        includeMetadata: true
-        period: "5000"
-        repeatCount: 3
-        timerName: producer
-      steps:
-        # Sends must also run inside a JTA transaction with XA: the pooled XA
-        # connection factory always hands out XA sessions, and brokers such as
-        # IBM MQ put unenlisted sends in a local unit of work that is never
-        # committed - the messages are silently discarded. See #427.
-        - transacted:
-            id: producer-xa-transaction
-            ref: PROPAGATION_REQUIRED
-        - setBody:
-            id: set-message
-            simple:
-              expression: Transactional message ${exchangeProperty.CamelTimerCounter}
-        - setHeader:
-            id: setHeader-5933
-            name: counter
-            simple:
-              expression: ${exchangeProperty.CamelTimerCounter}
-        - log:
-            id: log-1795
-            message: "Message sent: ${body}"
-        - to:
-            id: send-to-input
-            uri: jms
-            parameters:
-              destinationName: input.queue
-              destinationType: queue
-        - log:
-            id: log-sent
-            message: Sent message to input queue
+# Consumer application (the system under test): XA transactions enabled. The
+# messages on input.queue are produced by a SEPARATE producer application with a
+# plain connection factory (see producer/), proving producer and consumer are
+# fully decoupled. Only the rollback-producer below sends from this XA app, and
+# it must run inside a JTA transaction (see #427): the XA pool always hands out
+# XA sessions and unenlisted sends are silently discarded by brokers like IBM MQ.
 - route:
     id: transactional-consumer-route
     from:

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
@@ -38,7 +38,9 @@
       parameters:
         destinationName: input.queue
         destinationType: queue
-        transacted: "true"
+        # transacted must stay false with XA: the JTA transaction manager wired into the
+        # JMS component drives the transaction; a local JMS transaction on an XA
+        # connection is rejected by brokers such as IBM MQ (MQRC 2072). See #427.
         cacheLevelName: CACHE_NONE
       steps:
         - transacted:
@@ -93,12 +95,67 @@
       id: dlq-consumer
       uri: jms
       parameters:
-        destinationName: DLQ2
+        destinationName: DLQ
         destinationType: queue
       steps:
         - log:
             id: log-dlq
             message: "Message sent to DLQ after max redeliveries: ${body}"
+# Rollback assertion (#427): the first delivery throws so the JTA transaction rolls
+# back; only a real XA rollback returns the message to the broker, which redelivers it
+# with JMSRedelivered=true. With broken XA enlistment the message would be lost
+# (auto-acked) and the redelivered log line would never appear.
+- route:
+    id: rollback-producer-route
+    from:
+      id: timer-rollback-producer
+      uri: timer
+      parameters:
+        period: "5000"
+        repeatCount: 1
+        timerName: rollbackProducer
+      steps:
+        - setBody:
+            id: set-rollback-message
+            simple:
+              expression: Rollback test message
+        - to:
+            id: send-to-rollback
+            uri: jms
+            parameters:
+              destinationName: rollback.queue
+              destinationType: queue
+- route:
+    id: rollback-consumer-route
+    errorHandler:
+      noErrorHandler: {}
+    from:
+      id: rollback-consumer
+      uri: jms
+      parameters:
+        destinationName: rollback.queue
+        destinationType: queue
+        cacheLevelName: CACHE_NONE
+      steps:
+        - choice:
+            id: rollback-check
+            otherwise:
+              id: redelivered-path
+              steps:
+                - log:
+                    id: log-redelivered
+                    message: "Message redelivered after XA rollback: ${body}"
+            when:
+              - steps:
+                  - log:
+                      id: log-first-delivery
+                      message: "First delivery - forcing XA rollback: ${body}"
+                  - throwException:
+                      id: throw-rollback
+                      exceptionType: java.lang.RuntimeException
+                      message: Forcing XA rollback
+                simple:
+                  expression: ${header.JMSRedelivered} == false
 - errorHandler:
     deadLetterChannel:
       deadLetterUri: jms:DLQ

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisTest/route-artemis.camel.yaml
@@ -9,6 +9,13 @@
         repeatCount: 3
         timerName: producer
       steps:
+        # Sends must also run inside a JTA transaction with XA: the pooled XA
+        # connection factory always hands out XA sessions, and brokers such as
+        # IBM MQ put unenlisted sends in a local unit of work that is never
+        # committed - the messages are silently discarded. See #427.
+        - transacted:
+            id: producer-xa-transaction
+            ref: PROPAGATION_REQUIRED
         - setBody:
             id: set-message
             simple:
@@ -115,6 +122,9 @@
         repeatCount: 1
         timerName: rollbackProducer
       steps:
+        - transacted:
+            id: rollback-producer-xa-transaction
+            ref: PROPAGATION_REQUIRED
         - setBody:
             id: set-rollback-message
             simple:

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/producer/application.properties
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/producer/application.properties
@@ -1,0 +1,4 @@
+# The producer app runs alongside the consumer app. On the Quarkus runtime both
+# would bind the default HTTP port 8080 - use a random port to avoid the clash.
+# Ignored by the plain and Spring Boot runtimes.
+quarkus.http.port=0

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/producer/forage-connectionfactory.properties.template
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/producer/forage-connectionfactory.properties.template
@@ -1,0 +1,16 @@
+# Producer application: models an independent external system publishing to the
+# broker. It uses a plain (non-XA) connection factory - no transaction settings -
+# so its sends commit normally, exactly like a producer that knows nothing about
+# the consumer's XA setup. See #427.
+forage.jms.kind=ibmmq
+forage.jms.broker.url=mq://localhost:1414/DEV.APP.SVRCONN/QM1  # Overridden by test with testcontainer URL
+forage.jms.username=app
+forage.jms.password=passw0rd
+
+# Connection pool settings
+forage.jms.pool.enabled=true
+forage.jms.pool.max.connections=5
+forage.jms.pool.max.sessions.per.connection=500
+forage.jms.pool.idle.timeout.millis=30000
+forage.jms.pool.connection.timeout.millis=30000
+forage.jms.pool.block.if.full=true

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/producer/route-ibm-producer.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/producer/route-ibm-producer.camel.yaml
@@ -1,0 +1,36 @@
+# Producer application: an independent process with a plain (non-XA) connection
+# factory, decoupled from the XA consumer application. Its sends need no
+# transaction because the connection factory is not XA - this models an external
+# system publishing to the broker.
+- route:
+    id: producer-route
+    from:
+      id: timer-producer
+      uri: timer
+      parameters:
+        includeMetadata: true
+        period: "5000"
+        repeatCount: 3
+        timerName: producer
+      steps:
+        - setBody:
+            id: set-message
+            simple:
+              expression: Transactional message ${exchangeProperty.CamelTimerCounter}
+        - setHeader:
+            id: set-counter
+            name: counter
+            simple:
+              expression: ${exchangeProperty.CamelTimerCounter}
+        - log:
+            id: log-message
+            message: "Message sent: ${body}"
+        - to:
+            id: send-to-input
+            uri: jms
+            parameters:
+              destinationName: input.queue
+              destinationType: queue
+        - log:
+            id: log-sent
+            message: Sent message to input queue

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
@@ -9,6 +9,13 @@
         repeatCount: 3
         timerName: producer
       steps:
+        # Sends must also run inside a JTA transaction with XA: the pooled XA
+        # connection factory always hands out XA sessions, and IBM MQ puts
+        # unenlisted sends in a local syncpoint unit of work that is never
+        # committed - the messages are silently discarded. See #427.
+        - transacted:
+            id: producer-xa-transaction
+            ref: PROPAGATION_REQUIRED
         - setBody:
             id: set-message
             simple:

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
@@ -1,42 +1,9 @@
-- route:
-    id: producer-route
-    from:
-      id: timer-producer
-      uri: timer
-      parameters:
-        includeMetadata: true
-        period: "5000"
-        repeatCount: 3
-        timerName: producer
-      steps:
-        # Sends must also run inside a JTA transaction with XA: the pooled XA
-        # connection factory always hands out XA sessions, and IBM MQ puts
-        # unenlisted sends in a local syncpoint unit of work that is never
-        # committed - the messages are silently discarded. See #427.
-        - transacted:
-            id: producer-xa-transaction
-            ref: PROPAGATION_REQUIRED
-        - setBody:
-            id: set-message
-            simple:
-              expression: Transactional message ${exchangeProperty.CamelTimerCounter}
-        - setHeader:
-            id: setHeader-5933
-            name: counter
-            simple:
-              expression: ${exchangeProperty.CamelTimerCounter}
-        - log:
-            id: log-1795
-            message: "Message sent: ${body}"
-        - to:
-            id: send-to-input
-            uri: jms
-            parameters:
-              destinationName: input.queue
-              destinationType: queue
-        - log:
-            id: log-sent
-            message: Sent message to input queue
+# Consumer application (the system under test): XA transactions enabled. The
+# messages on input.queue are produced by a SEPARATE producer application with a
+# plain connection factory (see producer/), proving producer and consumer are
+# fully decoupled. Sends from this XA application happen only inside the JTA
+# transaction (forward to output.queue, dead-letter to DLQ), where the XA
+# session is enlisted automatically. See #427.
 - route:
     id: transactional-consumer-route
     from:

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsIbmMqTest/route-ibm.camel.yaml
@@ -38,7 +38,9 @@
       parameters:
         destinationName: input.queue
         destinationType: queue
-        transacted: "true"
+        # transacted must stay false with XA: the JTA transaction manager wired into the
+        # JMS component drives the transaction; a local JMS transaction on an XA
+        # connection is rejected by IBM MQ (MQRC_SYNCPOINT_NOT_AVAILABLE, 2072). See #427.
         cacheLevelName: CACHE_NONE
       steps:
         - transacted:
@@ -93,7 +95,7 @@
       id: dlq-consumer
       uri: jms
       parameters:
-        destinationName: DLQ2
+        destinationName: DLQ
         destinationType: queue
       steps:
         - log:

--- a/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
+++ b/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
+import org.apache.camel.spi.ComponentCustomizer;
 import org.jboss.logging.Logger;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
@@ -48,23 +49,10 @@ public class ForageJmsProcessor {
     @Record(value = ExecutionTime.RUNTIME_INIT)
     void registerIbmMqConnectionFactory(ForageJmsRecorder recorder, BuildProducer<CamelRuntimeBeanBuildItem> beans) {
 
-        ConnectionFactoryConfig defaultConfig = DESCRIPTOR.createConfig(null);
-        Set<String> named = ConfigStore.getInstance()
-                .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
-
-        Map<String, ConnectionFactoryConfig> configs;
-        if (!named.isEmpty()) {
-            configs = named.stream().collect(Collectors.toMap(n -> n, DESCRIPTOR::createConfig));
-        } else {
-            // Check if default (unprefixed) properties exist before creating a default config
-            Set<String> defaultPrefixes = ConfigStore.getInstance()
-                    .readPrefixes(defaultConfig, ConfigHelper.getDefaultPropertyRegexp(DESCRIPTOR.modulePrefix()));
-            if (!defaultPrefixes.isEmpty()) {
-                configs = Collections.singletonMap((String) null, defaultConfig);
-            } else {
-                LOG.debug("No Forage JMS configuration found, skipping ConnectionFactory discovery");
-                return;
-            }
+        Map<String, ConnectionFactoryConfig> configs = discoverConfigs();
+        if (configs.isEmpty()) {
+            LOG.debug("No Forage JMS configuration found, skipping ConnectionFactory discovery");
+            return;
         }
 
         for (Map.Entry<String, ConnectionFactoryConfig> entry : configs.entrySet()) {
@@ -78,5 +66,44 @@ public class ForageJmsProcessor {
                         new CamelRuntimeBeanBuildItem(beanName, ConnectionFactory.class.getName(), connectionFactory));
             }
         }
+    }
+
+    /**
+     * Wires a JTA transaction manager into the Camel JMS component when any Forage JMS
+     * configuration enables transactions, so the message listener container starts a JTA
+     * transaction around receive() and XA sessions enlist in it (#427).
+     */
+    @BuildStep
+    @Record(value = ExecutionTime.RUNTIME_INIT)
+    void registerJmsTransactionManagerCustomizer(
+            ForageJmsRecorder recorder, BuildProducer<CamelRuntimeBeanBuildItem> beans) {
+
+        boolean anyTransactionEnabled =
+                discoverConfigs().values().stream().anyMatch(ConnectionFactoryConfig::transactionEnabled);
+
+        if (anyTransactionEnabled) {
+            beans.produce(new CamelRuntimeBeanBuildItem(
+                    "forageJmsTransactionManagerCustomizer",
+                    ComponentCustomizer.class.getName(),
+                    recorder.createJmsTransactionManagerCustomizer()));
+        }
+    }
+
+    private Map<String, ConnectionFactoryConfig> discoverConfigs() {
+        ConnectionFactoryConfig defaultConfig = DESCRIPTOR.createConfig(null);
+        Set<String> named = ConfigStore.getInstance()
+                .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+
+        if (!named.isEmpty()) {
+            return named.stream().collect(Collectors.toMap(n -> n, DESCRIPTOR::createConfig));
+        }
+
+        // Check if default (unprefixed) properties exist before creating a default config
+        Set<String> defaultPrefixes = ConfigStore.getInstance()
+                .readPrefixes(defaultConfig, ConfigHelper.getDefaultPropertyRegexp(DESCRIPTOR.modulePrefix()));
+        if (!defaultPrefixes.isEmpty()) {
+            return Collections.singletonMap(null, defaultConfig);
+        }
+        return Collections.emptyMap();
     }
 }

--- a/library/jms/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/jms/ForageJmsRecorder.java
+++ b/library/jms/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/jms/ForageJmsRecorder.java
@@ -2,7 +2,9 @@ package io.kaoto.forage.quarkus.jms;
 
 import jakarta.jms.ConnectionFactory;
 
+import org.apache.camel.spi.ComponentCustomizer;
 import org.jboss.logging.Logger;
+import io.kaoto.forage.jms.common.transactions.JmsJtaTransactionSupport;
 import io.kaoto.forage.jms.ibmmq.IbmMqJms;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
@@ -20,5 +22,16 @@ public class ForageJmsRecorder {
             throw new IllegalStateException("IBM MQ ConnectionFactory could not be created for id '%s'".formatted(id));
         }
         return new RuntimeValue<>(cf);
+    }
+
+    /**
+     * Creates a {@link ComponentCustomizer} that wires a Spring {@code JtaTransactionManager}
+     * (wrapping the Narayana transaction manager) into the Camel JMS component, so JMS
+     * consumers receive within a JTA transaction and XA sessions enlist in it (#427).
+     */
+    public RuntimeValue<ComponentCustomizer> createJmsTransactionManagerCustomizer() {
+        LOG.info("Registering Forage JTA transaction manager customizer for the Camel JMS component");
+        return new RuntimeValue<>(JmsJtaTransactionSupport.jmsComponentCustomizer(
+                JmsJtaTransactionSupport.createJtaTransactionManager()));
     }
 }

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/PooledConnectionFactory.java
@@ -2,8 +2,10 @@ package io.kaoto.forage.jms.common;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.XAConnectionFactory;
+import jakarta.transaction.TransactionManager;
 
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
+import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.jms.ConnectionFactoryProvider;
@@ -78,12 +80,14 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
                 return connectionFactory;
             }
 
-            // The XAConnectionFactory is wrapped as a plain ConnectionFactory, so sessions do NOT
-            // enlist in JTA transactions. Enlisting via JmsPoolXAConnectionFactory alone breaks
-            // consumption on brokers that reject local transactions on XA connections (IBM MQ
-            // MQRC 2072): completing XA also needs a JtaTransactionManager wired into the Camel
-            // JMS component. Tracked in #427.
-            final JmsPoolConnectionFactory pooledConnectionFactory = setupPooledConnectionFactory(xaConnectionFactory);
+            // Sessions created within an active JTA transaction enlist their XAResource in the
+            // Narayana transaction. This alone breaks consumption on brokers that reject local
+            // transactions on XA connections (IBM MQ MQRC 2072), so each runtime also wires a
+            // JtaTransactionManager into the Camel JMS component (see JmsJtaTransactionSupport)
+            // and endpoints must NOT enable local transactions (transacted=true). See #427.
+            TransactionManager transactionManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+            final JmsPoolXAConnectionFactory pooledConnectionFactory =
+                    setupPooledXAConnectionFactory(xaConnectionFactory, transactionManager);
 
             LOG.info("Pooled XA ConnectionFactory initialized successfully for id: {}", id);
             return pooledConnectionFactory;
@@ -101,6 +105,15 @@ public abstract class PooledConnectionFactory implements ConnectionFactoryProvid
             LOG.info("Pooled ConnectionFactory initialized successfully for id: {}", id);
             return pooledConnectionFactory;
         }
+    }
+
+    private JmsPoolXAConnectionFactory setupPooledXAConnectionFactory(
+            XAConnectionFactory xaConnectionFactory, TransactionManager transactionManager) {
+        JmsPoolXAConnectionFactory pooledConnectionFactory = new JmsPoolXAConnectionFactory();
+        pooledConnectionFactory.setConnectionFactory(xaConnectionFactory);
+        pooledConnectionFactory.setTransactionManager(transactionManager);
+        applyPoolSettings(pooledConnectionFactory);
+        return pooledConnectionFactory;
     }
 
     private <T> JmsPoolConnectionFactory setupPooledConnectionFactory(T underlyingConnectionFactory) {

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/JmsJtaTransactionSupport.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/JmsJtaTransactionSupport.java
@@ -1,0 +1,80 @@
+package io.kaoto.forage.jms.common.transactions;
+
+import jakarta.jms.ConnectionFactory;
+
+import java.util.Set;
+import org.apache.camel.component.jms.JmsComponent;
+import org.apache.camel.spi.ComponentCustomizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.jta.JtaTransactionManager;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.UserTransactionImple;
+
+/**
+ * Wires JTA transaction management into the Camel JMS component when
+ * {@code forage.jms.transaction.enabled=true}.
+ *
+ * <p>Setting a {@link JtaTransactionManager} on the JMS component makes Spring's
+ * {@code DefaultMessageListenerContainer} begin a JTA transaction around each
+ * {@code receive()}, so XA sessions obtained from the pooled XA connection factory
+ * enlist in the Narayana transaction and a rollback returns the message to the broker.
+ *
+ * <p>Endpoints must NOT enable local JMS transactions ({@code transacted=true}) when XA
+ * is active: brokers such as IBM MQ reject locally-transacted work on XA connections
+ * that have no coordinating transaction manager (MQRC_SYNCPOINT_NOT_AVAILABLE, 2072).
+ * See issue #427.
+ */
+public final class JmsJtaTransactionSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(JmsJtaTransactionSupport.class);
+
+    private JmsJtaTransactionSupport() {}
+
+    /**
+     * Creates a Spring {@link JtaTransactionManager} backed by the JVM-global Narayana
+     * transaction manager — the same instance the pooled XA connection factory and the
+     * JTA transaction policies use, so all participants share one transaction.
+     */
+    public static JtaTransactionManager createJtaTransactionManager() {
+        JtaTransactionManager transactionManager = new JtaTransactionManager(
+                new UserTransactionImple(), com.arjuna.ats.jta.TransactionManager.transactionManager());
+        transactionManager.setTransactionSynchronizationRegistry(new TransactionSynchronizationRegistryImple());
+        transactionManager.afterPropertiesSet();
+        return transactionManager;
+    }
+
+    /**
+     * Creates a {@link ComponentCustomizer} that sets the given transaction manager on every
+     * {@link JmsComponent} added to the CamelContext (unless one is already configured).
+     * Camel core applies customizers found in the registry on all runtimes.
+     */
+    public static ComponentCustomizer jmsComponentCustomizer(JtaTransactionManager transactionManager) {
+        return ComponentCustomizer.builder(JmsComponent.class).build((name, component) -> {
+            if (component.getConfiguration().getTransactionManager() != null) {
+                LOG.debug("Camel JMS component '{}' already has a transaction manager, leaving it untouched", name);
+                return;
+            }
+            LOG.info("Configuring Camel JMS component '{}' with the Forage JTA transaction manager", name);
+            component.setTransactionManager(transactionManager);
+
+            // JmsComponent.doInit() auto-discovers a single ConnectionFactory from the registry
+            // ONLY when no transaction manager is set; setting one above disables that discovery,
+            // so replicate it here (endpoints referencing #name explicitly are unaffected)
+            if (component.getConfiguration().getConnectionFactory() == null
+                    && component.isAllowAutoWiredConnectionFactory()) {
+                Set<ConnectionFactory> beans =
+                        component.getCamelContext().getRegistry().findByType(ConnectionFactory.class);
+                if (beans.size() == 1) {
+                    ConnectionFactory connectionFactory = beans.iterator().next();
+                    LOG.info("Configuring Camel JMS component '{}' with ConnectionFactory {}", name, connectionFactory);
+                    component.setConnectionFactory(connectionFactory);
+                } else if (beans.size() > 1) {
+                    LOG.debug(
+                            "Cannot autowire ConnectionFactory on component '{}' as {} instances found in registry",
+                            name,
+                            beans.size());
+                }
+            }
+        });
+    }
+}

--- a/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/PooledConnectionFactoryTest.java
+++ b/library/jms/forage-jms-common/src/test/java/io/kaoto/forage/jms/common/PooledConnectionFactoryTest.java
@@ -9,7 +9,6 @@ import jakarta.jms.XAJMSContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
@@ -60,18 +59,18 @@ class PooledConnectionFactoryTest {
     }
 
     @Test
-    @DisplayName("XA branch returns a plain pooled factory: JTA enlistment is not wired yet (#427)")
-    void xaBranchReturnsPlainPooledFactory() {
+    @DisplayName("XA branch returns a pooled XA factory enlisting sessions with the Narayana TM (#427)")
+    void xaBranchReturnsPooledXaFactoryWithTransactionManager() {
         System.setProperty(TRANSACTION_ENABLED_PROPERTY, "true");
 
         ConnectionFactory connectionFactory =
                 new StubPooledConnectionFactory(new StubDualConnectionFactory()).create(null);
 
-        // A JmsPoolXAConnectionFactory alone breaks consumption on brokers that reject
-        // local transactions on XA connections (IBM MQ MQRC 2072); switching to it must
-        // come together with Camel JMS component JTA wiring — tracked in #427
-        assertThat(connectionFactory).isInstanceOf(JmsPoolConnectionFactory.class);
-        assertThat(connectionFactory).isNotInstanceOf(JmsPoolXAConnectionFactory.class);
+        assertThat(connectionFactory).isInstanceOf(JmsPoolXAConnectionFactory.class);
+        JmsPoolXAConnectionFactory pooled = (JmsPoolXAConnectionFactory) connectionFactory;
+        assertThat(pooled.getTransactionManager())
+                .as("XA pool must enlist sessions with the JVM-global Narayana transaction manager")
+                .isSameAs(com.arjuna.ats.jta.TransactionManager.transactionManager());
     }
 
     @Test

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.apache.camel.CamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.jta.JtaTransactionManager;
 import io.kaoto.forage.core.annotations.ConditionalBean;
 import io.kaoto.forage.core.annotations.ConditionalBeanGroup;
 import io.kaoto.forage.core.annotations.FactoryType;
@@ -25,6 +26,7 @@ import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.jms.common.ConnectionFactoryCommonExportHelper;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
+import io.kaoto.forage.jms.common.transactions.JmsJtaTransactionSupport;
 
 @ForageFactory(
         value = "JMS Connection",
@@ -67,7 +69,13 @@ import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
                         @ConditionalBean(
                                 name = "SUPPORTS",
                                 javaType = "org.apache.camel.spi.TransactedPolicy",
-                                description = "Joins existing transaction if present, otherwise runs without one")
+                                description = "Joins existing transaction if present, otherwise runs without one"),
+                        @ConditionalBean(
+                                name = "jtaTransactionManager",
+                                javaType = "org.springframework.transaction.jta.JtaTransactionManager",
+                                description = "Spring JtaTransactionManager wrapping the Narayana transaction manager, "
+                                        + "set on the Camel JMS component so consumers receive within a JTA "
+                                        + "transaction and XA sessions enlist")
                     }),
             @ConditionalBeanGroup(
                     id = "jms-connection-pool",
@@ -81,6 +89,8 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
 
     private CamelContext camelContext;
     private static final String DEFAULT_CONNECTION_FACTORY = "connectionFactory";
+    private static final String JTA_TRANSACTION_MANAGER = "jtaTransactionManager";
+    private static final String JMS_TRANSACTION_MANAGER_CUSTOMIZER = "forageJmsTransactionManagerCustomizer";
 
     @Override
     public void cleanup() {
@@ -93,10 +103,17 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         }
         closeAndUnbind(DEFAULT_CONNECTION_FACTORY);
 
-        // Unbind JTA transaction policies if they were registered
+        // Unbind JTA transaction policies and transaction manager wiring if they were registered
         if (anyTransactionEnabled(config, prefixes)) {
             for (String name : List.of(
-                    "PROPAGATION_REQUIRED", "MANDATORY", "NEVER", "NOT_SUPPORTED", "REQUIRES_NEW", "SUPPORTS")) {
+                    "PROPAGATION_REQUIRED",
+                    "MANDATORY",
+                    "NEVER",
+                    "NOT_SUPPORTED",
+                    "REQUIRES_NEW",
+                    "SUPPORTS",
+                    JTA_TRANSACTION_MANAGER,
+                    JMS_TRANSACTION_MANAGER_CUSTOMIZER)) {
                 camelContext.getRegistry().unbind(name);
             }
         }
@@ -125,6 +142,17 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
             camelContext.getRegistry().bind("NOT_SUPPORTED", new NotSupportedJtaTransactionPolicy());
             camelContext.getRegistry().bind("REQUIRES_NEW", new RequiresNewJtaTransactionPolicy());
             camelContext.getRegistry().bind("SUPPORTS", new SupportsJtaTransactionPolicy());
+
+            // Wire JTA into the Camel JMS component so the listener container starts a JTA
+            // transaction around receive() and XA sessions enlist in it (#427). The customizer
+            // is applied by Camel core to every JmsComponent added to the context.
+            JtaTransactionManager jtaTransactionManager = JmsJtaTransactionSupport.createJtaTransactionManager();
+            camelContext.getRegistry().bind(JTA_TRANSACTION_MANAGER, jtaTransactionManager);
+            camelContext
+                    .getRegistry()
+                    .bind(
+                            JMS_TRANSACTION_MANAGER_CUSTOMIZER,
+                            JmsJtaTransactionSupport.jmsComponentCustomizer(jtaTransactionManager));
         }
 
         if (!prefixes.isEmpty()) {

--- a/library/jms/forage-jms/src/test/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactoryTransactionTest.java
+++ b/library/jms/forage-jms/src/test/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactoryTransactionTest.java
@@ -6,7 +6,9 @@ import jakarta.jms.JMSContext;
 
 import java.util.List;
 import org.apache.camel.CamelContext;
+import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.springframework.transaction.jta.JtaTransactionManager;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +40,37 @@ class ConnectionFactoryBeanFactoryTransactionTest {
                     .as("JTA policy bean '%s' should be bound when a prefixed config enables transactions", name)
                     .isNotNull();
         }
+    }
+
+    @Test
+    void transactionEnabledWiresJtaTransactionManagerIntoJmsComponent() {
+        CamelContext camelContext = new DefaultCamelContext();
+        ConnectionFactory connectionFactory = dummyConnectionFactory();
+        camelContext.getRegistry().bind("mq1", connectionFactory);
+
+        ConnectionFactoryBeanFactory beanFactory = new ConnectionFactoryBeanFactory();
+        beanFactory.setCamelContext(camelContext);
+        beanFactory.configure();
+
+        JtaTransactionManager jtaTransactionManager =
+                camelContext.getRegistry().lookupByNameAndType("jtaTransactionManager", JtaTransactionManager.class);
+        assertThat(jtaTransactionManager)
+                .as("A JtaTransactionManager should be bound when transactions are enabled")
+                .isNotNull();
+
+        // Resolving the component fires onComponentAdd, which applies the registered
+        // ComponentCustomizer — the mechanism used at runtime when routes create the component
+        JmsComponent jmsComponent = camelContext.getComponent("jms", JmsComponent.class);
+        assertThat(jmsComponent.getConfiguration().getTransactionManager())
+                .as("The Camel JMS component should receive the Forage JTA transaction manager (#427)")
+                .isSameAs(jtaTransactionManager);
+
+        // Setting a transaction manager disables JmsComponent's own ConnectionFactory
+        // auto-discovery, so the customizer must replicate it
+        assertThat(jmsComponent.getConfiguration().getConnectionFactory())
+                .as("The single registry ConnectionFactory should still be auto-discovered when a "
+                        + "transaction manager is set (#427)")
+                .isSameAs(connectionFactory);
     }
 
     private static ConnectionFactory dummyConnectionFactory() {

--- a/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/jta/ForageJmsTransactionManagementAutoConfiguration.java
+++ b/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/jta/ForageJmsTransactionManagementAutoConfiguration.java
@@ -2,10 +2,14 @@ package io.kaoto.forage.springboot.jms.jta;
 
 import jakarta.annotation.PostConstruct;
 
+import org.apache.camel.spi.ComponentCustomizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.jta.JtaTransactionManager;
+import io.kaoto.forage.jms.common.transactions.JmsJtaTransactionSupport;
 import io.kaoto.forage.springboot.common.jta.ConditionalOnAnyForageTransactionEnabled;
 
 @Configuration
@@ -19,5 +23,15 @@ public class ForageJmsTransactionManagementAutoConfiguration
     @PostConstruct
     public void init() {
         log.info("ForageJmsTransactionManagementAutoConfiguration initialized - transaction management enabled");
+    }
+
+    /**
+     * Sets the JTA transaction manager on the Camel JMS component so the message listener
+     * container starts a JTA transaction around {@code receive()} and XA sessions enlist in
+     * it (#427). Applied by Camel to every {@code JmsComponent} added to the context.
+     */
+    @Bean
+    public ComponentCustomizer forageJmsTransactionManagerCustomizer(JtaTransactionManager jtaTransactionManager) {
+        return JmsJtaTransactionSupport.jmsComponentCustomizer(jtaTransactionManager);
     }
 }

--- a/tests/plans/jms-messaging.md
+++ b/tests/plans/jms-messaging.md
@@ -206,6 +206,10 @@ cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
         repeatCount: 3
         period: "5000"
       steps:
+        # sends must run inside a JTA transaction with XA: unenlisted sends on the
+        # XA pool are silently discarded by brokers such as IBM MQ (see #427)
+        - transacted:
+            ref: PROPAGATION_REQUIRED
         - setBody:
             simple:
               expression: "Transactional message ${exchangeProperty.CamelTimerCounter}"

--- a/tests/plans/jms-messaging.md
+++ b/tests/plans/jms-messaging.md
@@ -227,7 +227,8 @@ cat > "${PROJECT_DIR}/route.camel.yaml" <<'ROUTE'
       parameters:
         destinationName: input.queue
         destinationType: queue
-        transacted: "true"
+        # transacted stays false with XA: the JTA transaction manager wired into the
+        # JMS component drives the transaction (see #427)
         cacheLevelName: CACHE_NONE
       steps:
         - transacted:

--- a/website/docs/examples/jms/transactional.md
+++ b/website/docs/examples/jms/transactional.md
@@ -52,7 +52,10 @@ forage.myBroker.jms.transaction.object.store.directory=tx-object-store
 forage.myBroker.jms.transaction.object.store.type=file-system
 ```
 
-Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAConnectionFactory` instead of a regular `ConnectionFactory`, initializes the Narayana transaction manager, and registers JTA transaction policies (`PROPAGATION_REQUIRED`, `PROPAGATION_REQUIRES_NEW`, etc.) in the Camel registry.
+Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAConnectionFactory` instead of a regular `ConnectionFactory` (pooled through an XA-aware pool that enlists sessions in the transaction), initializes the Narayana transaction manager, registers JTA transaction policies (`PROPAGATION_REQUIRED`, `PROPAGATION_REQUIRES_NEW`, etc.) in the Camel registry, and configures the Camel JMS component with a JTA transaction manager so every consumer receives its messages inside a JTA transaction.
+
+!!! warning "Do not set `transacted=true` on JMS endpoints when XA is enabled"
+    With `transaction.enabled=true` the JTA transaction manager wired into the JMS component drives the transaction. Setting `transacted: "true"` on an endpoint would additionally start a *local* JMS transaction on the XA connection, which brokers such as IBM MQ reject (`MQRC_SYNCPOINT_NOT_AVAILABLE`, reason code 2072). Leave `transacted` at its default (`false`).
 
 ## Route
 
@@ -86,7 +89,6 @@ Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAC
           parameters:
             destinationName: input.queue
             destinationType: queue
-            transacted: "true"
             cacheLevelName: CACHE_NONE
           steps:
             - transacted:
@@ -154,7 +156,7 @@ Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAC
                     .log("Sent message to input queue");
 
             // Transactional consumer - processes messages within XA transaction
-            from("jms:queue:input.queue?transacted=true")
+            from("jms:queue:input.queue?cacheLevelName=CACHE_NONE")
                     .transacted("PROPAGATION_REQUIRED")
                     .log("Processing message: ${body}")
                     .choice()
@@ -187,9 +189,9 @@ The example has four routes:
 
 Key points in the transactional consumer:
 
-- `transacted: "true"` on the JMS endpoint tells Camel to use transacted message acknowledgment.
+- The JMS endpoint does **not** set `transacted=true` -- the JTA transaction manager that Forage wires into the JMS component starts a JTA transaction around each receive, and the XA session enlists in it. A local JMS transaction would conflict with XA (IBM MQ rejects it with reason code 2072).
 - `cacheLevelName: CACHE_NONE` is required for XA transactions to prevent stale session caching.
-- `transacted` with `ref: PROPAGATION_REQUIRED` joins an existing transaction or creates a new one.
+- `transacted` with `ref: PROPAGATION_REQUIRED` joins the transaction started by the consumer (or creates a new one when there is none).
 
 ## Running
 
@@ -203,7 +205,7 @@ You can also monitor queue depths in the Artemis web console at `http://localhos
 
 ## Key Takeaways
 
-- **One property enables XA** -- setting `transaction.enabled=true` switches from plain `ConnectionFactory` to `XAConnectionFactory` and wires up Narayana automatically.
+- **One property enables XA** -- setting `transaction.enabled=true` switches from plain `ConnectionFactory` to a pooled `XAConnectionFactory`, wires up Narayana, and configures the Camel JMS component with a JTA transaction manager automatically.
 - **Transaction policies are auto-registered** -- `PROPAGATION_REQUIRED`, `PROPAGATION_REQUIRES_NEW`, and others are available in the registry without any Java configuration.
 - **Rollback is automatic** -- any exception within a transacted route causes a full rollback; the message returns to the queue for redelivery.
 - **DLQ safety net** -- after the broker's maximum redelivery attempts, messages move to the dead letter queue rather than being lost.

--- a/website/docs/examples/jms/transactional.md
+++ b/website/docs/examples/jms/transactional.md
@@ -57,12 +57,20 @@ Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAC
 !!! warning "Do not set `transacted=true` on JMS endpoints when XA is enabled"
     With `transaction.enabled=true` the JTA transaction manager wired into the JMS component drives the transaction. Setting `transacted: "true"` on an endpoint would additionally start a *local* JMS transaction on the XA connection, which brokers such as IBM MQ reject (`MQRC_SYNCPOINT_NOT_AVAILABLE`, reason code 2072). Leave `transacted` at its default (`false`).
 
+!!! warning "Producers must send inside a JTA transaction"
+    With XA enabled the pool always hands out XA sessions. A send that runs outside a JTA
+    transaction is never enlisted: on IBM MQ it lands in a local syncpoint unit of work that is
+    never committed, so the message is **silently discarded** (ActiveMQ Artemis auto-commits
+    such sends, masking the problem). Start every producer route with a `transacted` step, as
+    the producer route below does.
+
 ## Route
 
 === "YAML"
 
     ```yaml
-    # Producer — sends a message to input.queue every 5 seconds
+    # Producer — sends a message to input.queue every 5 seconds,
+    # inside a JTA transaction so the XA send is committed
     - route:
         id: producer-route
         from:
@@ -70,6 +78,8 @@ Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAC
           parameters:
             period: "5000"
           steps:
+            - transacted:
+                ref: PROPAGATION_REQUIRED
             - setBody:
                 simple:
                   expression: Transactional message
@@ -149,8 +159,10 @@ Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAC
         @Override
         public void configure() throws Exception {
 
-            // Producer - sends messages to input queue
+            // Producer - sends messages to input queue inside a JTA
+            // transaction so the XA send is committed
             from("timer:producer?period=10000")
+                    .transacted("PROPAGATION_REQUIRED")
                     .setBody(constant("Transactional message"))
                     .to("jms:queue:input.queue")
                     .log("Sent message to input queue");
@@ -182,7 +194,7 @@ Setting `transaction.enabled=true` changes Forage's behavior: it creates an `XAC
 
 The example has four routes:
 
-1. **Producer** -- a timer sends messages to `input.queue` at a fixed interval.
+1. **Producer** -- a timer sends messages to `input.queue` at a fixed interval, inside its own JTA transaction so the XA send commits.
 2. **Transactional consumer** -- consumes from `input.queue` within an XA transaction. Roughly 30% of messages trigger a simulated error, causing the transaction to roll back. Successful messages are forwarded to `output.queue`.
 3. **Output consumer** -- logs messages that completed the transaction successfully.
 4. **DLQ consumer** -- logs messages that exhausted the broker's maximum redelivery attempts.

--- a/website/docs/examples/transactions/distributed-xa.md
+++ b/website/docs/examples/transactions/distributed-xa.md
@@ -97,7 +97,9 @@ The critical detail is the shared `transaction.node.id=xa-node1` across both JMS
       uri: jms
       parameters:
         destinationName: in
-        transacted: true
+        # transacted stays false with XA: the JTA transaction manager wired into the
+        # JMS component drives the transaction (a local JMS transaction on an XA
+        # connection is rejected by brokers such as IBM MQ)
         cacheLevelName: CACHE_NONE
       steps:
         - transacted:

--- a/website/docs/examples/transactions/distributed-xa.md
+++ b/website/docs/examples/transactions/distributed-xa.md
@@ -152,7 +152,10 @@ The critical detail is the shared `transaction.node.id=xa-node1` across both JMS
                     message: End transaction with message ${body}
 
 # Message generator — produces test messages every 5 seconds,
-# ~40% are ROLLBACK messages to demonstrate rollback behavior
+# ~40% are ROLLBACK messages to demonstrate rollback behavior.
+# The transacted step is required: with XA enabled, sends outside a JTA
+# transaction are never enlisted and brokers such as IBM MQ silently
+# discard them (Artemis auto-commits them, masking the problem)
 - route:
     id: message-generator-route
     from:
@@ -160,6 +163,8 @@ The critical detail is the shared `transaction.node.id=xa-node1` across both JMS
       parameters:
         period: "5000"
       steps:
+        - transacted:
+            ref: PROPAGATION_REQUIRED
         - setHeader:
             name: eventId
             simple:

--- a/website/docs/examples/transactions/distributed-xa.md
+++ b/website/docs/examples/transactions/distributed-xa.md
@@ -16,17 +16,34 @@ A single XA transaction spanning both JMS and JDBC, demonstrating two-phase comm
 - Java 17 or later
 - [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) with the Forage plugin installed
 
-Start PostgreSQL and ActiveMQ Artemis:
+Start ActiveMQ Artemis:
 
 ```bash
-camel infra run postgres
 camel infra run artemis
 ```
+
+Start PostgreSQL with prepared transactions enabled:
+
+```bash
+docker run -d --name camel-postgres -p 5432:5432 \
+  -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=postgres \
+  postgres:16 -c max_prepared_transactions=100
+```
+
+!!! warning "PostgreSQL must allow prepared transactions"
+    A transaction spanning two resources uses two-phase commit: Narayana issues
+    `PREPARE TRANSACTION` against PostgreSQL, which fails with
+    `ERROR: prepared transactions are disabled` when `max_prepared_transactions` is `0` —
+    and `0` is both the PostgreSQL default and what `camel infra run postgres` starts with.
+    Start PostgreSQL with `-c max_prepared_transactions=100` as shown above, or on an
+    existing server run `ALTER SYSTEM SET max_prepared_transactions = 100;` and restart it.
+    The single-resource JDBC examples don't need this: with only one participant, Narayana
+    uses the one-phase-commit optimization and never issues `PREPARE TRANSACTION`.
 
 Create the database schema:
 
 ```bash
-docker exec -i camel-postgres psql -U postgres -c \
+docker exec -i camel-postgres psql -U test -d postgres -c \
   "CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, action VARCHAR(255));"
 ```
 

--- a/website/docs/modules/jms.md
+++ b/website/docs/modules/jms.md
@@ -54,3 +54,12 @@ Setting `forage.jms.transaction.enabled=true` switches the module to XA mode:
     transaction on an XA connection is rejected by brokers such as IBM MQ
     (`MQRC_SYNCPOINT_NOT_AVAILABLE`, reason code 2072). Use `cacheLevelName: CACHE_NONE` on
     transactional consumers.
+
+!!! warning "Producers need a transaction too"
+    Any route that *sends* to a `jms:` endpoint must also run inside a JTA transaction (add a
+    `transacted` step before the send). The XA pool always hands out XA sessions, and a send
+    outside a JTA transaction is never enlisted: on IBM MQ it lands in a local syncpoint unit
+    of work that is never committed, so the message is **silently discarded**. ActiveMQ Artemis
+    auto-commits such sends, which can mask the problem until you switch brokers. Consumers are
+    covered automatically — the JTA transaction manager on the component starts a transaction
+    around each delivery.

--- a/website/docs/modules/jms.md
+++ b/website/docs/modules/jms.md
@@ -35,3 +35,22 @@ forage.primaryBroker.jms.url=tcp://broker1:61616
 forage.backupBroker.jms.kind=artemis
 forage.backupBroker.jms.url=tcp://broker2:61617
 ```
+
+## XA Transactions
+
+Setting `forage.jms.transaction.enabled=true` switches the module to XA mode:
+
+- The connection factory becomes an XA-aware pool (`JmsPoolXAConnectionFactory`) that enlists
+  sessions in the Narayana transaction manager.
+- The Narayana transaction manager is initialized from the `forage.jms.transaction.*` properties.
+- JTA transaction policies (`PROPAGATION_REQUIRED`, `REQUIRES_NEW`, ...) are registered in the
+  Camel registry for use with the `transacted` EIP.
+- The Camel JMS component is configured with a JTA transaction manager, so consumers receive
+  each message inside a JTA transaction and a rollback returns the message to the broker.
+
+!!! warning "Endpoint contract"
+    Leave `transacted` at its default (`false`) on `jms:` endpoints. The JTA transaction manager
+    wired into the component drives the transaction; enabling the endpoint's *local* JMS
+    transaction on an XA connection is rejected by brokers such as IBM MQ
+    (`MQRC_SYNCPOINT_NOT_AVAILABLE`, reason code 2072). Use `cacheLevelName: CACHE_NONE` on
+    transactional consumers.


### PR DESCRIPTION
Fixes #427.

## Summary

`forage.jms.transaction.enabled=true` previously created an XA connection factory and initialized Narayana, but nothing made JMS sessions enlist in JTA transactions: the pooled factory wrapped the XA factory as a plain pool, and the Camel JMS component had no transaction manager. PR #415/#417 descoped the pooled-XA part because switching the pool alone breaks IBM MQ (`MQRC_SYNCPOINT_NOT_AVAILABLE`, 2072). This PR lands the complete fix:

- **XA pool (the descoped part of #415/#417)**: `PooledConnectionFactory` now builds a `JmsPoolXAConnectionFactory` wired with Narayana's `TransactionManager`, so sessions created inside a JTA transaction enlist their `XAResource`.
- **Component-level JTA wiring**: new `JmsJtaTransactionSupport` (forage-jms-common) creates a Spring `JtaTransactionManager` backed by the JVM-global Narayana TM plus a `ComponentCustomizer` that sets it on every `JmsComponent`. Camel's `CustomizersLifecycleStrategy` applies registry-provided customizers on all runtimes, so each runtime just registers the bean:
  - **plain Camel**: `ConnectionFactoryBeanFactory` binds `jtaTransactionManager` + the customizer alongside the JTA policies (and unbinds them in `cleanup()`)
  - **Spring Boot**: `@Bean ComponentCustomizer` in `ForageJmsTransactionManagementAutoConfiguration`, reusing the auto-configured `JtaTransactionManager`
  - **Quarkus**: `ForageJmsRecorder.createJmsTransactionManagerCustomizer()` recorded as a `CamelRuntimeBeanBuildItem` when any JMS config enables transactions
- **ConnectionFactory auto-discovery preserved**: camel-jms's `JmsComponent.doInit()` skips its own single-`ConnectionFactory` registry discovery when a transaction manager is set, so the customizer replicates that discovery (endpoints referencing `#name` explicitly are unaffected).
- **Endpoint contract**: with XA enabled, endpoints must NOT set `transacted=true` — the component-level JTA TM drives the transaction; a local JMS transaction on an XA connection is rejected by IBM MQ (MQRC 2072). Documented in `website/docs` (jms module page, transactional + distributed-xa examples), test plans, and applied to `route-ibm.camel.yaml` / `route-artemis.camel.yaml`.

## Integration test hardening

- Artemis IT gains a **rollback assertion**: a route (with `noErrorHandler`) throws on first delivery, so only a real XA rollback returns the message to the broker; the test asserts the broker redelivers it with `JMSRedelivered=true`. With broken XA enlistment the message would be auto-acked and lost, so a broker that tolerates XA misuse (Artemis) can no longer hide regressions.
- The DLQ consumer route now listens on `DLQ` (where the dead letter channel actually sends) instead of the never-used `DLQ2`, and both ITs assert DLQ delivery.
- `JmsIbmMqTest.ibmMqTransactional` remains the strict gate (2072 on any local-transaction misuse).

## Testing

- Unit tests: pooled XA factory + Narayana TM assertions, bean factory wiring test proving the `JmsComponent` receives both the `JtaTransactionManager` and the auto-discovered `ConnectionFactory`.
- `JmsArtemisTest` passes locally on **all three runtimes** (plain, Spring Boot, Quarkus): 1 message commits through to the output queue, 2 are dead-lettered to DLQ inside the XA transaction, and the rollback message is redelivered by the broker after a real XA rollback.
- `JmsIbmMqTest` is disabled on macOS — needs CI to validate the acceptance criteria on IBM MQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled XA transaction support for JMS, with automatic JTA transaction manager integration for Camel JMS components.
  * Added runtime customizer support so JMS components receive the correct transaction manager when transactions are enabled.
* **Bug Fixes**
  * Corrected XA transactional verification to cover commit, rollback behavior, and dead-lettering after max redeliveries.
  * Fixed DLQ consumption to match the configured DLQ destination for both Artemis and IBM MQ scenarios.
* **Documentation**
  * Updated JMS XA docs and examples with clearer rules for route-level transactions and keeping endpoint local transactions disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->