### PR TITLE
Add forage-security-tls: properties-driven SSLContextParameters provider

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/annotations/FactoryType.java
@@ -23,7 +23,10 @@ public enum FactoryType {
 
     /** Factory that creates Spring RabbitMQ ConnectionFactory beans */
     SPRING_RABBITMQ_CONNECTION_FACTORY(
-            "org.springframework.amqp.rabbit.connection.ConnectionFactory", "forage-spring-rabbitmq");
+            "org.springframework.amqp.rabbit.connection.ConnectionFactory", "forage-spring-rabbitmq"),
+
+    /** Factory that creates SSLContextParameters beans for TLS */
+    SSL_CONTEXT_PARAMETERS("org.apache.camel.support.jsse.SSLContextParameters", "forage-security-tls");
 
     private final String displayName;
 

--- a/forage-catalog/pom.xml
+++ b/forage-catalog/pom.xml
@@ -514,6 +514,12 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-security-tls</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Route Policy Modules -->
         <dependency>

--- a/library/security/forage-security-tls/pom.xml
+++ b/library/security/forage-security-tls/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kaoto.forage</groupId>
+        <artifactId>security</artifactId>
+        <version>1.4.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-security-tls</artifactId>
+    <name>Forage :: Library :: Security :: TLS</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kaoto.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/security/forage-security-tls/src/main/java/io/kaoto/forage/security/tls/TlsBeanFactory.java
+++ b/library/security/forage-security-tls/src/main/java/io/kaoto/forage/security/tls/TlsBeanFactory.java
@@ -1,0 +1,141 @@
+package io.kaoto.forage.security.tls;
+
+import java.util.Set;
+import org.apache.camel.CamelContext;
+import org.apache.camel.support.jsse.CipherSuitesParameters;
+import org.apache.camel.support.jsse.KeyManagersParameters;
+import org.apache.camel.support.jsse.KeyStoreParameters;
+import org.apache.camel.support.jsse.SSLContextParameters;
+import org.apache.camel.support.jsse.SSLContextServerParameters;
+import org.apache.camel.support.jsse.TrustManagersParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.kaoto.forage.core.annotations.FactoryType;
+import io.kaoto.forage.core.annotations.ForageFactory;
+import io.kaoto.forage.core.common.BeanFactory;
+import io.kaoto.forage.core.util.config.ConfigHelper;
+import io.kaoto.forage.core.util.config.ConfigStore;
+
+@ForageFactory(
+        value = "TLS Context",
+        components = {},
+        description = "Creates SSLContextParameters beans for TLS/SSL configuration",
+        type = FactoryType.SSL_CONTEXT_PARAMETERS,
+        autowired = true,
+        configClass = TlsConfig.class)
+public class TlsBeanFactory implements BeanFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(TlsBeanFactory.class);
+
+    private CamelContext camelContext;
+    private static final String DEFAULT_BEAN_NAME = "sslContextParameters";
+
+    @Override
+    public void cleanup() {
+        TlsConfig config = new TlsConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("tls"));
+
+        for (String name : prefixes) {
+            camelContext.getRegistry().unbind(name);
+        }
+        camelContext.getRegistry().unbind(DEFAULT_BEAN_NAME);
+    }
+
+    @Override
+    public void configure() {
+        TlsConfig config = new TlsConfig();
+        Set<String> prefixes =
+                ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("tls"));
+
+        if (!prefixes.isEmpty()) {
+            for (String name : prefixes) {
+                try {
+                    if (camelContext.getRegistry().lookupByNameAndType(name, SSLContextParameters.class) == null) {
+                        TlsConfig tlsConfig = new TlsConfig(name);
+                        SSLContextParameters sslCtxParams = createSslContextParameters(tlsConfig);
+                        if (sslCtxParams != null) {
+                            camelContext.getRegistry().bind(name, sslCtxParams);
+                            LOG.info("Registered SSLContextParameters bean '{}'", name);
+                        }
+                    }
+                } catch (Exception ex) {
+                    LOG.error("Failed to configure TLS profile '{}': {}", name, ex.getMessage(), ex);
+                }
+            }
+        } else {
+            try {
+                if (camelContext.getRegistry().lookupByNameAndType(DEFAULT_BEAN_NAME, SSLContextParameters.class)
+                        == null) {
+                    SSLContextParameters sslCtxParams = createSslContextParameters(config);
+                    if (sslCtxParams != null) {
+                        camelContext.getRegistry().bind(DEFAULT_BEAN_NAME, sslCtxParams);
+                        LOG.info("Registered default SSLContextParameters bean '{}'", DEFAULT_BEAN_NAME);
+                    }
+                }
+            } catch (Exception ex) {
+                LOG.error("Failed to configure default TLS profile: {}", ex.getMessage(), ex);
+            }
+        }
+    }
+
+    SSLContextParameters createSslContextParameters(TlsConfig config) {
+        if (config.keystorePath() == null && config.truststorePath() == null) {
+            LOG.debug("No keystore or truststore configured, skipping SSLContextParameters creation");
+            return null;
+        }
+
+        SSLContextParameters sslCtxParams = new SSLContextParameters();
+
+        if (config.keystorePath() != null) {
+            KeyStoreParameters ksp = new KeyStoreParameters();
+            ksp.setResource(config.keystorePath());
+            ksp.setPassword(config.keystorePassword());
+            ksp.setType(config.keystoreType());
+
+            KeyManagersParameters kmp = new KeyManagersParameters();
+            kmp.setKeyStore(ksp);
+            kmp.setKeyPassword(config.keystorePassword());
+
+            sslCtxParams.setKeyManagers(kmp);
+        }
+
+        if (config.truststorePath() != null) {
+            KeyStoreParameters tsp = new KeyStoreParameters();
+            tsp.setResource(config.truststorePath());
+            tsp.setPassword(config.truststorePassword());
+            tsp.setType(config.truststoreType());
+
+            TrustManagersParameters tmp = new TrustManagersParameters();
+            tmp.setKeyStore(tsp);
+
+            sslCtxParams.setTrustManagers(tmp);
+        }
+
+        String clientAuth = config.clientAuthentication();
+        if (clientAuth != null && !"NONE".equalsIgnoreCase(clientAuth)) {
+            SSLContextServerParameters serverParams = new SSLContextServerParameters();
+            serverParams.setClientAuthentication(clientAuth);
+            sslCtxParams.setServerParameters(serverParams);
+        }
+
+        if (config.cipherSuites().isPresent()) {
+            CipherSuitesParameters csp = new CipherSuitesParameters();
+            csp.setCipherSuite(config.cipherSuitesList());
+            sslCtxParams.setCipherSuites(csp);
+        }
+
+        sslCtxParams.setSecureSocketProtocol(config.secureSocketProtocol());
+
+        return sslCtxParams;
+    }
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+}

