### PR TITLE
Fix #407: fail loudly on misconfiguration

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -265,8 +265,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
         try {
             LOG.info("Running: jbang app install --force -Dcamel.jbang.version={} camel@apache/camel", version);
             ProcessBuilder pb = new ProcessBuilder(
-                    "jbang", "app", "install", "--force",
-                    "-Dcamel.jbang.version=" + version, "camel@apache/camel");
+                    "jbang", "app", "install", "--force", "-Dcamel.jbang.version=" + version, "camel@apache/camel");
             pb.redirectErrorStream(true);
             Process process = pb.start();
             String output;

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentBeanFactory.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentBeanFactory.java
@@ -76,34 +76,29 @@ public class AgentBeanFactory implements BeanFactory {
     private void configureMultiAgent(Set<String> prefixes, ClassLoader cl) {
         for (String agentName : prefixes) {
             if (camelContext.getRegistry().lookupByNameAndType(agentName, Agent.class) == null) {
-                try {
-                    AgentConfig agentConfig = new AgentConfig(agentName);
-                    Agent agent = AgentCreator.createAgent(agentConfig, agentName, cl);
-                    if (agent != null) {
-                        camelContext.getRegistry().bind(agentName, agent);
-                        LOG.info("Registered Agent bean with name: {}", agentName);
-                    }
-                } catch (Exception e) {
-                    LOG.warn("Failed to create agent '{}': {}", agentName, e.getMessage());
-                    LOG.debug("Agent creation exception details", e);
+                AgentConfig agentConfig = new AgentConfig(agentName);
+                Agent agent = AgentCreator.createAgent(agentConfig, agentName, cl);
+                if (agent == null) {
+                    throw new IllegalStateException(
+                            "Failed to create agent '%s': AgentCreator returned null. ".formatted(agentName)
+                                    + "Check that the model kind, provider dependency, and configuration are correct.");
                 }
+                camelContext.getRegistry().bind(agentName, agent);
+                LOG.info("Registered Agent bean with name: {}", agentName);
             }
         }
     }
 
     private void configureDefaultAgent(ClassLoader cl) {
         if (camelContext.getRegistry().lookupByNameAndType(AgentCreator.DEFAULT_AGENT, Agent.class) == null) {
-            try {
-                AgentConfig agentConfig = new AgentConfig();
-                Agent agent = AgentCreator.createAgent(agentConfig, AgentCreator.DEFAULT_AGENT, cl);
-                if (agent != null) {
-                    camelContext.getRegistry().bind(AgentCreator.DEFAULT_AGENT, agent);
-                    LOG.info("Registered default Agent bean with name: {}", AgentCreator.DEFAULT_AGENT);
-                }
-            } catch (Exception e) {
-                LOG.warn("Failed to create default agent: {}", e.getMessage());
-                LOG.debug("Agent creation exception details", e);
+            AgentConfig agentConfig = new AgentConfig();
+            Agent agent = AgentCreator.createAgent(agentConfig, AgentCreator.DEFAULT_AGENT, cl);
+            if (agent == null) {
+                throw new IllegalStateException("Failed to create default agent: AgentCreator returned null. "
+                        + "Check that the model kind, provider dependency, and configuration are correct.");
             }
+            camelContext.getRegistry().bind(AgentCreator.DEFAULT_AGENT, agent);
+            LOG.info("Registered default Agent bean with name: {}", AgentCreator.DEFAULT_AGENT);
         }
     }
 

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
@@ -109,6 +109,14 @@ public final class AgentCreator {
             // Only create embedding/RAG pipeline when embedding properties are configured
             if (config.hasEmbeddingConfig()) {
                 EmbeddingModel embeddingModel = createEmbeddingModel(config, modelKind, name, classLoader);
+                if (embeddingModel == null) {
+                    throw new IllegalStateException(
+                            "Embedding configuration is present for agent '%s' but no EmbeddingModelProvider was found for kind '%s'. "
+                                            .formatted(name, modelKind)
+                                    + "Add the corresponding forage embedding model dependency to the classpath "
+                                    + "(e.g. forage-model-embeddings-ollama, forage-model-embeddings-openai).");
+                }
+
                 EmbeddingStore<TextSegment> embeddingStore =
                         createEmbeddingStore(config, modelKind, name, classLoader, embeddingModel);
 
@@ -117,6 +125,12 @@ public final class AgentCreator {
 
                 if (retrievalAugmentor != null) {
                     agentConfiguration.withRetrievalAugmentor(retrievalAugmentor);
+                } else {
+                    LOG.error(
+                            "RAG pipeline could not be assembled for agent '{}': "
+                                    + "embedding model was created but retrieval augmentor is null. "
+                                    + "Ensure an EmbeddingStoreProvider and RetrievalAugmentorProvider are on the classpath.",
+                            name);
                 }
             }
 
@@ -268,7 +282,16 @@ public final class AgentCreator {
             }
         }
 
-        LOG.debug("No embedding model provider found for kind: {}", modelKind);
+        String availableKinds = providers.stream()
+                .map(p -> p.type().getAnnotation(ForageBean.class))
+                .filter(a -> a != null)
+                .map(ForageBean::value)
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("none");
+        LOG.error(
+                "No embedding model provider found for kind '{}'. Available embedding providers: {}",
+                modelKind,
+                availableKinds);
         return null;
     }
 
@@ -311,7 +334,7 @@ public final class AgentCreator {
             }
         }
 
-        LOG.debug("No embedding store model provider found for kind: {}", modelKind);
+        LOG.error("No embedding store provider found on the classpath for agent '{}'", agentName);
         return null;
     }
 
@@ -356,7 +379,7 @@ public final class AgentCreator {
             }
         }
 
