### PR TITLE
chore: auto-validate Camel CLI and forage plugin versions before integration tests

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -1,9 +1,14 @@
 package io.kaoto.forage.integration.tests;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.camel.actions.CamelActionBuilder;
 import org.citrusframework.context.TestContext;
@@ -173,6 +178,9 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
     }
 
     private void internalBeforeAll(ExtensionContext context, CamelActionBuilder camel) {
+        ensureCamelCliVersion();
+        deleteForagePlugin();
+
         String projectVersion = ExportHelper.getProjectVersion();
         // ensure, that forage plugin is installed
         CitrusExtensionHelper.getTestRunner(context)
@@ -184,6 +192,125 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
                         .withArg("--groupId", "io.kaoto.forage")
                         .withArg("--version", projectVersion)
                         .withArg("--gav", "io.kaoto.forage:camel-jbang-plugin-forage:" + projectVersion));
+    }
+
+    private static final Pattern CAMEL_VERSION_PATTERN = Pattern.compile("Camel (?:CLI|JBang) version:\\s*(\\S+)");
+
+    /**
+     * Validates the installed Camel CLI major.minor matches the project's expected version.
+     * Auto-installs the correct version via JBang if there is a mismatch.
+     */
+    private void ensureCamelCliVersion() {
+        String expectedVersion = ExportHelper.getCamelVersion();
+        String expectedMajorMinor = majorMinor(expectedVersion);
+        if (expectedMajorMinor == null) {
+            LOG.warn("Could not determine expected Camel version from build properties, skipping CLI version check");
+            return;
+        }
+
+        String installedVersion = getInstalledCamelVersion();
+        if (installedVersion == null) {
+            throw new IllegalStateException(
+                    "Camel CLI is not installed. Install it with: jbang app install camel@apache/camel");
+        }
+
+        String installedMajorMinor = majorMinor(installedVersion);
+        if (expectedMajorMinor.equals(installedMajorMinor)) {
+            LOG.info("Camel CLI version {} matches expected major.minor {}", installedVersion, expectedMajorMinor);
+            return;
+        }
+
+        LOG.warn(
+                "Camel CLI version mismatch: installed {}, expected {}. Auto-installing the correct version...",
+                installedVersion,
+                expectedVersion);
+        installCamelCli(expectedVersion);
+    }
+
+    private String getInstalledCamelVersion() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("camel", "version");
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            String output;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = reader.lines().collect(Collectors.joining("\n"));
+            }
+            process.waitFor(15, TimeUnit.SECONDS);
+
+            Matcher matcher = CAMEL_VERSION_PATTERN.matcher(output);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+            LOG.warn("Could not parse Camel CLI version from output: {}", output);
+            return null;
+        } catch (Exception e) {
+            LOG.warn("Failed to check Camel CLI version: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private void installCamelCli(String version) {
+        try {
+            String alias = "camel@apache/camel/camel-" + version;
+            LOG.info("Running: jbang app install --force {}", alias);
+            ProcessBuilder pb = new ProcessBuilder("jbang", "app", "install", "--force", alias);
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            String output;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = reader.lines().collect(Collectors.joining("\n"));
+            }
+            int exitCode = process.waitFor();
+            if (exitCode == 0) {
+                LOG.info("Camel CLI installed successfully: {}", output);
+            } else {
+                throw new IllegalStateException(
+                        "Failed to install Camel CLI version " + version + " (exit code " + exitCode + "): " + output);
+            }
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Failed to install Camel CLI. Run manually: jbang app install --force camel@apache/camel/camel-"
+                            + version,
+                    e);
+        }
+    }
+
+    private static String majorMinor(String version) {
+        if (version == null) {
+            return null;
+        }
+        String[] parts = version.split("\\.");
+        if (parts.length >= 2) {
+            return parts[0] + "." + parts[1];
+        }
+        return null;
+    }
+
+    /**
+     * Removes any previously installed forage plugin to ensure a clean install
+     * with the current build's version.
+     */
+    private void deleteForagePlugin() {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("camel", "plugin", "delete", "forage");
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            String output;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = reader.lines().collect(Collectors.joining("\n"));
+            }
+            int exitCode = process.waitFor();
+            if (exitCode == 0) {
+                LOG.info("Deleted existing forage plugin: {}", output);
+            } else {
+                LOG.debug("No existing forage plugin to delete (exit code {})", exitCode);
+            }
+        } catch (Exception e) {
+            LOG.debug("Could not delete forage plugin (may not exist): {}", e.getMessage());
+        }
     }
 
     @Override

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -210,8 +210,8 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
 
         String installedVersion = getInstalledCamelVersion();
         if (installedVersion == null) {
-            throw new IllegalStateException(
-                    "Camel CLI is not installed. Install it with: jbang app install camel@apache/camel");
+            LOG.info("Camel CLI app is not installed — Citrus invokes JBang directly, skipping version check");
+            return;
         }
 
         String installedMajorMinor = majorMinor(installedVersion);

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -1,6 +1,7 @@
 package io.kaoto.forage.integration.tests;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -231,19 +232,29 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
         try {
             ProcessBuilder pb = new ProcessBuilder("camel", "version");
             pb.redirectErrorStream(true);
-            Process process = pb.start();
+            Process process;
+            try {
+                process = pb.start();
+            } catch (IOException notFound) {
+                LOG.info("Camel CLI executable not found on PATH: {}", notFound.getMessage());
+                return null;
+            }
             String output;
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                 output = reader.lines().collect(Collectors.joining("\n"));
             }
