### PR TITLE
[backport camel-latest] Fix #406: AI provider hygiene sweep

### DIFF
--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfig.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfig.java
@@ -24,13 +24,8 @@ import static io.kaoto.forage.agent.AgentConfigEntries.FEATURES;
 import static io.kaoto.forage.agent.AgentConfigEntries.LOG_REQUESTS;
 import static io.kaoto.forage.agent.AgentConfigEntries.LOG_RESPONSES;
 import static io.kaoto.forage.agent.AgentConfigEntries.MAX_TOKENS;
-import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_INFINISPAN_CACHE_NAME;
-import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_INFINISPAN_SERVER_LIST;
 import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_KIND;
 import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_MAX_MESSAGES;
-import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_REDIS_HOST;
-import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_REDIS_PASSWORD;
-import static io.kaoto.forage.agent.AgentConfigEntries.MEMORY_REDIS_PORT;
 import static io.kaoto.forage.agent.AgentConfigEntries.MODEL_KIND;
 import static io.kaoto.forage.agent.AgentConfigEntries.MODEL_NAME;
 import static io.kaoto.forage.agent.AgentConfigEntries.TEMPERATURE;
@@ -143,30 +138,6 @@ public class AgentConfig extends AbstractConfig {
 
     public Integer memoryMaxMessages() {
         return get(MEMORY_MAX_MESSAGES).map(Integer::parseInt).orElse(20);
-    }
-
-    // Redis memory
-
-    public String memoryRedisHost() {
-        return get(MEMORY_REDIS_HOST).orElse("localhost");
-    }
-
-    public Integer memoryRedisPort() {
-        return get(MEMORY_REDIS_PORT).map(Integer::parseInt).orElse(6379);
-    }
-
-    public String memoryRedisPassword() {
-        return get(MEMORY_REDIS_PASSWORD).orElse(null);
-    }
-
-    // Infinispan memory
-
-    public String memoryInfinispanServerList() {
-        return get(MEMORY_INFINISPAN_SERVER_LIST).orElse("localhost:11222");
-    }
-
-    public String memoryInfinispanCacheName() {
-        return get(MEMORY_INFINISPAN_CACHE_NAME).orElse("chat-memory");
     }
 
     // EmbeddingStore

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
@@ -195,58 +195,6 @@ public final class AgentConfigEntries extends ConfigEntries {
             false,
             ConfigTag.COMMON);
 
-    // Redis memory
-    public static final ConfigModule MEMORY_REDIS_HOST = ConfigModule.of(
-            AgentConfig.class,
-            "forage.agent.memory.redis.host",
-            "Redis server hostname",
-            "Redis Host",
-            "localhost",
-            "string",
-            false,
-            ConfigTag.COMMON);
-
-    public static final ConfigModule MEMORY_REDIS_PORT = ConfigModule.of(
-            AgentConfig.class,
-            "forage.agent.memory.redis.port",
-            "Redis server port",
-            "Redis Port",
-            "6379",
-            "integer",
-            false,
-            ConfigTag.COMMON);
-
-    public static final ConfigModule MEMORY_REDIS_PASSWORD = ConfigModule.of(
-            AgentConfig.class,
-            "forage.agent.memory.redis.password",
-            "Redis authentication password",
-            "Redis Password",
-            null,
-            "password",
-            false,
-            ConfigTag.SECURITY);
-
-    // Infinispan memory
-    public static final ConfigModule MEMORY_INFINISPAN_SERVER_LIST = ConfigModule.of(
-            AgentConfig.class,
-            "forage.agent.memory.infinispan.server-list",
-            "Comma-separated list of Infinispan servers",
-            "Server List",
-            "localhost:11222",
-            "string",
-            false,
-            ConfigTag.COMMON);
-
-    public static final ConfigModule MEMORY_INFINISPAN_CACHE_NAME = ConfigModule.of(
-            AgentConfig.class,
-            "forage.agent.memory.infinispan.cache-name",
-            "Infinispan cache name for storing messages",
-            "Cache Name",
-            "chat-memory",
-            "string",
-            false,
-            ConfigTag.COMMON);
-
     // EMBEDDING STORE
 
     public static final ConfigModule EMBEDDING_STORE_FILE_SOURCE = ConfigModule.of(
@@ -256,7 +204,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "File source",
             null,
             "string",
-            true,
+            false,
             ConfigTag.COMMON);
 
     public static final ConfigModule EMBEDDING_STORE_MAX_SIZE = ConfigModule.of(
@@ -370,11 +318,6 @@ public final class AgentConfigEntries extends ConfigEntries {
                 LOG_RESPONSES,
                 TIMEOUT,
                 MEMORY_MAX_MESSAGES,
-                MEMORY_REDIS_HOST,
-                MEMORY_REDIS_PORT,
-                MEMORY_REDIS_PASSWORD,
-                MEMORY_INFINISPAN_SERVER_LIST,
-                MEMORY_INFINISPAN_CACHE_NAME,
                 EMBEDDING_STORE_FILE_SOURCE,
                 EMBEDDING_STORE_MAX_SIZE,
                 EMBEDDING_STORE_OVERLAP_SIZE,

--- a/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleConfig.java
+++ b/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleConfig.java
@@ -4,9 +4,12 @@ import io.kaoto.forage.core.util.config.AbstractConfig;
 
 import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.API_KEY;
 import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.LOG_REQUESTS;
+import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.MAX_OUTPUT_TOKENS;
 import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.MODEL_NAME;
 import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.TEMPERATURE;
 import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.TIMEOUT;
+import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.TOP_K;
+import static io.kaoto.forage.models.chat.google.GoogleConfigEntries.TOP_P;
 
 /**
  * Configuration class for Google Gemini AI model integration in the Forage framework.
@@ -155,5 +158,17 @@ public class GoogleConfig extends AbstractConfig {
 
     public Boolean logRequestsAndResponses() {
         return get(LOG_REQUESTS).map(Boolean::parseBoolean).orElse(null);
+    }
+
+    public Integer maxOutputTokens() {
+        return get(MAX_OUTPUT_TOKENS).map(Integer::parseInt).orElse(null);
+    }
+
+    public Double topP() {
+        return get(TOP_P).map(Double::parseDouble).orElse(null);
+    }
+
+    public Integer topK() {
+        return get(TOP_K).map(Integer::parseInt).orElse(null);
     }
 }

--- a/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleConfigEntries.java
+++ b/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleConfigEntries.java
@@ -50,8 +50,44 @@ public final class GoogleConfigEntries extends ConfigEntries {
             "boolean",
             false,
             ConfigTag.ADVANCED);
+    public static final ConfigModule MAX_OUTPUT_TOKENS = ConfigModule.of(
+            GoogleConfig.class,
+            "forage.google.max.output.tokens",
+            "Maximum number of output tokens",
+            "Max Output Tokens",
+            null,
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule TOP_P = ConfigModule.of(
+            GoogleConfig.class,
+            "forage.google.top.p",
+            "Top-p (nucleus sampling) parameter (0.0-1.0)",
+            "Top P",
+            null,
+            "double",
+            false,
+            ConfigTag.ADVANCED);
+    public static final ConfigModule TOP_K = ConfigModule.of(
+            GoogleConfig.class,
+            "forage.google.top.k",
+            "Top-k sampling parameter",
+            "Top K",
+            null,
+            "integer",
+            false,
+            ConfigTag.ADVANCED);
 
     static {
-        initModules(GoogleConfigEntries.class, API_KEY, MODEL_NAME, TEMPERATURE, TIMEOUT, LOG_REQUESTS);
+        initModules(
+                GoogleConfigEntries.class,
+                API_KEY,
+                MODEL_NAME,
+                TEMPERATURE,
+                TIMEOUT,
+                LOG_REQUESTS,
+                MAX_OUTPUT_TOKENS,
+                TOP_P,
+                TOP_K);
     }
 }

--- a/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleGeminiProvider.java
+++ b/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleGeminiProvider.java
@@ -38,6 +38,16 @@ public class GoogleGeminiProvider implements ModelProvider {
             builder.timeout(ofSeconds(timeout));
         }
 
+        if (config.maxOutputTokens() != null) {
+            builder.maxOutputTokens(config.maxOutputTokens());
+        }
+        if (config.topP() != null) {
+            builder.topP(config.topP());
+        }
+        if (config.topK() != null) {
+            builder.topK(config.topK());
+        }
+
         Boolean logRequests = config.logRequestsAndResponses();
         if (logRequests != null) {
             builder.logRequestsAndResponses(logRequests);

--- a/library/ai/models/chat/forage-model-hugging-face/src/main/java/io/kaoto/forage/models/chat/huggingface/HuggingFaceConfig.java
+++ b/library/ai/models/chat/forage-model-hugging-face/src/main/java/io/kaoto/forage/models/chat/huggingface/HuggingFaceConfig.java
@@ -3,17 +3,11 @@ package io.kaoto.forage.models.chat.huggingface;
 import io.kaoto.forage.core.util.config.AbstractConfig;
 
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.API_KEY;
-import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.DO_SAMPLE;
-import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.LOG_REQUESTS_AND_RESPONSES;
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.MAX_NEW_TOKENS;
-import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.MAX_RETRIES;
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.MODEL_ID;
-import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.REPETITION_PENALTY;
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.RETURN_FULL_TEXT;
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.TEMPERATURE;
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.TIMEOUT;
-import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.TOP_K;
-import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.TOP_P;
 import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.WAIT_FOR_MODEL;
 
 /**
@@ -33,15 +27,9 @@ import static io.kaoto.forage.models.chat.huggingface.HuggingFaceConfigEntries.W
  *   <li><strong>HUGGINGFACE_MODEL_ID</strong> - The HuggingFace model ID to use (e.g., microsoft/DialoGPT-medium)</li>
  *   <li><strong>HUGGINGFACE_TEMPERATURE</strong> - Temperature for response generation (0.0-2.0)</li>
  *   <li><strong>HUGGINGFACE_MAX_NEW_TOKENS</strong> - Maximum number of new tokens to generate</li>
- *   <li><strong>HUGGINGFACE_TOP_K</strong> - Top-k sampling parameter</li>
- *   <li><strong>HUGGINGFACE_TOP_P</strong> - Top-p (nucleus) sampling parameter</li>
- *   <li><strong>HUGGINGFACE_DO_SAMPLE</strong> - Whether to use sampling</li>
- *   <li><strong>HUGGINGFACE_REPETITION_PENALTY</strong> - Penalty for repeating tokens</li>
  *   <li><strong>HUGGINGFACE_RETURN_FULL_TEXT</strong> - Whether to return full text including input</li>
  *   <li><strong>HUGGINGFACE_WAIT_FOR_MODEL</strong> - Whether to wait for model to load</li>
  *   <li><strong>HUGGINGFACE_TIMEOUT</strong> - Request timeout in seconds</li>
- *   <li><strong>HUGGINGFACE_MAX_RETRIES</strong> - Maximum number of retry attempts</li>
- *   <li><strong>HUGGINGFACE_LOG_REQUESTS_AND_RESPONSES</strong> - Whether to log requests and responses</li>
  * </ul>
  *
  * <p><strong>Configuration Sources:</strong>
@@ -164,63 +152,6 @@ public class HuggingFaceConfig extends AbstractConfig {
     }
 
     /**
-     * Returns the top-k sampling parameter.
-     *
-     * <p>Limits the number of highest probability vocabulary tokens to keep for top-k filtering.
-     * Only the top k most likely tokens are considered for sampling.
-     *
-     * @return the top-k value, or null if not configured
-     */
-    public Integer topK() {
-        return get(TOP_K).map(Integer::parseInt).orElse(null);
-    }
-
-    /**
-     * Returns the top-p (nucleus sampling) probability threshold.
-     *
-     * <p>An alternative to top-k for controlling response diversity. The model considers
-     * only the most probable tokens whose cumulative probability exceeds the top-p value.
-     *
-     * <p><strong>Value Range:</strong> 0.0 to 1.0
-     *
-     * @return the top-p value, or null if not configured
-     */
-    public Double topP() {
-        return get(TOP_P).map(Double::parseDouble).orElse(null);
-    }
-
-    /**
-     * Returns whether to use sampling for text generation.
-     *
-     * <p>When set to false, uses greedy decoding (always selects the most probable token).
-     * When set to true, uses sampling with temperature, top-k, and top-p parameters.
-     *
-     * @return true if sampling is enabled, false if disabled, or null if not configured
-     */
-    public Boolean doSample() {
-        return get(DO_SAMPLE).map(Boolean::parseBoolean).orElse(null);
-    }
-
-    /**
-     * Returns the repetition penalty for discouraging token repetition.
-     *
-     * <p>Penalizes tokens that have already appeared in the sequence, discouraging
-     * the model from repeating the same phrases or words.
-     *
-     * <p><strong>Value Range:</strong> typically 1.0 to 2.0
-     * <ul>
-     *   <li><strong>1.0</strong> - No penalty (default)</li>
-     *   <li><strong>1.1-1.3</strong> - Moderate penalty</li>
-     *   <li><strong>2.0</strong> - Strong penalty against repetition</li>
-     * </ul>
-     *
-     * @return the repetition penalty value, or null if not configured
-     */
-    public Double repetitionPenalty() {
-        return get(REPETITION_PENALTY).map(Double::parseDouble).orElse(null);
-    }
-
-    /**
      * Returns whether to return the full text including the input prompt.
      *
      * <p>When set to true, the response includes both the input prompt and the generated text.
@@ -254,32 +185,5 @@ public class HuggingFaceConfig extends AbstractConfig {
      */
     public Integer timeoutSeconds() {
         return get(TIMEOUT).map(Integer::parseInt).orElse(null);
-    }
-
-    /**
-     * Returns the maximum number of retry attempts for failed requests.
-     *
-     * <p>When a request fails due to transient issues, this setting controls how many times
-     * to retry before giving up.
-     *
-     * @return the maximum retry attempts, or null if not configured
-     */
-    public Integer maxRetries() {
-        return get(MAX_RETRIES).map(Integer::parseInt).orElse(null);
-    }
-
-    /**
-     * Returns whether to log both request and response details.
-     *
-     * <p>When enabled, logs the details of both requests sent to and responses received
-     * from HuggingFace Inference API. Useful for debugging and monitoring.
-     *
-     * <p><strong>Security Note:</strong> Be cautious when enabling in production
-     * as this may log sensitive data including API keys and user content.
-     *
-     * @return true if request and response logging is enabled, false if disabled, or null if not configured
-     */
-    public Boolean logRequestsAndResponses() {
-        return get(LOG_REQUESTS_AND_RESPONSES).map(Boolean::parseBoolean).orElse(null);
     }
 }

--- a/library/ai/models/chat/forage-model-hugging-face/src/main/java/io/kaoto/forage/models/chat/huggingface/HuggingFaceConfigEntries.java
+++ b/library/ai/models/chat/forage-model-hugging-face/src/main/java/io/kaoto/forage/models/chat/huggingface/HuggingFaceConfigEntries.java
@@ -41,42 +41,6 @@ public final class HuggingFaceConfigEntries extends ConfigEntries {
             "integer",
             false,
             ConfigTag.COMMON);
-    public static final ConfigModule TOP_K = ConfigModule.of(
-            HuggingFaceConfig.class,
-            "forage.huggingface.top.k",
-            "Top-k sampling parameter",
-            "Top K",
-            null,
-            "integer",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule TOP_P = ConfigModule.of(
-            HuggingFaceConfig.class,
-            "forage.huggingface.top.p",
-            "Top-p (nucleus) sampling parameter",
-            "Top P",
-            null,
-            "double",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule DO_SAMPLE = ConfigModule.of(
-            HuggingFaceConfig.class,
-            "forage.huggingface.do.sample",
-            "Whether to use sampling for text generation",
-            "Do Sample",
-            null,
-            "boolean",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule REPETITION_PENALTY = ConfigModule.of(
-            HuggingFaceConfig.class,
-            "forage.huggingface.repetition.penalty",
-            "Penalty for repeating tokens (1.0-2.0)",
-            "Repetition Penalty",
-            null,
-            "double",
-            false,
-            ConfigTag.ADVANCED);
     public static final ConfigModule RETURN_FULL_TEXT = ConfigModule.of(
             HuggingFaceConfig.class,
             "forage.huggingface.return.full.text",
@@ -104,24 +68,6 @@ public final class HuggingFaceConfigEntries extends ConfigEntries {
             "integer",
             false,
             ConfigTag.ADVANCED);
-    public static final ConfigModule MAX_RETRIES = ConfigModule.of(
-            HuggingFaceConfig.class,
-            "forage.huggingface.max.retries",
-            "Maximum number of retry attempts",
-            "Max Retries",
-            null,
-            "integer",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(
-            HuggingFaceConfig.class,
-            "forage.huggingface.log.requests.and.responses",
-            "Enable request and response logging",
-            "Log Requests/Responses",
-            null,
-            "boolean",
-            false,
-            ConfigTag.ADVANCED);
 
     static {
         initModules(
@@ -130,14 +76,8 @@ public final class HuggingFaceConfigEntries extends ConfigEntries {
                 MODEL_ID,
                 TEMPERATURE,
                 MAX_NEW_TOKENS,
-                TOP_K,
-                TOP_P,
-                DO_SAMPLE,
-                REPETITION_PENALTY,
                 RETURN_FULL_TEXT,
                 WAIT_FOR_MODEL,
-                TIMEOUT,
-                MAX_RETRIES,
-                LOG_REQUESTS_AND_RESPONSES);
+                TIMEOUT);
     }
 }

--- a/library/ai/models/chat/forage-model-hugging-face/src/main/java/io/kaoto/forage/models/chat/huggingface/HuggingFaceProvider.java
+++ b/library/ai/models/chat/forage-model-hugging-face/src/main/java/io/kaoto/forage/models/chat/huggingface/HuggingFaceProvider.java
@@ -45,7 +45,10 @@ public class HuggingFaceProvider implements ModelProvider {
             builder.waitForModel(config.waitForModel());
         }
 
-        // Configure connection and reliability settings
+        if (config.returnFullText() != null) {
+            builder.returnFullText(config.returnFullText());
+        }
+
         if (config.timeoutSeconds() != null) {
             builder.timeout(ofSeconds(config.timeoutSeconds()));
         }

--- a/library/ai/models/chat/forage-model-ollama/src/main/java/io/kaoto/forage/models/chat/ollama/OllamaConfigEntries.java
+++ b/library/ai/models/chat/forage-model-ollama/src/main/java/io/kaoto/forage/models/chat/ollama/OllamaConfigEntries.java
@@ -19,7 +19,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "forage.ollama.model.name",
             "The Ollama model to use",
             "Model Name",
-            "llama3",
+            "llama3.2",
             "string",
             false,
             ConfigTag.COMMON);

--- a/library/ai/models/chat/forage-model-ollama/src/test/java/io/kaoto/forage/models/chat/ollama/OllamaDefaultValueTests.java
+++ b/library/ai/models/chat/forage-model-ollama/src/test/java/io/kaoto/forage/models/chat/ollama/OllamaDefaultValueTests.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OllamaDefaultValueTests {
 
     private static final String DEFAULT_BASE_URL = "http://localhost:11434";
-    private static final String DEFAULT_MODEL_NAME = "llama3";
+    private static final String DEFAULT_MODEL_NAME = "llama3.2";
 
     @Test
     @DisplayName("Should return default base URL when no configuration provided")

--- a/library/ai/models/chat/forage-model-open-ai/src/main/java/io/kaoto/forage/models/chat/openai/OpenAIConfigEntries.java
+++ b/library/ai/models/chat/forage-model-open-ai/src/main/java/io/kaoto/forage/models/chat/openai/OpenAIConfigEntries.java
@@ -19,7 +19,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "forage.openai.model.name",
             "The specific OpenAI model to use",
             "Model Name",
-            "gpt-3.5-turbo",
+            "gpt-4o-mini",
             "string",
             true,
             ConfigTag.COMMON);

--- a/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiConfig.java
+++ b/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiConfig.java
@@ -7,16 +7,11 @@ import io.kaoto.forage.core.util.config.AbstractConfig;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.API_KEY;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.LOG_REQUESTS_AND_RESPONSES;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.MAX_NEW_TOKENS;
-import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.MAX_RETRIES;
-import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.MIN_NEW_TOKENS;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.MODEL_NAME;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.PROJECT_ID;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.RANDOM_SEED;
-import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.REPETITION_PENALTY;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.STOP_SEQUENCES;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.TEMPERATURE;
-import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.TIMEOUT;
-import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.TOP_K;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.TOP_P;
 import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.URL;
 
@@ -40,13 +35,10 @@ import static io.kaoto.forage.models.chat.watsonxai.WatsonxAiConfigEntries.URL;
  *   <li><strong>WATSONXAI_TEMPERATURE</strong> - Controls randomness (0.0-2.0)</li>
  *   <li><strong>WATSONXAI_MAX_NEW_TOKENS</strong> - Maximum new tokens in response</li>
  *   <li><strong>WATSONXAI_TOP_P</strong> - Nucleus sampling parameter (0.0-1.0)</li>
- *   <li><strong>WATSONXAI_TOP_K</strong> - Top-k sampling parameter</li>
  *   <li><strong>WATSONXAI_RANDOM_SEED</strong> - Random seed for reproducible results</li>
  *   <li><strong>WATSONXAI_REPETITION_PENALTY</strong> - Penalty for repetition (1.0-2.0)</li>
- *   <li><strong>WATSONXAI_MIN_NEW_TOKENS</strong> - Minimum new tokens in response</li>
  *   <li><strong>WATSONXAI_STOP_SEQUENCES</strong> - Stop sequences for response generation</li>
  *   <li><strong>WATSONXAI_TIMEOUT</strong> - Request timeout in seconds</li>
- *   <li><strong>WATSONXAI_MAX_RETRIES</strong> - Maximum retry attempts</li>
  *   <li><strong>WATSONXAI_LOG_REQUESTS_AND_RESPONSES</strong> - Enable request/response logging</li>
  * </ul>
  *
@@ -229,43 +221,12 @@ public class WatsonxAiConfig extends AbstractConfig {
     }
 
     /**
-     * Returns the top-k sampling parameter.
-     *
-     * <p>Limits the number of highest probability tokens to consider during generation.
-     *
-     * @return the top-k value, or null if not configured
-     */
-    public Integer topK() {
-        return get(TOP_K).map(Integer::parseInt).orElse(null);
-    }
-
-    /**
      * Returns the random seed for deterministic response generation.
      *
      * @return the random seed value, or null if not configured
      */
     public Integer randomSeed() {
         return get(RANDOM_SEED).map(Integer::parseInt).orElse(null);
-    }
-
-    /**
-     * Returns the repetition penalty for discouraging repetitive content.
-     *
-     * <p><strong>Value Range:</strong> 1.0 to 2.0
-     *
-     * @return the repetition penalty value, or null if not configured
-     */
-    public Double repetitionPenalty() {
-        return get(REPETITION_PENALTY).map(Double::parseDouble).orElse(null);
-    }
-
-    /**
-     * Returns the minimum number of new tokens for model responses.
-     *
-     * @return the minimum new tokens, or null if not configured
-     */
-    public Integer minNewTokens() {
-        return get(MIN_NEW_TOKENS).map(Integer::parseInt).orElse(null);
     }
 
     /**
@@ -282,24 +243,6 @@ public class WatsonxAiConfig extends AbstractConfig {
                         .filter(s -> !s.isEmpty())
                         .toList())
                 .orElse(null);
-    }
-
-    /**
-     * Returns the request timeout duration in seconds.
-     *
-     * @return the timeout in seconds, or null if not configured
-     */
-    public Integer timeoutSeconds() {
-        return get(TIMEOUT).map(Integer::parseInt).orElse(null);
-    }
-
-    /**
-     * Returns the maximum number of retry attempts for failed requests.
-     *
-     * @return the maximum retry attempts, or null if not configured
-     */
-    public Integer maxRetries() {
-        return get(MAX_RETRIES).map(Integer::parseInt).orElse(null);
     }
 
     /**

--- a/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiConfigEntries.java
+++ b/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiConfigEntries.java
@@ -68,38 +68,11 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "double",
             false,
             ConfigTag.ADVANCED);
-    public static final ConfigModule TOP_K = ConfigModule.of(
-            WatsonxAiConfig.class,
-            "forage.watsonxai.top.k",
-            "Top-k sampling parameter",
-            "Top K",
-            null,
-            "integer",
-            false,
-            ConfigTag.ADVANCED);
     public static final ConfigModule RANDOM_SEED = ConfigModule.of(
             WatsonxAiConfig.class,
             "forage.watsonxai.random.seed",
             "Random seed for reproducible results",
             "Random Seed",
-            null,
-            "integer",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule REPETITION_PENALTY = ConfigModule.of(
-            WatsonxAiConfig.class,
-            "forage.watsonxai.repetition.penalty",
-            "Penalty for repetition (1.0-2.0)",
-            "Repetition Penalty",
-            null,
-            "double",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule MIN_NEW_TOKENS = ConfigModule.of(
-            WatsonxAiConfig.class,
-            "forage.watsonxai.min.new.tokens",
-            "Minimum number of new tokens in response",
-            "Min New Tokens",
             null,
             "integer",
             false,
@@ -111,24 +84,6 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Stop Sequences",
             null,
             "string",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule TIMEOUT = ConfigModule.of(
-            WatsonxAiConfig.class,
-            "forage.watsonxai.timeout",
-            "Request timeout in seconds",
-            "Timeout",
-            null,
-            "integer",
-            false,
-            ConfigTag.ADVANCED);
-    public static final ConfigModule MAX_RETRIES = ConfigModule.of(
-            WatsonxAiConfig.class,
-            "forage.watsonxai.max.retries",
-            "Maximum number of retry attempts",
-            "Max Retries",
-            null,
-            "integer",
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(
@@ -151,13 +106,8 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
                 TEMPERATURE,
                 MAX_NEW_TOKENS,
                 TOP_P,
-                TOP_K,
                 RANDOM_SEED,
-                REPETITION_PENALTY,
-                MIN_NEW_TOKENS,
                 STOP_SEQUENCES,
-                TIMEOUT,
-                MAX_RETRIES,
                 LOG_REQUESTS_AND_RESPONSES);
     }
 }

--- a/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiProvider.java
+++ b/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiProvider.java
@@ -82,11 +82,18 @@ public class WatsonxAiProvider implements ModelProvider {
             builder.topP(config.topP());
         }
 
+        if (config.maxNewTokens() != null) {
+            builder.maxOutputTokens(config.maxNewTokens());
+        }
+
         if (config.stopSequences() != null) {
             builder.stopSequences(config.stopSequences());
         }
 
-        // Configure logging settings
+        if (config.randomSeed() != null) {
+            builder.seed(config.randomSeed());
+        }
+
         if (config.logRequestsAndResponses() != null) {
             builder.logRequests(config.logRequestsAndResponses());
             builder.logResponses(config.logRequestsAndResponses());

--- a/library/ai/models/embeddings/forage-model-embeddings-ollama/src/main/java/io/kaoto/forage/models/embeddings/ollama/OllamaEmbeddingConfig.java
+++ b/library/ai/models/embeddings/forage-model-embeddings-ollama/src/main/java/io/kaoto/forage/models/embeddings/ollama/OllamaEmbeddingConfig.java
@@ -34,7 +34,7 @@ import static io.kaoto.forage.models.embeddings.ollama.OllamaEmbeddingConfigEntr
  * @see io.kaoto.forage.core.util.config.ConfigModule
  * @since 1.0
  */
-public class OllamaEmbedddingConfig extends AbstractConfig {
+public class OllamaEmbeddingConfig extends AbstractConfig {
 
     /**
      * Creates an Ollama Embedding model instance.
@@ -57,11 +57,11 @@ public class OllamaEmbedddingConfig extends AbstractConfig {
      *
      * @since 1.0
      */
-    public OllamaEmbedddingConfig() {
+    public OllamaEmbeddingConfig() {
         this(null);
     }
 
-    public OllamaEmbedddingConfig(String prefix) {
+    public OllamaEmbeddingConfig(String prefix) {
         super(prefix, OllamaEmbeddingConfigEntries.class);
     }
 
@@ -120,7 +120,7 @@ public class OllamaEmbedddingConfig extends AbstractConfig {
      * @return the Ollama model name, never null
      */
     public String modelName() {
-        return get(MODEL_NAME).orElse("llama3");
+        return get(MODEL_NAME).orElse(MODEL_NAME.defaultValue());
     }
 
     /**

--- a/library/ai/models/embeddings/forage-model-embeddings-ollama/src/main/java/io/kaoto/forage/models/embeddings/ollama/OllamaEmbeddingConfigEntries.java
+++ b/library/ai/models/embeddings/forage-model-embeddings-ollama/src/main/java/io/kaoto/forage/models/embeddings/ollama/OllamaEmbeddingConfigEntries.java
@@ -6,7 +6,7 @@ import io.kaoto.forage.core.util.config.ConfigTag;
 
 public final class OllamaEmbeddingConfigEntries extends ConfigEntries {
     public static final ConfigModule BASE_URL = ConfigModule.of(
-            OllamaEmbedddingConfig.class,
+            OllamaEmbeddingConfig.class,
             "forage.ollama.embedding.model.base.url",
             "The base URL of the Ollama server",
             "Base URL",
@@ -15,16 +15,16 @@ public final class OllamaEmbeddingConfigEntries extends ConfigEntries {
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MODEL_NAME = ConfigModule.of(
-            OllamaEmbedddingConfig.class,
+            OllamaEmbeddingConfig.class,
             "forage.ollama.embedding.model.name",
             "The Ollama model to use",
             "Model Name",
-            "llama3",
+            "nomic-embed-text",
             "string",
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
-            OllamaEmbedddingConfig.class,
+            OllamaEmbeddingConfig.class,
             "forage.ollama.embedding.model.timeout",
             "Used for the HttpClientBuilder that will be used to communicate with Ollama",
             "Timeout",
@@ -33,7 +33,7 @@ public final class OllamaEmbeddingConfigEntries extends ConfigEntries {
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
-            OllamaEmbedddingConfig.class,
+            OllamaEmbeddingConfig.class,
             "forage.ollama.embedding.model.max.retries",
             "Used for the HttpClientBuilder that will be used to communicate with Ollama",
             "Max retries",
@@ -42,7 +42,7 @@ public final class OllamaEmbeddingConfigEntries extends ConfigEntries {
             false,
             ConfigTag.COMMON);
     public static final ConfigModule LOG_REQUESTS = ConfigModule.of(
-            OllamaEmbedddingConfig.class,
+            OllamaEmbeddingConfig.class,
             "forage.ollama.embedding.model.log.requests",
             "Enable request logging",
             "Log Requests",
@@ -51,7 +51,7 @@ public final class OllamaEmbeddingConfigEntries extends ConfigEntries {
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_RESPONSES = ConfigModule.of(
-            OllamaEmbedddingConfig.class,
+            OllamaEmbeddingConfig.class,
             "forage.ollama.embedding.model.log.responses",
             "Enable response logging",
             "Log Responses",

--- a/library/ai/models/embeddings/forage-model-embeddings-ollama/src/main/java/io/kaoto/forage/models/embeddings/ollama/OllamaEmbeddingProvider.java
+++ b/library/ai/models/embeddings/forage-model-embeddings-ollama/src/main/java/io/kaoto/forage/models/embeddings/ollama/OllamaEmbeddingProvider.java
@@ -14,7 +14,7 @@ import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
  * Provider for creating Ollama embedding models with configurable parameters.
  *
  * <p>This provider creates instances of {@link OllamaEmbeddingModel} using configuration
- * values managed by {@link OllamaEmbedddingConfig}. The configuration supports environment
+ * values managed by {@link OllamaEmbeddingConfig}. The configuration supports environment
  * variables, system properties, and configuration files for flexible deployment.
  *
  * <p><strong>Configuration:</strong>
@@ -37,7 +37,7 @@ import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
  * ChatModel model = provider.newModel();
  * }</pre>
  *
- * @see OllamaEmbedddingConfig
+ * @see OllamaEmbeddingConfig
  * @see ModelProvider
  * @since 1.0
  */
@@ -60,7 +60,7 @@ public class OllamaEmbeddingProvider implements EmbeddingModelProvider {
      */
     @Override
     public EmbeddingModel create(String id) {
-        final OllamaEmbedddingConfig config = new OllamaEmbedddingConfig(id);
+        final OllamaEmbeddingConfig config = new OllamaEmbeddingConfig(id);
 
         String baseUrl = config.baseUrl();
         String modelName = config.modelName();

--- a/library/ai/models/embeddings/forage-model-embeddings-ollama/src/test/java/io/kaoto/forage/models/embeddings/ollama/EmbeddingOllamaConfigurationSourcesTest.java
+++ b/library/ai/models/embeddings/forage-model-embeddings-ollama/src/test/java/io/kaoto/forage/models/embeddings/ollama/EmbeddingOllamaConfigurationSourcesTest.java
@@ -31,7 +31,7 @@ class EmbeddingOllamaConfigurationSourcesTest {
     @Test
     @DisplayName("Should load from configuration file only")
     void shouldLoadFromConfigurationFileOnly() {
-        OllamaEmbedddingConfig config = new OllamaEmbedddingConfig();
+        OllamaEmbeddingConfig config = new OllamaEmbeddingConfig();
 
         assertThat(config.baseUrl()).isEqualTo("testUrl");
         assertThat(config.modelName()).isEqualTo("gnomic-embed-text");

--- a/library/ai/vector-dbs/forage-vectordb-in-memory-store/src/main/java/io/kaoto/forage/vectordb/inmemory/InMemoryStoreConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-in-memory-store/src/main/java/io/kaoto/forage/vectordb/inmemory/InMemoryStoreConfigEntries.java
@@ -12,7 +12,7 @@ public final class InMemoryStoreConfigEntries extends ConfigEntries {
             "File source",
             null,
             "string",
-            true,
+            false,
             ConfigTag.COMMON);
 
     public static final ConfigModule MAX_SIZE = ConfigModule.of(

--- a/library/ai/vector-dbs/forage-vectordb-in-memory-store/src/main/java/io/kaoto/forage/vectordb/inmemory/InMemoryStoreProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-in-memory-store/src/main/java/io/kaoto/forage/vectordb/inmemory/InMemoryStoreProvider.java
@@ -53,9 +53,9 @@ import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
  * @since 1.0
  */
 @ForageBean(
-        value = "inMemoryStore",
+        value = "in-memory-store",
         components = {"camel-langchain4j-embeddings"},
-        description = "MariaDB with vector support")
+        description = "In-memory embedding store")
 public class InMemoryStoreProvider implements EmbeddingStoreProvider, EmbeddingModelAware {
     private static final Logger LOG = LoggerFactory.getLogger(InMemoryStoreProvider.class);
 
@@ -76,8 +76,13 @@ public class InMemoryStoreProvider implements EmbeddingStoreProvider, EmbeddingM
         }
 
         String fileSource = config.fileSource();
-        Integer maxSize = config.maxSize();
-        Integer overlapSize = config.overlapSize();
+        if (fileSource == null) {
+            LOG.trace("InMemory embedding store is not created. The source file is not provided.");
+            return null;
+        }
+
+        int maxSize = config.maxSize() != null ? config.maxSize() : 300;
+        int overlapSize = config.overlapSize() != null ? config.overlapSize() : 30;
 
         LOG.trace(
                 "Creating InMemory embedding store from {} with configuration: maxSize={}, overlapSize={}",

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusConfig.java
@@ -136,11 +136,11 @@ public class MilvusConfig extends AbstractConfig {
     }
 
     public String username() {
-        return get(USERNAME).orElse("");
+        return get(USERNAME).orElse(null);
     }
 
     public String password() {
-        return get(PASSWORD).orElse("");
+        return get(PASSWORD).orElse(null);
     }
 
     public ConsistencyLevelEnum consistencyLevel() {
@@ -158,7 +158,7 @@ public class MilvusConfig extends AbstractConfig {
     }
 
     public String databaseName() {
-        return getRequired(DATABASE_NAME, "Missing Milvus database name");
+        return get(DATABASE_NAME).orElse(null);
     }
 
     public String idFieldName() {

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusConfigEntries.java
@@ -82,7 +82,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "forage.milvus.username",
             "Username for authentication",
             "Username",
-            "",
+            null,
             "string",
             false,
             ConfigTag.SECURITY);
@@ -91,7 +91,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "forage.milvus.password",
             "Password for authentication",
             "Password",
-            "",
+            null,
             "password",
             false,
             ConfigTag.SECURITY);
@@ -129,7 +129,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Database Name",
             null,
             "string",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule ID_FIELD_NAME = ConfigModule.of(
             MilvusConfig.class,

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusProvider.java
@@ -76,6 +76,7 @@ public class MilvusProvider implements EmbeddingStoreProvider {
                 .consistencyLevel(config.consistencyLevel())
                 .retrieveEmbeddingsOnSearch(config.retrieveEmbeddingsOnSearch())
                 .autoFlushOnInsert(config.autoFlushOnInsert())
+                .databaseName(config.databaseName())
                 .build();
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/io/kaoto/forage/vectordb/pgvector/PgVectorConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/io/kaoto/forage/vectordb/pgvector/PgVectorConfig.java
@@ -37,7 +37,7 @@ public class PgVectorConfig extends AbstractConfig {
     }
 
     public Integer port() {
-        return get(PORT).map(Integer::parseInt).orElseThrow(() -> new MissingConfigException("Missing PGVector port"));
+        return get(PORT).map(Integer::parseInt).orElse(5432);
     }
 
     public String user() {

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/io/kaoto/forage/vectordb/pgvector/PgVectorConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/io/kaoto/forage/vectordb/pgvector/PgVectorConfigEntries.java
@@ -19,9 +19,9 @@ public final class PgVectorConfigEntries extends ConfigEntries {
             "forage.pgvector.port",
             "PostgreSQL server port number",
             "Port",
-            null,
+            "5432",
             "integer",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule USER = ConfigModule.of(
             PgVectorConfig.class,

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/io/kaoto/forage/vectordb/pinecone/PineconeConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/io/kaoto/forage/vectordb/pinecone/PineconeConfig.java
@@ -2,10 +2,10 @@ package io.kaoto.forage.vectordb.pinecone;
 
 import org.openapitools.db_control.client.model.DeletionProtection;
 import io.kaoto.forage.core.util.config.AbstractConfig;
-import io.kaoto.forage.core.util.config.MissingConfigException;
 
 import static io.kaoto.forage.vectordb.pinecone.PineconeConfigEntries.API_KEY;
 import static io.kaoto.forage.vectordb.pinecone.PineconeConfigEntries.CLOUD;
+import static io.kaoto.forage.vectordb.pinecone.PineconeConfigEntries.CREATE_INDEX;
 import static io.kaoto.forage.vectordb.pinecone.PineconeConfigEntries.DELETION_PROTECTION;
 import static io.kaoto.forage.vectordb.pinecone.PineconeConfigEntries.DIMENSION;
 import static io.kaoto.forage.vectordb.pinecone.PineconeConfigEntries.INDEX;
@@ -44,18 +44,20 @@ public class PineconeConfig extends AbstractConfig {
         return get(METADATA_TEXT_KEY).orElse("text_segment");
     }
 
+    public boolean createIndex() {
+        return get(CREATE_INDEX).map(Boolean::parseBoolean).orElse(false);
+    }
+
     public Integer dimension() {
-        return get(DIMENSION)
-                .map(Integer::parseInt)
-                .orElseThrow(() -> new MissingConfigException("Missing Pinecone dimension"));
+        return get(DIMENSION).map(Integer::parseInt).orElse(null);
     }
 
     public String cloud() {
-        return getRequired(CLOUD, "Missing Pinecone cloud");
+        return get(CLOUD).orElse(null);
     }
 
     public String region() {
-        return getRequired(REGION, "Missing Pinecone region");
+        return get(REGION).orElse(null);
     }
 
     public DeletionProtection deletionProtection() {

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/io/kaoto/forage/vectordb/pinecone/PineconeConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/io/kaoto/forage/vectordb/pinecone/PineconeConfigEntries.java
@@ -71,29 +71,29 @@ public final class PineconeConfigEntries extends ConfigEntries {
     public static final ConfigModule DIMENSION = ConfigModule.of(
             PineconeConfig.class,
             "forage.pinecone.dimension",
-            "Vector dimension size",
+            "Vector dimension size (required when create.index is true)",
             "Dimension",
             null,
             "integer",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule CLOUD = ConfigModule.of(
             PineconeConfig.class,
             "forage.pinecone.cloud",
-            "Cloud provider (e.g., aws, gcp, azure)",
+            "Cloud provider, e.g. aws, gcp, azure (required when create.index is true)",
             "Cloud",
             null,
             "string",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule REGION = ConfigModule.of(
             PineconeConfig.class,
             "forage.pinecone.region",
-            "Cloud region for the index",
+            "Cloud region for the index (required when create.index is true)",
             "Region",
             null,
             "string",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule DELETION_PROTECTION = ConfigModule.of(
             PineconeConfig.class,

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/io/kaoto/forage/vectordb/pinecone/PineconeProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/io/kaoto/forage/vectordb/pinecone/PineconeProvider.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import io.kaoto.forage.core.ai.EmbeddingStoreProvider;
 import io.kaoto.forage.core.annotations.ForageBean;
 import dev.langchain4j.store.embedding.pinecone.PineconeEmbeddingStore;
+import dev.langchain4j.store.embedding.pinecone.PineconeServerlessIndexConfig;
 
 /**
  * Provider for creating Pinecone embedding stores within the Forage framework.
@@ -65,11 +66,21 @@ public class PineconeProvider implements EmbeddingStoreProvider {
 
         PineconeConfig config = new PineconeConfig(id);
 
+        PineconeServerlessIndexConfig indexConfig = null;
+        if (config.createIndex()) {
+            indexConfig = PineconeServerlessIndexConfig.builder()
+                    .dimension(config.dimension())
+                    .cloud(config.cloud())
+                    .region(config.region())
+                    .deletionProtection(config.deletionProtection())
+                    .build();
+        }
+
         return PineconeEmbeddingStore.builder()
                 .apiKey(config.apiKey())
                 .index(config.index())
                 .nameSpace(config.nameSpace())
-                .createIndex(null)
+                .createIndex(indexConfig)
                 .metadataTextKey(config.metadataTextKey())
                 .build();
     }

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/io/kaoto/forage/vectordb/qdrant/QdrantConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/io/kaoto/forage/vectordb/qdrant/QdrantConfig.java
@@ -1,7 +1,6 @@
 package io.kaoto.forage.vectordb.qdrant;
 
 import io.kaoto.forage.core.util.config.AbstractConfig;
-import io.kaoto.forage.core.util.config.MissingConfigException;
 
 import static io.kaoto.forage.vectordb.qdrant.QdrantConfigEntries.API_KEY;
 import static io.kaoto.forage.vectordb.qdrant.QdrantConfigEntries.COLLECTION_NAME;
@@ -34,7 +33,7 @@ public class QdrantConfig extends AbstractConfig {
     }
 
     public Integer port() {
-        return get(PORT).map(Integer::parseInt).orElseThrow(() -> new MissingConfigException("Missing Qdrant port"));
+        return get(PORT).map(Integer::parseInt).orElse(6334);
     }
 
     public Boolean useTls() {

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/io/kaoto/forage/vectordb/qdrant/QdrantConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/io/kaoto/forage/vectordb/qdrant/QdrantConfigEntries.java
@@ -28,9 +28,9 @@ public final class QdrantConfigEntries extends ConfigEntries {
             "forage.qdrant.port",
             "Qdrant server port number",
             "Port",
-            null,
+            "6334",
             "integer",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule USE_TLS = ConfigModule.of(
             QdrantConfig.class,

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfig.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import io.kaoto.forage.core.util.config.AbstractConfig;
-import io.kaoto.forage.core.util.config.MissingConfigException;
 
 import static io.kaoto.forage.vectordb.weaviate.WeaviateConfigEntries.API_KEY;
 import static io.kaoto.forage.vectordb.weaviate.WeaviateConfigEntries.AVOID_DUPS;
@@ -48,25 +47,19 @@ public class WeaviateConfig extends AbstractConfig {
     }
 
     public Integer port() {
-        return get(PORT).map(Integer::parseInt).orElseThrow(() -> new MissingConfigException("Missing Weaviate port"));
+        return get(PORT).map(Integer::parseInt).orElse(8080);
     }
 
     public Boolean useGrpcForInserts() {
-        return get(USE_GRPC_FOR_INSERTS)
-                .map(Boolean::parseBoolean)
-                .orElseThrow(() -> new MissingConfigException("Missing Weaviate use grpc for inserts"));
+        return get(USE_GRPC_FOR_INSERTS).map(Boolean::parseBoolean).orElse(false);
     }
 
     public Boolean securedGrpc() {
-        return get(SECURED_GRPC)
-                .map(Boolean::parseBoolean)
-                .orElseThrow(() -> new MissingConfigException("Missing Weaviate secured grpc"));
+        return get(SECURED_GRPC).map(Boolean::parseBoolean).orElse(false);
     }
 
     public Integer grpcPort() {
-        return get(GRPC_PORT)
-                .map(Integer::parseInt)
-                .orElseThrow(() -> new MissingConfigException("Missing Weaviate grpc port"));
+        return get(GRPC_PORT).map(Integer::parseInt).orElse(50051);
     }
 
     public String objectClass() {

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/io/kaoto/forage/vectordb/weaviate/WeaviateConfigEntries.java
@@ -37,36 +37,36 @@ public final class WeaviateConfigEntries extends ConfigEntries {
             "forage.weaviate.port",
             "Weaviate server port number",
             "Port",
-            null,
+            "8080",
             "integer",
-            true,
+            false,
             ConfigTag.COMMON);
     public static final ConfigModule USE_GRPC_FOR_INSERTS = ConfigModule.of(
             WeaviateConfig.class,
             "forage.weaviate.use.grpc.for.inserts",
             "Use gRPC protocol for insert operations",
             "Use gRPC for Inserts",
-            null,
+            "false",
             "boolean",
-            true,
+            false,
             ConfigTag.ADVANCED);
     public static final ConfigModule SECURED_GRPC = ConfigModule.of(
             WeaviateConfig.class,
             "forage.weaviate.secured.grpc",
             "Enable secured gRPC connections",
             "Secured gRPC",
-            null,
+            "false",
             "boolean",
-            true,
+            false,
             ConfigTag.SECURITY);
     public static final ConfigModule GRPC_PORT = ConfigModule.of(
             WeaviateConfig.class,
             "forage.weaviate.grpc.port",
             "gRPC server port number",
             "gRPC Port",
-            null,
+            "50051",
             "integer",
-            true,
+            false,
             ConfigTag.ADVANCED);
     public static final ConfigModule OBJECT_CLASS = ConfigModule.of(
             WeaviateConfig.class,


### PR DESCRIPTION
## Backport of #471

Cherry-pick of #471 onto `camel-latest`.

**Original PR:** #471 - Fix #406: AI provider hygiene sweep
**Original author:** @Croway
**Target branch:** `camel-latest`

### Original description

See #471 for full details. Summary of changes:

- InMemoryStore: null-safety, description fix, kebab-case value
- Pinecone: wire index-creation config
- HuggingFace: wire returnFullText, remove unsupported config
- Watsonx: wire maxNewTokens/randomSeed, remove unsupported entries
- Agent config: remove dead redis/infinispan entries, fix required flag
- Anthropic/DashScope: fix error before UnsupportedOperationException
- Default model names refreshed
- Milvus: wire databaseName, fix credentials
- Weaviate/Qdrant/PgVector: add port defaults, Weaviate gRPC defaults
- OllamaEmbedddingConfig triple-d typo fix
- Google Gemini: add maxOutputTokens/topP/topK