-        LOG.debug("No retrieval augmentor provider found for kind: {}", modelKind);
+        LOG.error("No retrieval augmentor provider found on the classpath for agent '{}'", agentName);
         return null;
     }
 

--- a/library/ai/rag/forage-default-retrieval-augmentor/src/main/java/io/kaoto/forage/rag/defaultRag/DefaultRetrievalAugmentorProvider.java
+++ b/library/ai/rag/forage-default-retrieval-augmentor/src/main/java/io/kaoto/forage/rag/defaultRag/DefaultRetrievalAugmentorProvider.java
@@ -78,11 +78,11 @@ public class DefaultRetrievalAugmentorProvider
         Double minScore = config.minScore();
 
         if (embeddingModel == null) {
-            LOG.trace("RAG is not configured, because no embedding model is provided");
+            LOG.error("RAG is not configured, because no embedding model is provided");
             return null;
         }
         if (embeddingStore == null) {
-            LOG.trace("RAG is not configured, because no embedding store is provided");
+            LOG.error("RAG is not configured, because no embedding store is provided");
             return null;
         }
 

--- a/library/ai/vector-dbs/forage-vectordb-in-memory-store/src/main/java/io/kaoto/forage/vectordb/inmemory/InMemoryStoreProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-in-memory-store/src/main/java/io/kaoto/forage/vectordb/inmemory/InMemoryStoreProvider.java
@@ -71,7 +71,7 @@ public class InMemoryStoreProvider implements EmbeddingStoreProvider, EmbeddingM
         final InMemoryStoreConfig config = new InMemoryStoreConfig(id);
 
         if (embeddingModel == null) {
-            LOG.trace("embeddingModel is mandatory for InMemoryStore creation");
+            LOG.error("embeddingModel is mandatory for InMemoryStore creation");
             return null;
         }
 
