### PR TITLE
Fix #410: implement Anthropic and DashScope chat model providers

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -265,8 +265,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
         try {
             LOG.info("Running: jbang app install --force -Dcamel.jbang.version={} camel@apache/camel", version);
             ProcessBuilder pb = new ProcessBuilder(
-                    "jbang", "app", "install", "--force",
-                    "-Dcamel.jbang.version=" + version, "camel@apache/camel");
+                    "jbang", "app", "install", "--force", "-Dcamel.jbang.version=" + version, "camel@apache/camel");
             pb.redirectErrorStream(true);
             Process process = pb.start();
             String output;

--- a/library/ai/models/chat/forage-model-anthropic/pom.xml
+++ b/library/ai/models/chat/forage-model-anthropic/pom.xml
@@ -26,12 +26,9 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Note: Anthropic integration will be available in future LangChain4J versions -->
-        <!-- For now, we use the core dependency and create a placeholder implementation -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j</artifactId>
-            <version>${langchain4j.version}</version>
+            <artifactId>langchain4j-anthropic</artifactId>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicConfig.java
+++ b/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicConfig.java
@@ -115,13 +115,12 @@ public class AnthropicConfig extends AbstractConfig {
      *
      * <p><strong>Common Model Names:</strong>
      * <ul>
-     *   <li><strong>claude-3-haiku-20240307</strong> - Fast and efficient model (default)</li>
-     *   <li><strong>claude-3-sonnet-20240229</strong> - Balanced performance and capabilities</li>
-     *   <li><strong>claude-3-opus-20240229</strong> - Most capable model</li>
-     *   <li><strong>claude-3-5-sonnet-20241022</strong> - Latest Sonnet model</li>
+     *   <li><strong>claude-sonnet-4-20250514</strong> - Balanced performance and capabilities (default)</li>
+     *   <li><strong>claude-haiku-4-5-20251001</strong> - Fast and efficient model</li>
+     *   <li><strong>claude-opus-4-20250115</strong> - Most capable model</li>
      * </ul>
      *
-     * @return the model name, defaults to "claude-3-haiku-20240307" if not configured
+     * @return the model name, defaults to "claude-sonnet-4-20250514" if not configured
      */
     public String modelName() {
         return get(MODEL_NAME).orElse(MODEL_NAME.defaultValue());

--- a/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicConfigEntries.java
+++ b/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicConfigEntries.java
@@ -17,9 +17,9 @@ public final class AnthropicConfigEntries extends ConfigEntries {
     public static final ConfigModule MODEL_NAME = ConfigModule.of(
             AnthropicConfig.class,
             "forage.anthropic.model.name",
-            "Claude model name (e.g., claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229)",
+            "Claude model name (e.g., claude-sonnet-4-20250514, claude-haiku-4-5-20251001, claude-opus-4-20250115)",
             "Model Name",
-            "claude-3-haiku-20240307",
+            "claude-sonnet-4-20250514",
             "string",
             false,
             ConfigTag.COMMON);

--- a/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicProvider.java
+++ b/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicProvider.java
@@ -1,51 +1,70 @@
 package io.kaoto.forage.models.chat.anthropic;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.time.Duration;
+import java.util.List;
 import io.kaoto.forage.core.ai.ModelProvider;
 import io.kaoto.forage.core.annotations.ForageBean;
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.chat.ChatModel;
 
-/**
- * Provider for creating Anthropic Claude chat models.
- *
- * <p><strong>Note:</strong> This is a placeholder implementation. The actual Anthropic integration
- * will be available when LangChain4J adds comprehensive support for Anthropic Claude in future versions.
- *
- * <p>This provider currently throws an UnsupportedOperationException to indicate that
- * the integration is not yet fully available. Once LangChain4J adds the complete {@code langchain4j-anthropic}
- * integration with a proper builder pattern, this implementation should be updated
- * to use the proper Anthropic integration.
- *
- * <p><strong>Configuration:</strong>
- * The configuration system is already in place and will work once the implementation is completed.
- * Required configuration includes:
- * <ul>
- *   <li>ANTHROPIC_API_KEY - Your Anthropic API key</li>
- *   <li>ANTHROPIC_MODEL_NAME - The Claude model to use (optional, defaults to "claude-3-haiku-20240307")</li>
- * </ul>
- */
 @ForageBean(
         value = "anthropic",
         components = {"camel-langchain4j-agent"},
         feature = "Chat Model",
         description = "Anthropic Claude models")
 public class AnthropicProvider implements ModelProvider {
-    private static final Logger LOG = LoggerFactory.getLogger(AnthropicProvider.class);
 
     @Override
     public ChatModel create(String id) {
-        final AnthropicConfig config = new AnthropicConfig(id);
-        LOG.warn("Anthropic integration is not yet fully available. This is a placeholder implementation.");
-        LOG.warn(
-                "Configuration loaded: API key configured={}, Model name={}",
-                config.apiKey() != null,
-                config.modelName());
+        AnthropicConfig config = new AnthropicConfig(id);
 
-        throw new UnsupportedOperationException("Anthropic integration is not yet fully available in LangChain4J. "
-                + "This provider will be implemented once langchain4j-anthropic dependency becomes fully available. "
-                + "Configuration is ready: API key is "
-                + (config.apiKey() != null ? "configured" : "missing") + ", model name is '"
-                + config.modelName() + "'");
+        String apiKey = config.apiKey();
+        String modelName = config.modelName();
+        Double temperature = config.temperature();
+        Integer maxTokens = config.maxTokens();
+        Double topP = config.topP();
+        Integer topK = config.topK();
+        List<String> stopSequences = config.stopSequences();
+        Integer timeoutSeconds = config.timeoutSeconds();
+        Integer maxRetries = config.maxRetries();
+        Boolean logRequestsAndResponses = config.logRequestsAndResponses();
+
+        AnthropicChatModel.AnthropicChatModelBuilder builder =
+                AnthropicChatModel.builder().apiKey(apiKey).modelName(modelName);
+
+        if (temperature != null) {
+            builder.temperature(temperature);
+        }
+
+        if (maxTokens != null) {
+            builder.maxTokens(maxTokens);
+        }
+
+        if (topP != null) {
+            builder.topP(topP);
+        }
+
+        if (topK != null) {
+            builder.topK(topK);
+        }
+
+        if (stopSequences != null) {
+            builder.stopSequences(stopSequences);
+        }
+
+        if (timeoutSeconds != null) {
+            builder.timeout(Duration.ofSeconds(timeoutSeconds));
+        }
+
+        if (maxRetries != null) {
+            builder.maxRetries(maxRetries);
+        }
+
+        if (logRequestsAndResponses != null) {
+            builder.logRequests(logRequestsAndResponses);
+            builder.logResponses(logRequestsAndResponses);
+        }
+
+        return builder.build();
     }
 }

--- a/library/ai/models/chat/forage-model-dashscope/pom.xml
+++ b/library/ai/models/chat/forage-model-dashscope/pom.xml
@@ -26,12 +26,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Note: Dashscope integration will be available in future LangChain4J versions -->
-        <!-- For now, we use the core dependency and create a custom implementation -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j</artifactId>
-            <version>${langchain4j.version}</version>
+            <artifactId>langchain4j-community-dashscope</artifactId>
+            <version>${langchain4j-community.version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/models/chat/forage-model-dashscope/src/main/java/io/kaoto/forage/models/chat/dashscope/DashscopeProvider.java
+++ b/library/ai/models/chat/forage-model-dashscope/src/main/java/io/kaoto/forage/models/chat/dashscope/DashscopeProvider.java
@@ -1,51 +1,62 @@
 package io.kaoto.forage.models.chat.dashscope;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.ai.ModelProvider;
 import io.kaoto.forage.core.annotations.ForageBean;
+import dev.langchain4j.community.model.dashscope.QwenChatModel;
 import dev.langchain4j.model.chat.ChatModel;
 
-/**
- * Provider for creating Dashscope Qwen chat models.
- *
- * <p><strong>Note:</strong> This is a placeholder implementation. The actual Dashscope integration
- * will be available when LangChain4J adds support for Alibaba Dashscope in future versions.
- *
- * <p>This provider currently throws an UnsupportedOperationException to indicate that
- * the integration is not yet available. Once LangChain4J adds the {@code langchain4j-dashscope}
- * or {@code langchain4j-alibaba-dashscope} dependency, this implementation should be updated
- * to use the proper Dashscope integration.
- *
- * <p><strong>Configuration:</strong>
- * The configuration system is already in place and will work once the implementation is completed.
- * Required configuration includes:
- * <ul>
- *   <li>DASHSCOPE_API_KEY - Your Dashscope API key</li>
- *   <li>DASHSCOPE_MODEL_NAME - The Qwen model to use (optional, defaults to "qwen-turbo")</li>
- * </ul>
- */
 @ForageBean(
         value = "dashscope",
         components = {"camel-langchain4j-agent"},
         feature = "Chat Model",
-        description = "Alibaba Cloud Qwen models via DashScope (placeholder)")
+        description = "Alibaba Cloud Qwen models via DashScope")
 public class DashscopeProvider implements ModelProvider {
-    private static final Logger LOG = LoggerFactory.getLogger(DashscopeProvider.class);
 
     @Override
     public ChatModel create(String id) {
-        final DashscopeConfig config = new DashscopeConfig(id);
-        LOG.warn("Dashscope integration is not yet available. This is a placeholder implementation.");
-        LOG.warn(
-                "Configuration loaded: API key configured={}, Model name={}",
-                config.apiKey() != null,
-                config.modelName());
+        DashscopeConfig config = new DashscopeConfig(id);
 
-        throw new UnsupportedOperationException("Dashscope integration is not yet available in LangChain4J. "
-                + "This provider will be implemented once langchain4j-dashscope dependency becomes available. "
-                + "Configuration is ready: API key is "
-                + (config.apiKey() != null ? "configured" : "missing") + ", model name is '"
-                + config.modelName() + "'");
+        String apiKey = config.apiKey();
+        String modelName = config.modelName();
+        Double temperature = config.temperature();
+        Integer maxTokens = config.maxTokens();
+        Double topP = config.topP();
+        Integer topK = config.topK();
+        Double repetitionPenalty = config.repetitionPenalty();
+        Long seed = config.seed();
+        Boolean enableSearch = config.enableSearch();
+
+        QwenChatModel.QwenChatModelBuilder builder =
+                QwenChatModel.builder().apiKey(apiKey).modelName(modelName);
+
+        if (temperature != null) {
+            builder.temperature(temperature.floatValue());
+        }
+
+        if (maxTokens != null) {
+            builder.maxTokens(maxTokens);
+        }
+
+        if (topP != null) {
+            builder.topP(topP);
+        }
+
+        if (topK != null) {
+            builder.topK(topK);
+        }
+
+        if (repetitionPenalty != null) {
+            builder.repetitionPenalty(repetitionPenalty.floatValue());
+        }
+
+        if (seed != null) {
+            builder.seed(seed.intValue());
+        }
+
+        if (enableSearch != null) {
+            builder.enableSearch(enableSearch);
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
## Summary
- Wire `AnthropicChatModel.builder()` to the existing Anthropic config surface (`langchain4j-anthropic` dependency, managed by `langchain4j-bom` at 1.11.0)
- Wire `QwenChatModel.builder()` to the existing DashScope config surface (`langchain4j-community-dashscope` at `1.11.0-beta19`)
- Update Anthropic default model from retired `claude-3-haiku-20240307` to `claude-sonnet-4-20250514`
- Remove placeholder `UnsupportedOperationException` throws and stale javadoc from both providers

## Test plan
- [x] `mvn clean compile` passes for both modules
- [x] Full `mvn clean install -DskipTests` passes from root (includes spotless formatting and catalog regeneration)
- [ ] Backport to `camel-latest`