### PR TITLE
Fix #299 (backport): path traversal protection in ConfigDirPropertyFileSource

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigDirPropertyFileSource.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigDirPropertyFileSource.java
@@ -38,7 +38,17 @@ public final class ConfigDirPropertyFileSource implements PropertyFileSource {
     public InputStream locate(String fileName) {
         String configDir = configDirSupplier.get();
         if (configDir != null) {
-            File file = Path.of(configDir, fileName).toAbsolutePath().toFile();
+            Path resolvedPath = Path.of(configDir, fileName).toAbsolutePath().normalize();
+            Path configDirPath = Path.of(configDir).toAbsolutePath().normalize();
+            if (!resolvedPath.startsWith(configDirPath)) {
+                LOG.warn(
+                        "Rejected path traversal attempt for file '{}': resolved path '{}' escapes config dir '{}'",
+                        fileName,
+                        resolvedPath,
+                        configDirPath);
+                return null;
+            }
+            File file = resolvedPath.toFile();
             if (file.exists()) {
                 try {
                     LOG.debug("Loading {} from config dir: {}", fileName, file.getAbsolutePath());

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSource.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSource.java
@@ -29,11 +29,20 @@ final class HomeDirectoryPropertyFileSource implements PropertyFileSource {
     public InputStream locate(String fileName) {
         String homeDir = homeDirSupplier.get();
         if (homeDir != null) {
-            Path file = Path.of(homeDir, fileName).toAbsolutePath();
-            if (file.toFile().exists()) {
+            Path resolvedPath = Path.of(homeDir, fileName).toAbsolutePath().normalize();
+            Path homeDirPath = Path.of(homeDir).toAbsolutePath().normalize();
+            if (!resolvedPath.startsWith(homeDirPath)) {
+                LOG.warn(
+                        "Rejected path traversal attempt for file '{}': resolved path '{}' escapes home dir '{}'",
+                        fileName,
+                        resolvedPath,
+                        homeDirPath);
+                return null;
+            }
+            if (resolvedPath.toFile().exists()) {
                 try {
                     LOG.info("Loading {} from home directory ({})", fileName, homeDir);
-                    return new FileInputStream(file.toFile());
+                    return new FileInputStream(resolvedPath.toFile());
                 } catch (IOException e) {
                     LOG.debug("Failed to load {} from home directory ({})", fileName, homeDir, e);
                 }

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/ConfigDirPropertyFileSourceTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/ConfigDirPropertyFileSourceTest.java
@@ -45,4 +45,11 @@ class ConfigDirPropertyFileSourceTest {
         }
         assertThat(props.getProperty("key")).isEqualTo("from-config-dir");
     }
+
+    @Test
+    void rejectsPathTraversalAttempt(@TempDir Path tempDir) throws Exception {
+        ConfigDirPropertyFileSource source = new ConfigDirPropertyFileSource(tempDir::toString);
+        InputStream is = source.locate("../../etc/passwd");
+        assertThat(is).isNull();
+    }
 }

--- a/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSourceTest.java
+++ b/core/forage-core-common/src/test/java/io/kaoto/forage/core/util/config/HomeDirectoryPropertyFileSourceTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class HomeDirectoryPropertyFileSourceTest {
@@ -65,5 +66,12 @@ class HomeDirectoryPropertyFileSourceTest {
         HomeDirectoryPropertyFileSource source =
                 new HomeDirectoryPropertyFileSource(() -> "/nonexistent-dir-" + System.nanoTime());
         assertThat(source.locate("anything.properties")).isNull();
+    }
+
+    @Test
+    @DisplayName("Rejects path traversal attempts that escape the home directory")
+    void rejectsPathTraversal(@TempDir Path tempDir) throws Exception {
+        HomeDirectoryPropertyFileSource source = new HomeDirectoryPropertyFileSource(tempDir::toString);
+        assertThat(source.locate("../../etc/passwd")).isNull();
     }
 }


### PR DESCRIPTION
## Summary
- Backport of #461 to `camel-latest`
- Adds `normalize()` + `Path.startsWith()` containment check in `ConfigDirPropertyFileSource.locate()` to reject file names with `../` sequences that escape the config directory
- Adds test for `../../etc/passwd` traversal attempt

## Test plan
- [x] `ConfigDirPropertyFileSourceTest` passes (5/5 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented configuration file requests from accessing paths outside the designated configuration or home directories.
  * Added warnings and safe rejection for path traversal attempts.

* **Tests**
  * Added coverage for traversal protection, missing files, directory resolution, source priority, and successful property file loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->