-            process.waitFor(15, TimeUnit.SECONDS);
+            if (!process.waitFor(15, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                LOG.warn("Camel CLI version check timed out");
+                return null;
+            }
 
             Matcher matcher = CAMEL_VERSION_PATTERN.matcher(output);
             if (matcher.find()) {
                 return matcher.group(1);
             }
             LOG.warn("Could not parse Camel CLI version from output: {}", output);
-            return null;
+            return "BROKEN";
         } catch (Exception e) {
             LOG.warn("Failed to check Camel CLI version: {}", e.getMessage());
             return null;
@@ -252,16 +263,21 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
 
     private void installCamelCli(String version) {
         try {
-            String alias = "camel@apache/camel/camel-" + version;
-            LOG.info("Running: jbang app install --force {}", alias);
-            ProcessBuilder pb = new ProcessBuilder("jbang", "app", "install", "--force", alias);
+            LOG.info("Running: jbang app install --force -Dcamel.jbang.version={} camel@apache/camel", version);
+            ProcessBuilder pb = new ProcessBuilder(
+                    "jbang", "app", "install", "--force",
+                    "-Dcamel.jbang.version=" + version, "camel@apache/camel");
             pb.redirectErrorStream(true);
             Process process = pb.start();
             String output;
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                 output = reader.lines().collect(Collectors.joining("\n"));
             }
-            int exitCode = process.waitFor();
+            if (!process.waitFor(120, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                throw new IllegalStateException("Camel CLI installation timed out after 120 seconds");
+            }
+            int exitCode = process.exitValue();
             if (exitCode == 0) {
                 LOG.info("Camel CLI installed successfully: {}", output);
             } else {
@@ -272,8 +288,8 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
             throw e;
         } catch (Exception e) {
             throw new IllegalStateException(
-                    "Failed to install Camel CLI. Run manually: jbang app install --force camel@apache/camel/camel-"
-                            + version,
+                    "Failed to install Camel CLI. Run manually: jbang app install --force -Dcamel.jbang.version="
+                            + version + " camel@apache/camel",
                     e);
         }
     }
@@ -302,7 +318,12 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                 output = reader.lines().collect(Collectors.joining("\n"));
             }
-            int exitCode = process.waitFor();
+            if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                LOG.warn("Forage plugin delete timed out");
+                return;
+            }
+            int exitCode = process.exitValue();
             if (exitCode == 0) {
                 LOG.info("Deleted existing forage plugin: {}", output);
             } else {


### PR DESCRIPTION
## Summary

- Auto-checks the installed Camel CLI major.minor against the project's expected version and reinstalls via JBang if mismatched
- Deletes any stale forage JBang plugin before re-adding with the current build's version
- Prevents cryptic `NoClassDefFoundError` failures caused by CLI/plugin version drift across branches

## Test plan

- [x] Install wrong Camel CLI (`jbang app install --force camel@apache/camel/camel-4.21.0`), run integration tests — CLI auto-corrected, tests pass
- [x] Run with correct CLI already installed — no reinstall, tests pass
- [x] Switch from `camel-latest` to `main`, run tests — stale 1.5.0-SNAPSHOT plugin replaced with 1.4.0-SNAPSHOT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integration setup now verifies that the expected Camel CLI version is installed.
  * Automatically installs the required CLI version when a mismatch is detected.
  * Ensures previously installed Forage plugins are removed before installation for cleaner, more reliable setup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->