### PR TITLE
Fix #457: Quarkus processors fail to discover forage prefixes at augmentation time

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageQuarkusConfigSourceAdapter.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageQuarkusConfigSourceAdapter.java
@@ -18,6 +18,7 @@ import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.core.util.config.PropertyFileLocator;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.ConfigValue;
 
 /**
  * Generic SmallRye {@link ConfigSourceFactory} adapter that translates Forage properties
@@ -59,24 +60,20 @@ public abstract class ForageQuarkusConfigSourceAdapter<C extends Config> impleme
         Map<String, String> configuration = new HashMap<>();
 
         String defaultRegexp = ConfigHelper.getDefaultPropertyRegexp(desc.modulePrefix());
-        boolean hasDefault = false;
         if (!prefixes.isEmpty()) {
             for (String name : prefixes) {
                 C config = desc.createConfig(name);
                 configuration.putAll(desc.translateProperties(name, config));
+                registerContextProperties(context, config, desc.modulePrefix(), name);
             }
         } else if (!ConfigStore.getInstance()
                         .readPrefixes(defaultConfig, defaultRegexp)
                         .isEmpty()
                 || !discoverPrefixesFromContext(context, defaultRegexp).isEmpty()) {
-            hasDefault = true;
             configuration.putAll(desc.translateProperties(null, defaultConfig));
+            registerContextProperties(context, defaultConfig, desc.modulePrefix(), null);
         } else {
             LOG.trace("No {} config found.", desc.modulePrefix());
-        }
-
-        if (prefixes.isEmpty() && hasDefault) {
-            DISCOVERED_PREFIXES.put(desc.modulePrefix(), Set.of("__default__"));
         }
 
         if (configuration.isEmpty()) {
@@ -111,6 +108,45 @@ public abstract class ForageQuarkusConfigSourceAdapter<C extends Config> impleme
             }
         }
         return prefixes;
+    }
+
+    /**
+     * Registers property values from the SmallRye {@link ConfigSourceContext} into the
+     * {@link ConfigStore} so that deployment processors can read them during augmentation.
+     *
+     * <p>Newer Quarkus versions no longer expose {@code application.properties} through
+     * {@code ConfigProvider.getConfig()} at augmentation time, but the {@link ConfigSourceContext}
+     * (available during config bootstrap) still sees all config sources. This method bridges
+     * that gap by eagerly storing the values into the singleton {@link ConfigStore}.
+     */
+    private void registerContextProperties(
+            ConfigSourceContext context, C config, String modulePrefix, String namedPrefix) {
+
+        String foragePrefixDot;
+        if (namedPrefix != null) {
+            foragePrefixDot = "forage." + namedPrefix + "." + modulePrefix + ".";
+        } else {
+            foragePrefixDot = "forage." + modulePrefix + ".";
+        }
+
+        Iterator<String> names = context.iterateNames();
+        while (names.hasNext()) {
+            String rawName = names.next();
+            String name = rawName;
+            if (rawName.startsWith("%")) {
+                int dot = rawName.indexOf('.');
+                if (dot < 0) {
+                    continue;
+                }
+                name = rawName.substring(dot + 1);
+            }
+            if (name.startsWith(foragePrefixDot)) {
+                ConfigValue cv = context.getValue(rawName);
+                if (cv != null && cv.getValue() != null) {
+                    config.register(name, cv.getValue());
+                }
+            }
+        }
     }
 
     /**

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageQuarkusConfigSourceAdapter.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/common/ForageQuarkusConfigSourceAdapter.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -36,6 +37,8 @@ public abstract class ForageQuarkusConfigSourceAdapter<C extends Config> impleme
 
     private static final Logger LOG = LoggerFactory.getLogger(ForageQuarkusConfigSourceAdapter.class);
 
+    private static final Map<String, Set<String>> DISCOVERED_PREFIXES = new ConcurrentHashMap<>();
+
     /**
      * Returns the module descriptor that provides module-specific knowledge.
      */
@@ -51,9 +54,12 @@ public abstract class ForageQuarkusConfigSourceAdapter<C extends Config> impleme
         Set<String> prefixes = new HashSet<>(ConfigStore.getInstance().readPrefixes(defaultConfig, namedRegexp));
         prefixes.addAll(discoverPrefixesFromContext(context, namedRegexp));
 
+        DISCOVERED_PREFIXES.put(desc.modulePrefix(), Set.copyOf(prefixes));
+
         Map<String, String> configuration = new HashMap<>();
 
         String defaultRegexp = ConfigHelper.getDefaultPropertyRegexp(desc.modulePrefix());