--- a/library/security/forage-security-tls/src/main/java/io/kaoto/forage/security/tls/TlsConfig.java
+++ b/library/security/forage-security-tls/src/main/java/io/kaoto/forage/security/tls/TlsConfig.java
@@ -1,0 +1,79 @@
+package io.kaoto.forage.security.tls;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import io.kaoto.forage.core.util.config.AbstractConfig;
+
+import static io.kaoto.forage.security.tls.TlsConfigEntries.CIPHER_SUITES;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.CLIENT_AUTHENTICATION;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.KEYSTORE_PASSWORD;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.KEYSTORE_PATH;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.KEYSTORE_TYPE;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.SECURE_SOCKET_PROTOCOL;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.TRUSTSTORE_PASSWORD;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.TRUSTSTORE_PATH;
+import static io.kaoto.forage.security.tls.TlsConfigEntries.TRUSTSTORE_TYPE;
+
+public class TlsConfig extends AbstractConfig {
+
+    public TlsConfig() {
+        this(null);
+    }
+
+    public TlsConfig(String prefix) {
+        super(prefix, TlsConfigEntries.class);
+    }
+
+    @Override
+    public String name() {
+        return "forage-security-tls";
+    }
+
+    public String keystorePath() {
+        return get(KEYSTORE_PATH).orElse(null);
+    }
+
+    public String keystorePassword() {
+        return get(KEYSTORE_PASSWORD).orElse(null);
+    }
+
+    public String keystoreType() {
+        return get(KEYSTORE_TYPE).orElse(KEYSTORE_TYPE.defaultValue());
+    }
+
+    public String truststorePath() {
+        return get(TRUSTSTORE_PATH).orElse(null);
+    }
+
+    public String truststorePassword() {
+        return get(TRUSTSTORE_PASSWORD).orElse(null);
+    }
+
+    public String truststoreType() {
+        return get(TRUSTSTORE_TYPE).orElse(TRUSTSTORE_TYPE.defaultValue());
+    }
+
+    public String clientAuthentication() {
+        return get(CLIENT_AUTHENTICATION).orElse(CLIENT_AUTHENTICATION.defaultValue());
+    }
+
+    public Optional<String> cipherSuites() {
+        return get(CIPHER_SUITES);
+    }
+
+    public List<String> cipherSuitesList() {
+        return cipherSuites()
+                .map(s -> Arrays.stream(s.split(","))
+                        .map(String::trim)
+                        .filter(v -> !v.isEmpty())
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    public String secureSocketProtocol() {
+        return get(SECURE_SOCKET_PROTOCOL).orElse(SECURE_SOCKET_PROTOCOL.defaultValue());
+    }
+}

--- a/library/security/forage-security-tls/src/main/java/io/kaoto/forage/security/tls/TlsConfigEntries.java
+++ b/library/security/forage-security-tls/src/main/java/io/kaoto/forage/security/tls/TlsConfigEntries.java
@@ -1,0 +1,112 @@
+package io.kaoto.forage.security.tls;
+
+import io.kaoto.forage.core.util.config.ConfigEntries;
+import io.kaoto.forage.core.util.config.ConfigModule;
+import io.kaoto.forage.core.util.config.ConfigTag;
+
+public final class TlsConfigEntries extends ConfigEntries {
+
+    public static final ConfigModule KEYSTORE_PATH = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.keystore.path",
+            "Path to the keystore file (filesystem path or classpath: URI)",
+            "Keystore Path",
+            null,
+            "string",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule KEYSTORE_PASSWORD = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.keystore.password",
+            "Password for the keystore",
+            "Keystore Password",
+            null,
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule KEYSTORE_TYPE = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.keystore.type",
+            "Type of the keystore (JKS, PKCS12, etc.)",
+            "Keystore Type",
+            "JKS",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule TRUSTSTORE_PATH = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.truststore.path",
+            "Path to the truststore file (filesystem path or classpath: URI)",
+            "Truststore Path",
+            null,
+            "string",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule TRUSTSTORE_PASSWORD = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.truststore.password",
+            "Password for the truststore",
+            "Truststore Password",
+            null,
+            "password",
+            false,
+            ConfigTag.SECURITY);
+
+    public static final ConfigModule TRUSTSTORE_TYPE = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.truststore.type",
+            "Type of the truststore (JKS, PKCS12, etc.)",
+            "Truststore Type",
+            "JKS",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule CLIENT_AUTHENTICATION = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.client.authentication",
+            "Client authentication mode: NONE, WANT, or REQUIRE",
+            "Client Authentication",
+            "NONE",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    public static final ConfigModule CIPHER_SUITES = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.cipher.suites",
+            "Comma-separated list of cipher suites to include",
+            "Cipher Suites",
+            null,
+            "string",
+            false,
+            ConfigTag.ADVANCED);
+
+    public static final ConfigModule SECURE_SOCKET_PROTOCOL = ConfigModule.of(
+            TlsConfig.class,
+            "forage.tls.secure.socket.protocol",
+            "The secure socket protocol (e.g., TLSv1.2, TLSv1.3)",
+            "Secure Socket Protocol",
+            "TLSv1.3",
+            "string",
+            false,
+            ConfigTag.COMMON);
+
+    static {
+        initModules(
+                TlsConfigEntries.class,
+                KEYSTORE_PATH,
+                KEYSTORE_PASSWORD,
+                KEYSTORE_TYPE,
+                TRUSTSTORE_PATH,
+                TRUSTSTORE_PASSWORD,
+                TRUSTSTORE_TYPE,
+                CLIENT_AUTHENTICATION,
+                CIPHER_SUITES,
+                SECURE_SOCKET_PROTOCOL);
+    }
+}

