### PR TITLE
feat: add HomeDirectoryPropertyFileSource (backport #428 to camel-latest)

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSource.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSource.java
@@ -1,0 +1,63 @@
+package io.kaoto.forage.core.util.config;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class HomeDirectoryPropertyFileSource implements PropertyFileSource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HomeDirectoryPropertyFileSource.class);
+
+    static final String PROPERTY = "forage.home.dir";
+    static final String ENV_VAR = "FORAGE_HOME_DIR";
+
+    private final Supplier<String> homeDirSupplier;
+
+    HomeDirectoryPropertyFileSource() {
+        this(HomeDirectoryPropertyFileSource::resolveHomeDir);
+    }
+
+    HomeDirectoryPropertyFileSource(Supplier<String> homeDirSupplier) {
+        this.homeDirSupplier = homeDirSupplier;
+    }
+
+    @Override
+    public InputStream locate(String fileName) {
+        String homeDir = homeDirSupplier.get();
+        if (homeDir != null) {
+            Path file = Path.of(homeDir, fileName).toAbsolutePath();
+            if (file.toFile().exists()) {
+                try {
+                    LOG.info("Loading {} from home directory ({})", fileName, homeDir);
+                    return new FileInputStream(file.toFile());
+                } catch (IOException e) {
+                    LOG.debug("Failed to load {} from home directory ({})", fileName, homeDir, e);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public int priority() {
+        return 150;
+    }
+
+    static String resolveHomeDir() {
+        String homeDir = System.getProperty(PROPERTY);
+        if (homeDir == null) {
+            homeDir = System.getenv(ENV_VAR);
+        }
+        if (homeDir == null) {
+            String userHome = System.getProperty("user.home");
+            if (userHome != null) {
+                homeDir = Path.of(userHome, ".forage").toString();
+            }
+        }
+        return homeDir;
+    }
+}

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/PropertyFileLocator.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/PropertyFileLocator.java
@@ -27,8 +27,9 @@ import org.slf4j.LoggerFactory;
  * <p><strong>Filesystem resolution order:</strong>
  * <ol>
  *   <li>Current working directory</li>
- *   <li>{@code forage.config.dir} system property</li>
- *   <li>{@code FORAGE_CONFIG_DIR} environment variable</li>
+ *   <li>{@code forage.config.dir} system property / {@code FORAGE_CONFIG_DIR} environment variable</li>
+ *   <li>User home directory ({@code $HOME/.forage/} by default, override with {@code forage.home.dir} or {@code FORAGE_HOME_DIR})</li>
+ *   <li>Classpath resources</li>
  *   <li>Pluggable sources discovered via {@link PluggablePropertyFileSourceLoader}</li>
  * </ol>
  *
@@ -51,6 +52,7 @@ public final class PropertyFileLocator {
         List<PropertyFileSource> sources = new ArrayList<>();
         sources.add(new WorkingDirectoryPropertyFileSource());
         sources.add(new ConfigDirPropertyFileSource());
+        sources.add(new HomeDirectoryPropertyFileSource());
         sources.add(new ClassPathPropertyFileSource());
         sources.sort(Comparator.comparingInt(PropertyFileSource::priority).reversed());
         BUILT_IN_SOURCES = List.copyOf(sources);
@@ -78,7 +80,7 @@ public final class PropertyFileLocator {
      * Attempts to open a properties file by consulting all registered
      * {@link PropertyFileSource} instances (built-in and pluggable) in priority order.
      *
-     * <p>Built-in sources (working directory, config directory, classpath) are tried first,
+     * <p>Built-in sources (working directory, config directory, user home directory, classpath) are tried first,
      * followed by any {@link PluggablePropertyFileSource} implementations discovered via
      * {@link java.util.ServiceLoader}.
      *

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSourceTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSourceTest.java
@@ -1,0 +1,69 @@
+package io.kaoto.forage.core.util.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HomeDirectoryPropertyFileSourceTest {
+
+    @Test
+    @DisplayName("Priority is 150 — between config dir and classpath")
+    void hasExpectedPriority() {
+        HomeDirectoryPropertyFileSource source = new HomeDirectoryPropertyFileSource();
+        assertThat(source.priority()).isEqualTo(150);
+    }
+
+    @Test
+    @DisplayName("resolveHomeDir returns $HOME/.forage when no override is set")
+    void resolvesDefaultHomeDirectory() {
+        String env = System.getenv(HomeDirectoryPropertyFileSource.ENV_VAR);
+        if (env != null) {
+            return;
+        }
+        String prop = System.getProperty(HomeDirectoryPropertyFileSource.PROPERTY);
+        try {
+            if (prop != null) {
+                return;
+            }
+            String resolved = HomeDirectoryPropertyFileSource.resolveHomeDir();
+            assertThat(resolved).isNotNull();
+            assertThat(resolved).endsWith(".forage");
+        } finally {
+            if (prop != null) {
+                System.setProperty(HomeDirectoryPropertyFileSource.PROPERTY, prop);
+            } else {
+                System.clearProperty(HomeDirectoryPropertyFileSource.PROPERTY);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Uses the injected supplier to resolve the home directory")
+    void usesInjectedSupplier() throws IOException {
+        Path customDir = Files.createTempDirectory("forage-home-test");
+        HomeDirectoryPropertyFileSource source = new HomeDirectoryPropertyFileSource(() -> customDir.toString());
+        assertThat(source.priority()).isEqualTo(150);
+
+        Path propsFile = customDir.resolve("my-app.properties");
+        Files.writeString(propsFile, "key=value\n");
+
+        try (InputStream is = source.locate("my-app.properties")) {
+            assertThat(is).isNotNull();
+            String content = new String(is.readAllBytes());
+            assertThat(content).contains("key=value");
+        }
+    }
+
+    @Test
+    @DisplayName("Returns null when the requested file does not exist in the supplied directory")
+    void locateReturnsNullForMissingFile() {
+        HomeDirectoryPropertyFileSource source =
+                new HomeDirectoryPropertyFileSource(() -> "/nonexistent-dir-" + System.nanoTime());
+        assertThat(source.locate("anything.properties")).isNull();
+    }
+}

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/PropertyFileLocatorTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/PropertyFileLocatorTest.java
@@ -161,10 +161,11 @@ class PropertyFileLocatorTest {
     @Test
     void builtInSourcesContainExpectedTypes() {
         List<PropertyFileSource> sources = PropertyFileLocator.getBuiltInSources();
-        assertThat(sources).hasSize(3);
+        assertThat(sources).hasSize(4);
         assertThat(sources.get(0)).isInstanceOf(WorkingDirectoryPropertyFileSource.class);
         assertThat(sources.get(1)).isInstanceOf(ConfigDirPropertyFileSource.class);
-        assertThat(sources.get(2)).isInstanceOf(ClassPathPropertyFileSource.class);
+        assertThat(sources.get(2)).isInstanceOf(HomeDirectoryPropertyFileSource.class);
+        assertThat(sources.get(3)).isInstanceOf(ClassPathPropertyFileSource.class);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Backport of #428 to `camel-latest`
- Adds `HomeDirectoryPropertyFileSource` for locating property files in the user's home configuration directory (`~/.forage/`)
- The home directory can be customized through a system property or environment variable
- Configuration lookup now checks the home directory before the configured system directory

Closes: #305