@@ -88,7 +88,9 @@ public class InMemoryStoreProvider implements EmbeddingStoreProvider, EmbeddingM
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         try (InputStream stream = classLoader.getResourceAsStream(fileSource)) {
             if (stream == null) {
-                LOG.trace("InMemory embedding store is not created. The source file is not provided.");
+                LOG.warn(
+                        "InMemory embedding store is not created. The source file '{}' was not found on the classpath.",
+                        fileSource);
                 return null;
             }
 

--- a/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/DataSourceCommonExportHelper.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/io/kaoto/forage/jdbc/common/DataSourceCommonExportHelper.java
@@ -10,7 +10,7 @@ public final class DataSourceCommonExportHelper {
      *
      * <p>Examples:
      * <ul>
-     *     <li>postgresql -&gt; io.kaoto.forage.jdbc.postgres.PostgresJdbc</li>
+     *     <li>postgresql -&gt; io.kaoto.forage.jdbc.postgresql.PostgresqlJdbc</li>
      *     <li>mysql -&gt; io.kaoto.forage.jdbc.mysql.MysqlJdbc</li>
      * </ul>
      */

--- a/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
@@ -264,8 +264,13 @@ public class DataSourceBeanFactory implements BeanFactory {
                 ServiceLoaderHelper.findProviderByClassName(providers, dataSourceProviderClass);
 
         if (dataSourceProvider == null) {
-            LOG.warn("DataSource {} has no provider for {}", name, dataSourceProviderClass);
-            return null;
+            String available = providers.stream()
+                    .map(p -> p.type().getName())
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("none");
+            throw new IllegalStateException(
+                    "No DataSourceProvider found for kind '%s' (expected %s). Available providers: %s"
+                            .formatted(dataSourceFactoryConfig.dbKind(), dataSourceProviderClass, available));
         }
 
         return doCreateDataSource(dataSourceProvider, name);

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/ConnectionFactoryCommonExportHelper.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/ConnectionFactoryCommonExportHelper.java
@@ -15,6 +15,11 @@ public class ConnectionFactoryCommonExportHelper {
     }
 
     public static String transformJmsKindIntoProviderClass(String jmsKind) {
-        return JMS_KIND_TO_PROVIDER_CLASS.getOrDefault(jmsKind.toLowerCase(), "io.kaoto.forage.jms.artemis.ArtemisJms");
+        String providerClass = JMS_KIND_TO_PROVIDER_CLASS.get(jmsKind.toLowerCase());
+        if (providerClass == null) {
+            throw new IllegalArgumentException(
+                    "Unknown JMS kind '%s'. Valid options: %s".formatted(jmsKind, JMS_KIND_TO_PROVIDER_CLASS.keySet()));
+        }
+        return providerClass;
     }
 }

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -233,8 +233,13 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
                 ServiceLoaderHelper.findProviderByClassName(providers, connectionFactoryProviderClass);
 
         if (connectionFactoryProvider == null) {
-            LOG.warn("ConnectionFactory {} has no provider for {}", name, connectionFactoryProviderClass);
-            return null;
+            String available = providers.stream()
+                    .map(p -> p.type().getName())
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("none");
+            throw new IllegalStateException(
+                    "No ConnectionFactoryProvider found for kind '%s' (expected %s). Available providers: %s"
+                            .formatted(connectionFactoryConfig.jmsKind(), connectionFactoryProviderClass, available));
         }
 
         return doCreateConnectionFactory(connectionFactoryProvider, name);


### PR DESCRIPTION
## Summary

Fixes #407. Replaces silent fallback, NPE chains, and TRACE/DEBUG-level swallowing across JDBC, JMS, RAG, and agent creation paths with fail-fast exceptions and actionable error messages.

- **JMS kind**: `getOrDefault` silent Artemis fallback → `IllegalArgumentException` listing valid kinds
- **JDBC kind**: NPE chain on unknown `db.kind` → `IllegalStateException` listing available providers; fix wrong javadoc example
- **RAG assembly**: TRACE/DEBUG log + return null → ERROR log + `IllegalStateException` when embedding config is present but pipeline can't be assembled
- **Agent creation**: WARN + swallow → rethrow at startup with descriptive messages

## Test plan

- [x] `mvn -DskipTests install` — full build passes
- [x] `cd library/ai/agents/forage-agent && mvn verify` — existing agent tests pass
- [ ] Manual: set `forage.jms.kind=typo` → verify `IllegalArgumentException` with valid kinds
- [ ] Manual: set `forage.jdbc.db.kind=foobar` → verify `IllegalStateException` with available providers
- [ ] Manual: configure embedding properties without embedding provider on classpath → verify `IllegalStateException` at startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid agent, embedding, retrieval, database, and JMS configurations now fail immediately with clearer error messages.
  * Missing providers and resources are reported with more actionable diagnostic details.
  * Agent setup no longer continues silently when required components cannot be created.

* **Documentation**
  * Corrected the PostgreSQL provider example in the JDBC documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->