--- a/library/security/forage-security-tls/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
+++ b/library/security/forage-security-tls/src/main/resources/META-INF/services/io.kaoto.forage.core.common.BeanFactory
@@ -1,0 +1,1 @@
+io.kaoto.forage.security.tls.TlsBeanFactory

--- a/library/security/forage-security-tls/src/test/java/io/kaoto/forage/security/tls/TlsBeanFactoryTest.java
+++ b/library/security/forage-security-tls/src/test/java/io/kaoto/forage/security/tls/TlsBeanFactoryTest.java
@@ -1,0 +1,271 @@
+package io.kaoto.forage.security.tls;
+
+import java.util.ServiceLoader;
+import org.apache.camel.support.jsse.SSLContextParameters;
+import io.kaoto.forage.core.common.BeanFactory;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TlsBeanFactory Tests")
+class TlsBeanFactoryTest {
+
+    @Nested
+    @DisplayName("ServiceLoader Tests")
+    class ServiceLoaderTests {
+
+        @Test
+        @DisplayName("Should be discoverable via ServiceLoader")
+        void shouldBeDiscoverableViaServiceLoader() {
+            ServiceLoader<BeanFactory> loader = ServiceLoader.load(BeanFactory.class);
+
+            boolean found = false;
+            for (BeanFactory factory : loader) {
+                if (factory instanceof TlsBeanFactory) {
+                    found = true;
+                    break;
+                }
+            }
+
+            assertThat(found).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("SSLContextParameters Creation Tests")
+    class SslContextParametersCreationTests {
+
+        @Test
+        @DisplayName("Should return null when nothing configured")
+        void shouldReturnNullWhenNothingConfigured() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config = new TlsConfigTest.TestTlsConfig();
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("Should create with keystore only")
+        void shouldCreateWithKeystoreOnly() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withKeystore("/path/to/keystore.p12", "secret", "PKCS12");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getKeyManagers()).isNotNull();
+            assertThat(result.getKeyManagers().getKeyStore().getResource()).isEqualTo("/path/to/keystore.p12");
+            assertThat(result.getKeyManagers().getKeyStore().getType()).isEqualTo("PKCS12");
+            assertThat(result.getTrustManagers()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should create with truststore only")
+        void shouldCreateWithTruststoreOnly() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withTruststore("/path/to/truststore.jks", "changeit", "JKS");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getTrustManagers()).isNotNull();
+            assertThat(result.getTrustManagers().getKeyStore().getResource()).isEqualTo("/path/to/truststore.jks");
+            assertThat(result.getTrustManagers().getKeyStore().getType()).isEqualTo("JKS");
+            assertThat(result.getKeyManagers()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should create with both keystore and truststore")
+        void shouldCreateWithBothKeystoreAndTruststore() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withKeystore("/path/to/keystore.p12", "secret", "PKCS12");
+            config = withTruststore(config, "/path/to/truststore.jks", "changeit", "JKS");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getKeyManagers()).isNotNull();
+            assertThat(result.getTrustManagers()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should not set server parameters when client auth is NONE")
+        void shouldNotSetServerParametersWhenClientAuthIsNone() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withKeystore("/path/to/keystore.jks", "secret", "JKS");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getServerParameters()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should set server parameters when client auth is REQUIRE")
+        void shouldSetServerParametersWhenClientAuthIsRequire() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withKeystore("/path/to/keystore.jks", "secret", "JKS");
+            config = withClientAuth(config, "REQUIRE");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getServerParameters()).isNotNull();
+            assertThat(result.getServerParameters().getClientAuthentication()).isEqualTo("REQUIRE");
+        }
+
+        @Test
+        @DisplayName("Should set cipher suites when configured")
+        void shouldSetCipherSuitesWhenConfigured() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withKeystore("/path/to/keystore.jks", "secret", "JKS");
+            config = withCipherSuites(config, "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getCipherSuites()).isNotNull();
+            assertThat(result.getCipherSuites().getCipherSuite())
+                    .containsExactly("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384");
+        }
+
+        @Test
+        @DisplayName("Should set secure socket protocol")
+        void shouldSetSecureSocketProtocol() {
+            TlsBeanFactory factory = new TlsBeanFactory();
+            TlsConfigTest.TestTlsConfig config =
+                    TlsConfigTest.TestTlsConfig.withKeystore("/path/to/keystore.jks", "secret", "JKS");
+
+            SSLContextParameters result = factory.createSslContextParameters(config);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getSecureSocketProtocol()).isEqualTo("TLSv1.3");
+        }
+
+        private TlsConfigTest.TestTlsConfig withTruststore(
+                TlsConfigTest.TestTlsConfig base, String path, String password, String type) {
+            TlsConfigTest.TestTlsConfig config = TlsConfigTest.TestTlsConfig.withKeystore(
+                    base.keystorePath(), base.keystorePassword(), base.keystoreType());
+            // Use reflection-free approach: create a combined config
+            return new CombinedTestTlsConfig(
+                    base.keystorePath(),
+                    base.keystorePassword(),
+                    base.keystoreType(),
+                    path,
+                    password,
+                    type,
+                    base.clientAuthentication(),
+                    null,
+                    base.secureSocketProtocol());
+        }
+
+        private TlsConfigTest.TestTlsConfig withClientAuth(TlsConfigTest.TestTlsConfig base, String clientAuth) {
+            return new CombinedTestTlsConfig(
+                    base.keystorePath(),
+                    base.keystorePassword(),
+                    base.keystoreType(),
+                    base.truststorePath(),
+                    base.truststorePassword(),
+                    base.truststoreType(),
+                    clientAuth,
+                    null,
+                    base.secureSocketProtocol());
+        }
+
+        private TlsConfigTest.TestTlsConfig withCipherSuites(TlsConfigTest.TestTlsConfig base, String cipherSuites) {
+            return new CombinedTestTlsConfig(
+                    base.keystorePath(),
+                    base.keystorePassword(),
+                    base.keystoreType(),
+                    base.truststorePath(),
+                    base.truststorePassword(),
+                    base.truststoreType(),
+                    base.clientAuthentication(),
+                    cipherSuites,
+                    base.secureSocketProtocol());
+        }
+    }
+
+    static class CombinedTestTlsConfig extends TlsConfigTest.TestTlsConfig {
+        private final String ksPath, ksPassword, ksType;
+        private final String tsPath, tsPassword, tsType;
+        private final String clientAuth, cipherSuites, protocol;
+
+        CombinedTestTlsConfig(
+                String ksPath,
+                String ksPassword,
+                String ksType,
+                String tsPath,
+                String tsPassword,
+                String tsType,
+                String clientAuth,
+                String cipherSuites,
+                String protocol) {
+            super();
+            this.ksPath = ksPath;
+            this.ksPassword = ksPassword;
+            this.ksType = ksType;
+            this.tsPath = tsPath;
+            this.tsPassword = tsPassword;
+            this.tsType = tsType;
+            this.clientAuth = clientAuth;
+            this.cipherSuites = cipherSuites;
+            this.protocol = protocol;
+        }
+
+        @Override
+        public String keystorePath() {
+            return ksPath;
+        }
+
+        @Override
+        public String keystorePassword() {
+            return ksPassword;
+        }
+
+        @Override
+        public String keystoreType() {
+            return ksType != null ? ksType : "JKS";
+        }
+
+        @Override
+        public String truststorePath() {
+            return tsPath;
+        }
+
+        @Override
+        public String truststorePassword() {
+            return tsPassword;
+        }
+
+        @Override
+        public String truststoreType() {
+            return tsType != null ? tsType : "JKS";
+        }
+
+        @Override
+        public String clientAuthentication() {
+            return clientAuth != null ? clientAuth : "NONE";
+        }
+
+        @Override
+        public java.util.Optional<String> cipherSuites() {
+            return java.util.Optional.ofNullable(cipherSuites);
+        }
+
+        @Override
+        public String secureSocketProtocol() {
+            return protocol != null ? protocol : "TLSv1.3";
+        }
+    }
+}

