### PR TITLE
chore: align dependency versions for Camel 4.18.3 / CQ 3.33.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <description>A plugin extension for Apache Camel that provides opinionated bean factories</description>
 
     <properties>
-        <camel.version>4.18.2</camel.version>
+        <camel.version>4.18.3</camel.version>
         <langchain4j.version>1.11.0</langchain4j.version>
         <langchain4j-beta.version>1.11.0-beta19</langchain4j-beta.version>
         <langchain4j-community.version>1.11.0-beta19</langchain4j-community.version>
@@ -21,9 +21,9 @@
         <aws-sdk.version>2.44.4</aws-sdk.version>
         <azure.identity.version>1.18.2</azure.identity.version>
         <azure.messaging.eventhubs.version>5.21.4</azure.messaging.eventhubs.version>
-        <camel-quarkus.version>3.33.0</camel-quarkus.version>
+        <camel-quarkus.version>3.33.2</camel-quarkus.version>
         <cxf.version>4.1.5</cxf.version>
-        <quarkiverse-cxf.version>3.33.0</quarkiverse-cxf.version>
+        <quarkiverse-cxf.version>3.33.8</quarkiverse-cxf.version>
         <wiremock.version>3.13.0</wiremock.version>
         <commons-io.version>2.18.0</commons-io.version>
         <citrus.version>4.10.1</citrus.version>
@@ -34,7 +34,7 @@
         <jsonschema-maven-plugin.version>4.38.0</jsonschema-maven-plugin.version>
         <junit-jupiter-suite.version>6.0.3</junit-jupiter-suite.version>
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
@@ -59,16 +59,16 @@
         <pooled-jms.version>3.2.2</pooled-jms.version>
         <postgresql.version>42.7.10</postgresql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.version>3.33.1.1</quarkus.version>
-        <quarkus-artemis-jms.version>3.12.1</quarkus-artemis-jms.version>
+        <quarkus.version>3.33.2.1</quarkus.version>
+        <quarkus-artemis-jms.version>3.13.0</quarkus-artemis-jms.version>
         <quarkus-pooled-jms.version>2.10.0</quarkus-pooled-jms.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <smallrye.version>3.16.0</smallrye.version>
         <spotless.version>3.4.0</spotless.version>
         <palantir-format.version>2.71.0</palantir-format.version>
         <camel-spring-boot.version>${camel.version}</camel-spring-boot.version>
-        <spring-boot.version>3.5.14</spring-boot.version>
-        <spring.version>6.2.17</spring.version>
+        <spring-boot.version>3.5.16</spring-boot.version>
+        <spring.version>6.2.19</spring.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <vertx.version>4.5.26</vertx.version>


### PR DESCRIPTION
## Summary

Aligns dependency versions for the upcoming 1.4.0 release, following the Camel Quarkus 3.33.2 release (which supports Camel 4.18.3).

| Property | Old | New | Source |
|---|---|---|---|
| `camel.version` | 4.18.2 | 4.18.3 | Camel 4.18.3 |
| `camel-quarkus.version` | 3.33.0 | 3.33.2 | CQ 3.33.2 |
| `quarkus.version` | 3.33.1.1 | 3.33.2.1 | CQ 3.33.2 POM |
| `quarkiverse-cxf.version` | 3.33.0 | 3.33.8 | CQ 3.33.2 POM |
| `spring-boot.version` | 3.5.14 | 3.5.16 | Camel 4.18.3 parent |
| `spring.version` | 6.2.17 | 6.2.19 | Camel 4.18.3 parent |
| `slf4j.version` | 2.0.17 | 2.0.18 | Camel 4.18.3 parent |
| `log4j.version` | 2.25.3 | 2.25.4 | Camel 4.18.3 parent |
| `quarkus-artemis-jms.version` | 3.12.1 | 3.13.0 | CQ 3.33.2 POM |

## Test plan

- [x] `mvn clean install` passes
- [x] JDBC integration tests pass on all runtimes (plain, quarkus, spring-boot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying framework and library versions, including Camel, Quarkus, Spring, Log4j, SLF4J, and Artemis JMS.
  * Includes the latest available maintenance and compatibility updates across the application stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->