+        boolean hasDefault = false;
         if (!prefixes.isEmpty()) {
             for (String name : prefixes) {
                 C config = desc.createConfig(name);
@@ -63,9 +69,14 @@ public abstract class ForageQuarkusConfigSourceAdapter<C extends Config> impleme
                         .readPrefixes(defaultConfig, defaultRegexp)
                         .isEmpty()
                 || !discoverPrefixesFromContext(context, defaultRegexp).isEmpty()) {
+            hasDefault = true;
             configuration.putAll(desc.translateProperties(null, defaultConfig));
         } else {
             LOG.trace("No {} config found.", desc.modulePrefix());
+        }
+
+        if (prefixes.isEmpty() && hasDefault) {
+            DISCOVERED_PREFIXES.put(desc.modulePrefix(), Set.of("__default__"));
         }
 
         if (configuration.isEmpty()) {
@@ -100,6 +111,19 @@ public abstract class ForageQuarkusConfigSourceAdapter<C extends Config> impleme
             }
         }
         return prefixes;
+    }
+
+    /**
+     * Returns prefixes discovered during config source assembly for the given module.
+     * Deployment processors call this to find prefixes that were discovered from
+     * the SmallRye {@link ConfigSourceContext} during the config bootstrap phase,
+     * which runs before augmentation build steps.
+     *
+     * @param modulePrefix the module prefix (e.g., "cxf", "agent")
+     * @return discovered prefixes, or empty set if none found
+     */
+    public static Set<String> getDiscoveredPrefixes(String modulePrefix) {
+        return DISCOVERED_PREFIXES.getOrDefault(modulePrefix, Collections.emptySet());
     }
 
     private static String capitalize(String s) {

--- a/library/ai/agents/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/agent/deployment/ForageAgentProcessor.java
+++ b/library/ai/agents/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/agent/deployment/ForageAgentProcessor.java
@@ -14,6 +14,7 @@ import io.kaoto.forage.agent.AgentModuleDescriptor;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
 import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.quarkus.agent.ForageAgentRecorder;
@@ -48,6 +49,9 @@ public class ForageAgentProcessor {
         AgentConfig defaultConfig = DESCRIPTOR.createConfig(null);
         Set<String> prefixes = ConfigStore.getInstance()
                 .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+        if (prefixes.isEmpty()) {
+            prefixes = ForageQuarkusConfigSourceAdapter.getDiscoveredPrefixes(DESCRIPTOR.modulePrefix());
+        }
 
         Map<String, AgentConfig> configs = prefixes.isEmpty()
                 ? Collections.singletonMap(DESCRIPTOR.defaultBeanName(), DESCRIPTOR.createConfig(null))

--- a/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
+++ b/library/cxf/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/cxf/deployment/ForageCxfProcessor.java
@@ -9,6 +9,7 @@ import org.jboss.logging.Logger;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
 import io.kaoto.forage.core.util.config.ConfigEntries;
 import io.kaoto.forage.core.util.config.ConfigEntry;
 import io.kaoto.forage.core.util.config.ConfigHelper;
@@ -60,6 +61,9 @@ public class ForageCxfProcessor {
         CxfConfig defaultConfig = DESCRIPTOR.createConfig(null);
         Set<String> named = ConfigStore.getInstance()
                 .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+        if (named.isEmpty()) {
+            named = ForageQuarkusConfigSourceAdapter.getDiscoveredPrefixes(DESCRIPTOR.modulePrefix());
+        }
 
         if (!named.isEmpty()) {
             for (String name : named) {

--- a/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/io/kaoto/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
+++ b/library/jdbc/camel-quarkus/jdbc/deployment/src/main/java/io/kaoto/forage/quarkus/jdbc/deployment/ForageJdbcProcessor.java
@@ -10,6 +10,7 @@ import org.jboss.logging.Logger;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
 import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.jdbc.common.DataSourceFactoryConfig;
@@ -54,6 +55,9 @@ public class ForageJdbcProcessor {
         DataSourceFactoryConfig defaultConfig = DESCRIPTOR.createConfig(null);
         Set<String> namedPrefixes = ConfigStore.getInstance()
                 .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+        if (namedPrefixes.isEmpty()) {
+            namedPrefixes = ForageQuarkusConfigSourceAdapter.getDiscoveredPrefixes(DESCRIPTOR.modulePrefix());
+        }
 
         if (!namedPrefixes.isEmpty()) {
             for (String prefix : namedPrefixes) {

--- a/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
+++ b/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
 import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
@@ -93,6 +94,9 @@ public class ForageJmsProcessor {
         ConnectionFactoryConfig defaultConfig = DESCRIPTOR.createConfig(null);
         Set<String> named = ConfigStore.getInstance()
                 .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+        if (named.isEmpty()) {
+            named = ForageQuarkusConfigSourceAdapter.getDiscoveredPrefixes(DESCRIPTOR.modulePrefix());
+        }
 
         if (!named.isEmpty()) {
             return named.stream().collect(Collectors.toMap(n -> n, DESCRIPTOR::createConfig));

--- a/library/messaging/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/deployment/ForageSpringRabbitMQProcessor.java
+++ b/library/messaging/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/deployment/ForageSpringRabbitMQProcessor.java
@@ -11,6 +11,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
 import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.core.util.config.ConfigStore;
 import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConfig;
@@ -60,6 +61,9 @@ public class ForageSpringRabbitMQProcessor {
         SpringRabbitMQConfig defaultConfig = DESCRIPTOR.createConfig(null);
         Set<String> named = ConfigStore.getInstance()
                 .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DESCRIPTOR.modulePrefix()));
+        if (named.isEmpty()) {
+            named = ForageQuarkusConfigSourceAdapter.getDiscoveredPrefixes(DESCRIPTOR.modulePrefix());
+        }
 
         Map<String, SpringRabbitMQConfig> configs;
         if (!named.isEmpty()) {

--- a/library/messaging/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/ForageSpringRabbitMQConfigSourceFactory.java
+++ b/library/messaging/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/messaging/springrabbitmq/ForageSpringRabbitMQConfigSourceFactory.java
@@ -1,0 +1,14 @@
+package io.kaoto.forage.quarkus.messaging.springrabbitmq;
+
+import io.kaoto.forage.core.common.ForageModuleDescriptor;
+import io.kaoto.forage.core.common.ForageQuarkusConfigSourceAdapter;
+import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQConfig;
+import io.kaoto.forage.messaging.spring.rabbitmq.common.SpringRabbitMQModuleDescriptor;
+
+public class ForageSpringRabbitMQConfigSourceFactory extends ForageQuarkusConfigSourceAdapter<SpringRabbitMQConfig> {
+
+    @Override
+    protected ForageModuleDescriptor<SpringRabbitMQConfig, ?> descriptor() {
+        return new SpringRabbitMQModuleDescriptor();
+    }
+}

--- a/library/messaging/camel-quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceFactory
+++ b/library/messaging/camel-quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceFactory
@@ -1,0 +1,1 @@
+io.kaoto.forage.quarkus.messaging.springrabbitmq.ForageSpringRabbitMQConfigSourceFactory


### PR DESCRIPTION
## Summary

- Cache prefixes discovered by `ForageQuarkusConfigSourceAdapter` (which has access to `ConfigSourceContext` and sees all property names) in a static map
- All Quarkus deployment processors (CXF, Agent, JMS, JDBC, RabbitMQ) fall back to this cache when `ConfigStore.readPrefixes()` returns empty at augmentation time
- Add missing `ConfigSourceFactory` for the Spring RabbitMQ Quarkus module

## Root Cause

Newer Quarkus versions no longer expose `application.properties` through `ConfigProvider.getConfig()` during build-time augmentation. The `ForageQuarkusConfigSourceAdapter` has always worked correctly (it uses `ConfigSourceContext.iterateNames()` which sees all config sources), but its discovery results were discarded for modules whose `translateProperties()` returns an empty map (CXF, RabbitMQ). The deployment processors relied solely on `ConfigStore.readPrefixes()` which uses the build-time SmallRye config — now empty for `forage.*` keys.

JDBC and JMS were unaffected because their `ConfigSourceFactory` translates to native Quarkus properties (`quarkus.datasource.*`, `quarkus.artemis.*`) and the Quarkus extensions (Agroal, Artemis) create beans from those translated properties.

## Test plan

- [x] CXF Quarkus export (`cxf/soap-server`) now starts successfully — `helloServer` and `helloClient` beans registered
- [x] `forage-core-common` unit tests pass (58 tests)
- [x] Full project builds cleanly
- [ ] Run full `./test-examples.sh export` from forage-examples for regression check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spring RabbitMQ configuration-source support.
  * Spring RabbitMQ settings can now be discovered from Quarkus configuration sources.
  * Improved discovery of named configurations for agent, CXF, JDBC, JMS, and RabbitMQ integrations.
* **Bug Fixes**
  * Configuration values available through Quarkus context are now recognized during application setup.
  * Added fallback handling when configuration prefixes are not found through the primary configuration store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->