--- a/library/security/forage-security-tls/src/test/java/io/kaoto/forage/security/tls/TlsConfigTest.java
+++ b/library/security/forage-security-tls/src/test/java/io/kaoto/forage/security/tls/TlsConfigTest.java
@@ -1,0 +1,258 @@
+package io.kaoto.forage.security.tls;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TlsConfig Tests")
+class TlsConfigTest {
+
+    @Nested
+    @DisplayName("Config Name Tests")
+    class ConfigNameTests {
+
+        @Test
+        @DisplayName("Should return correct config name")
+        void shouldReturnCorrectConfigName() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.name()).isEqualTo("forage-security-tls");
+        }
+    }
+
+    @Nested
+    @DisplayName("Keystore Tests")
+    class KeystoreTests {
+
+        @Test
+        @DisplayName("Should return null when keystore path not configured")
+        void shouldReturnNullWhenKeystorePathNotConfigured() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.keystorePath()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should return configured keystore path")
+        void shouldReturnConfiguredKeystorePath() {
+            TestTlsConfig config = TestTlsConfig.withKeystore("/path/to/keystore.p12", "secret", "PKCS12");
+
+            assertThat(config.keystorePath()).isEqualTo("/path/to/keystore.p12");
+            assertThat(config.keystorePassword()).isEqualTo("secret");
+            assertThat(config.keystoreType()).isEqualTo("PKCS12");
+        }
+
+        @Test
+        @DisplayName("Should default keystore type to JKS")
+        void shouldDefaultKeystoreTypeToJKS() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.keystoreType()).isEqualTo("JKS");
+        }
+    }
+
+    @Nested
+    @DisplayName("Truststore Tests")
+    class TruststoreTests {
+
+        @Test
+        @DisplayName("Should return null when truststore path not configured")
+        void shouldReturnNullWhenTruststorePathNotConfigured() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.truststorePath()).isNull();
+        }
+
+        @Test
+        @DisplayName("Should return configured truststore path")
+        void shouldReturnConfiguredTruststorePath() {
+            TestTlsConfig config = TestTlsConfig.withTruststore("/path/to/truststore.jks", "changeit", "JKS");
+
+            assertThat(config.truststorePath()).isEqualTo("/path/to/truststore.jks");
+            assertThat(config.truststorePassword()).isEqualTo("changeit");
+            assertThat(config.truststoreType()).isEqualTo("JKS");
+        }
+
+        @Test
+        @DisplayName("Should default truststore type to JKS")
+        void shouldDefaultTruststoreTypeToJKS() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.truststoreType()).isEqualTo("JKS");
+        }
+    }
+
+    @Nested
+    @DisplayName("Client Authentication Tests")
+    class ClientAuthenticationTests {
+
+        @Test
+        @DisplayName("Should default to NONE")
+        void shouldDefaultToNone() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.clientAuthentication()).isEqualTo("NONE");
+        }
+
+        @Test
+        @DisplayName("Should return configured value")
+        void shouldReturnConfiguredValue() {
+            TestTlsConfig config = TestTlsConfig.withClientAuthentication("REQUIRE");
+
+            assertThat(config.clientAuthentication()).isEqualTo("REQUIRE");
+        }
+    }
+
+    @Nested
+    @DisplayName("Cipher Suites Tests")
+    class CipherSuitesTests {
+
+        @Test
+        @DisplayName("Should return empty when not configured")
+        void shouldReturnEmptyWhenNotConfigured() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.cipherSuites()).isEmpty();
+            assertThat(config.cipherSuitesList()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should parse comma-separated cipher suites")
+        void shouldParseCommaSeparatedCipherSuites() {
+            TestTlsConfig config = TestTlsConfig.withCipherSuites("TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384");
+
+            assertThat(config.cipherSuitesList()).containsExactly("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384");
+        }
+    }
+
+    @Nested
+    @DisplayName("Secure Socket Protocol Tests")
+    class SecureSocketProtocolTests {
+
+        @Test
+        @DisplayName("Should default to TLSv1.3")
+        void shouldDefaultToTLSv13() {
+            TestTlsConfig config = new TestTlsConfig();
+
+            assertThat(config.secureSocketProtocol()).isEqualTo("TLSv1.3");
+        }
+
+        @Test
+        @DisplayName("Should return configured value")
+        void shouldReturnConfiguredValue() {
+            TestTlsConfig config = TestTlsConfig.withSecureSocketProtocol("TLSv1.2");
+
+            assertThat(config.secureSocketProtocol()).isEqualTo("TLSv1.2");
+        }
+    }
+
+    static class TestTlsConfig extends TlsConfig {
+        private String testKeystorePath;
+        private String testKeystorePassword;
+        private String testKeystoreType;
+        private String testTruststorePath;
+        private String testTruststorePassword;
+        private String testTruststoreType;
+        private String testClientAuthentication;
+        private String testCipherSuites;
+        private String testSecureSocketProtocol;
+
+        TestTlsConfig() {
+            super();
+        }
+
+        static TestTlsConfig withKeystore(String path, String password, String type) {
+            TestTlsConfig config = new TestTlsConfig();
+            config.testKeystorePath = path;
+            config.testKeystorePassword = password;
+            config.testKeystoreType = type;
+            return config;
+        }
+
+        static TestTlsConfig withTruststore(String path, String password, String type) {
+            TestTlsConfig config = new TestTlsConfig();
+            config.testTruststorePath = path;
+            config.testTruststorePassword = password;
+            config.testTruststoreType = type;
+            return config;
+        }
+
+        static TestTlsConfig withClientAuthentication(String clientAuth) {
+            TestTlsConfig config = new TestTlsConfig();
+            config.testClientAuthentication = clientAuth;
+            return config;
+        }
+
+        static TestTlsConfig withCipherSuites(String cipherSuites) {
+            TestTlsConfig config = new TestTlsConfig();
+            config.testCipherSuites = cipherSuites;
+            return config;
+        }
+
+        static TestTlsConfig withSecureSocketProtocol(String protocol) {
+            TestTlsConfig config = new TestTlsConfig();
+            config.testSecureSocketProtocol = protocol;
+            return config;
+        }
+
+        @Override
+        public String keystorePath() {
+            return testKeystorePath;
+        }
+
+        @Override
+        public String keystorePassword() {
+            return testKeystorePassword;
+        }
+
+        @Override
+        public String keystoreType() {
+            return testKeystoreType != null ? testKeystoreType : "JKS";
+        }
+
+        @Override
+        public String truststorePath() {
+            return testTruststorePath;
+        }
+
+        @Override
+        public String truststorePassword() {
+            return testTruststorePassword;
+        }
+
+        @Override
+        public String truststoreType() {
+            return testTruststoreType != null ? testTruststoreType : "JKS";
+        }
+
+        @Override
+        public String clientAuthentication() {
+            return testClientAuthentication != null ? testClientAuthentication : "NONE";
+        }
+
+        @Override
+        public Optional<String> cipherSuites() {
+            return Optional.ofNullable(testCipherSuites);
+        }
+
+        @Override
+        public List<String> cipherSuitesList() {
+            return cipherSuites()
+                    .map(s -> java.util.Arrays.stream(s.split(","))
+                            .map(String::trim)
+                            .filter(v -> !v.isEmpty())
+                            .collect(java.util.stream.Collectors.toList()))
+                    .orElse(Collections.emptyList());
+        }
+
+        @Override
+        public String secureSocketProtocol() {
+            return testSecureSocketProtocol != null ? testSecureSocketProtocol : "TLSv1.3";
+        }
+    }
+}

--- a/library/security/pom.xml
+++ b/library/security/pom.xml
@@ -16,6 +16,7 @@
         <module>forage-security-shiro</module>
         <module>forage-security-spring</module>
         <module>forage-security-keycloak</module>
+        <module>forage-security-tls</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Summary

- Adds a new `forage-security-tls` module that creates `SSLContextParameters` beans from `forage.tls.*` properties
- Supports keystore/truststore configuration, client authentication, cipher suites, and secure socket protocol selection
- Named/prefixed profiles for multiple TLS configurations (e.g., `forage.clientTls.tls.keystore.path=...`)
- Beans are registered in the Camel registry so any component (HTTP, Netty, FTPS, Kafka, CXF, etc.) can reference them
- Adds `SSL_CONTEXT_PARAMETERS` to `FactoryType` enum and registers the module in the catalog

Cross-cutting value: unblocks or simplifies #147 (Artemis SSL), #148 (IBM MQ SSL), #343 (CXF HTTP conduit tuning), and future Kafka/MongoDB/Elasticsearch modules.

Fixes #436

## Test plan

- [x] 22 unit tests pass (TlsConfigTest + TlsBeanFactoryTest)
- [x] Module builds successfully with `mvn verify`
- [ ] Integration test with actual keystore/truststore (future)