### PR TITLE
[backport camel-latest] Fix #433: scope JTA transaction wiring per named JMS broker

### DIFF
--- a/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
+++ b/library/jms/camel-quarkus/deployment/src/main/java/io/kaoto/forage/quarkus/jms/deployment/ForageJmsProcessor.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.camel.quarkus.core.deployment.spi.CamelRuntimeBeanBuildItem;
+import org.apache.camel.quarkus.core.deployment.spi.RuntimeCamelContextCustomizerBuildItem;
+import org.apache.camel.spi.CamelContextCustomizer;
 import org.apache.camel.spi.ComponentCustomizer;
 import org.jboss.logging.Logger;
 import io.kaoto.forage.core.annotations.FactoryType;
@@ -70,9 +72,9 @@ public class ForageJmsProcessor {
     }
 
     /**
-     * Wires a JTA transaction manager into the Camel JMS component when any Forage JMS
-     * configuration enables transactions, so the message listener container starts a JTA
-     * transaction around receive() and XA sessions enlist in it (#427).
+     * Wires a JTA transaction manager into the default Camel JMS component when any Forage
+     * JMS configuration enables transactions (#427). Named components are pre-configured
+     * with per-broker JTA scoping (#433).
      */
     @BuildStep
     @Record(value = ExecutionTime.RUNTIME_INIT)
@@ -87,6 +89,27 @@ public class ForageJmsProcessor {
                     "forageJmsTransactionManagerCustomizer",
                     ComponentCustomizer.class.getName(),
                     recorder.createJmsTransactionManagerCustomizer()));
+        }
+    }
+
+    /**
+     * Registers per-broker {@code JmsComponent} instances so routes using
+     * {@code mq1:queue:...} get the correct ConnectionFactory and JTA scoping (#433).
+     */
+    @BuildStep
+    @Record(value = ExecutionTime.RUNTIME_INIT)
+    void registerPerBrokerJmsComponents(
+            ForageJmsRecorder recorder, BuildProducer<RuntimeCamelContextCustomizerBuildItem> customizers) {
+
+        Map<String, ConnectionFactoryConfig> configs = discoverConfigs();
+        Map<String, Boolean> namedPrefixes = configs.entrySet().stream()
+                .filter(e -> e.getKey() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().transactionEnabled()));
+
+        if (!namedPrefixes.isEmpty()) {
+            RuntimeValue<CamelContextCustomizer> customizer =
+                    recorder.createPerBrokerJmsComponentCustomizer(namedPrefixes);
+            customizers.produce(new RuntimeCamelContextCustomizerBuildItem(customizer));
         }
     }
 

--- a/library/jms/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/jms/ForageJmsRecorder.java
+++ b/library/jms/camel-quarkus/runtime/src/main/java/io/kaoto/forage/quarkus/jms/ForageJmsRecorder.java
@@ -2,8 +2,11 @@ package io.kaoto.forage.quarkus.jms;
 
 import jakarta.jms.ConnectionFactory;
 
+import java.util.Map;
+import org.apache.camel.spi.CamelContextCustomizer;
 import org.apache.camel.spi.ComponentCustomizer;
 import org.jboss.logging.Logger;
+import org.springframework.transaction.jta.JtaTransactionManager;
 import io.kaoto.forage.jms.common.transactions.JmsJtaTransactionSupport;
 import io.kaoto.forage.jms.ibmmq.IbmMqJms;
 import io.quarkus.runtime.RuntimeValue;
@@ -26,12 +29,41 @@ public class ForageJmsRecorder {
 
     /**
      * Creates a {@link ComponentCustomizer} that wires a Spring {@code JtaTransactionManager}
-     * (wrapping the Narayana transaction manager) into the Camel JMS component, so JMS
-     * consumers receive within a JTA transaction and XA sessions enlist in it (#427).
+     * (wrapping the Narayana transaction manager) into the default Camel JMS component, so
+     * JMS consumers receive within a JTA transaction and XA sessions enlist in it (#427).
+     * Named components are handled by {@link #createPerBrokerJmsComponentCustomizer} (#433).
      */
     public RuntimeValue<ComponentCustomizer> createJmsTransactionManagerCustomizer() {
-        LOG.info("Registering Forage JTA transaction manager customizer for the Camel JMS component");
+        LOG.info("Registering Forage JTA transaction manager customizer for the default Camel JMS component");
         return new RuntimeValue<>(JmsJtaTransactionSupport.jmsComponentCustomizer(
                 JmsJtaTransactionSupport.createJtaTransactionManager()));
+    }
+
+    /**
+     * Creates a {@link CamelContextCustomizer} that registers per-broker {@code JmsComponent}
+     * instances so each named broker has its own ConnectionFactory and JTA scoping (#433).
+     */
+    public RuntimeValue<CamelContextCustomizer> createPerBrokerJmsComponentCustomizer(
+            Map<String, Boolean> namedPrefixes) {
+        return new RuntimeValue<>(camelContext -> {
+            JtaTransactionManager jtaTransactionManager = null;
+            boolean anyTransactionEnabled = namedPrefixes.containsValue(Boolean.TRUE);
+            if (anyTransactionEnabled) {
+                jtaTransactionManager = JmsJtaTransactionSupport.createJtaTransactionManager();
+            }
+
+            for (Map.Entry<String, Boolean> entry : namedPrefixes.entrySet()) {
+                String name = entry.getKey();
+                boolean txEnabled = entry.getValue();
+                ConnectionFactory cf = camelContext.getRegistry().lookupByNameAndType(name, ConnectionFactory.class);
+                if (cf == null) {
+                    LOG.warnf("ConnectionFactory '%s' not found in registry, skipping JmsComponent registration", name);
+                    continue;
+                }
+                JtaTransactionManager perBrokerTm = txEnabled ? jtaTransactionManager : null;
+                camelContext.addComponent(name, JmsJtaTransactionSupport.createJmsComponent(cf, perBrokerTm));
+                LOG.infof("Registered per-broker JmsComponent '%s' (transactions=%s)", name, txEnabled);
+            }
+        });
     }
 }

--- a/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/JmsJtaTransactionSupport.java
+++ b/library/jms/forage-jms-common/src/main/java/io/kaoto/forage/jms/common/transactions/JmsJtaTransactionSupport.java
@@ -7,6 +7,7 @@ import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.spi.ComponentCustomizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.jta.JtaTransactionManager;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.UserTransactionImple;
@@ -44,14 +45,37 @@ public final class JmsJtaTransactionSupport {
     }
 
     /**
-     * Creates a {@link ComponentCustomizer} that sets the given transaction manager on every
-     * {@link JmsComponent} added to the CamelContext (unless one is already configured).
-     * Camel core applies customizers found in the registry on all runtimes.
+     * Creates a pre-configured {@link JmsComponent} with the given connection factory
+     * and optional transaction manager. Used to register per-named-broker components
+     * so each broker has its own JTA scoping (#433).
+     */
+    public static JmsComponent createJmsComponent(
+            ConnectionFactory connectionFactory, PlatformTransactionManager transactionManager) {
+        JmsComponent component = new JmsComponent();
+        component.setConnectionFactory(connectionFactory);
+        if (transactionManager != null) {
+            component.setTransactionManager(transactionManager);
+        }
+        return component;
+    }
+
+    /**
+     * Creates a {@link ComponentCustomizer} that sets the given transaction manager on the
+     * default {@code jms} {@link JmsComponent}. Named components (registered per broker by
+     * {@link #createJmsComponent}) are skipped because they are pre-configured with the
+     * correct transaction manager (or none) at creation time (#433).
      */
     public static ComponentCustomizer jmsComponentCustomizer(JtaTransactionManager transactionManager) {
         return ComponentCustomizer.builder(JmsComponent.class).build((name, component) -> {
             if (component.getConfiguration().getTransactionManager() != null) {
                 LOG.debug("Camel JMS component '{}' already has a transaction manager, leaving it untouched", name);
+                return;
+            }
+            if (!"jms".equals(name)) {
+                LOG.debug(
+                        "Skipping JTA wiring for named JMS component '{}' — "
+                                + "per-broker components are pre-configured at creation time",
+                        name);
                 return;
             }
             LOG.info("Configuring Camel JMS component '{}' with the Forage JTA transaction manager", name);

--- a/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
+++ b/library/jms/forage-jms/src/main/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactory.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 import org.apache.camel.CamelContext;
+import org.apache.camel.component.jms.JmsComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.jta.JtaTransactionManager;
@@ -102,6 +103,7 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
 
         for (String name : prefixes) {
             closeAndUnbind(name);
+            camelContext.removeComponent(name);
         }
         closeAndUnbind(DEFAULT_CONNECTION_FACTORY);
 
@@ -158,8 +160,9 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
         Set<String> prefixes =
                 ConfigStore.getInstance().readPrefixes(config, ConfigHelper.getNamedPropertyRegexp("jms"));
 
-        // Bind JTA policies when the default config OR any discovered prefixed config
-        // has transactions enabled (e.g., forage.mq1.jms.transaction.enabled=true)
+        // Bind JTA policies and transaction manager when the default config OR any
+        // discovered prefixed config has transactions enabled (#427)
+        JtaTransactionManager jtaTransactionManager = null;
         if (anyTransactionEnabled(config, prefixes)) {
             camelContext.getRegistry().bind("PROPAGATION_REQUIRED", new RequiredJtaTransactionPolicy());
             camelContext.getRegistry().bind("MANDATORY", new MandatoryJtaTransactionPolicy());
@@ -168,29 +171,42 @@ public class ConnectionFactoryBeanFactory implements BeanFactory {
             camelContext.getRegistry().bind("REQUIRES_NEW", new RequiresNewJtaTransactionPolicy());
             camelContext.getRegistry().bind("SUPPORTS", new SupportsJtaTransactionPolicy());
 
-            // Wire JTA into the Camel JMS component so the listener container starts a JTA
-            // transaction around receive() and XA sessions enlist in it (#427). The customizer
-            // is applied by Camel core to every JmsComponent added to the context.
-            JtaTransactionManager jtaTransactionManager = JmsJtaTransactionSupport.createJtaTransactionManager();
+            jtaTransactionManager = JmsJtaTransactionSupport.createJtaTransactionManager();
             camelContext.getRegistry().bind(JTA_TRANSACTION_MANAGER, jtaTransactionManager);
-            camelContext
-                    .getRegistry()
-                    .bind(
-                            JMS_TRANSACTION_MANAGER_CUSTOMIZER,
-                            JmsJtaTransactionSupport.jmsComponentCustomizer(jtaTransactionManager));
+
+            // Apply the ComponentCustomizer to the default "jms" component ONLY when
+            // the default (unprefixed) config enables transactions. Named per-broker
+            // components are pre-configured at creation time (#433).
+            if (config.transactionEnabled()) {
+                camelContext
+                        .getRegistry()
+                        .bind(
+                                JMS_TRANSACTION_MANAGER_CUSTOMIZER,
+                                JmsJtaTransactionSupport.jmsComponentCustomizer(jtaTransactionManager));
+            }
         }
 
         if (!prefixes.isEmpty()) {
             for (String name : prefixes) {
-                if (camelContext.getRegistry().lookupByNameAndType(name, ConnectionFactory.class) == null) {
+                ConnectionFactory connectionFactory =
+                        camelContext.getRegistry().lookupByNameAndType(name, ConnectionFactory.class);
+                if (connectionFactory == null) {
                     ConnectionFactoryConfig cfConfig = new ConnectionFactoryConfig(name);
-                    ConnectionFactory connectionFactory = newConnectionFactory(cfConfig, name);
+                    connectionFactory = newConnectionFactory(cfConfig, name);
                     if (connectionFactory != null) {
                         camelContext.getRegistry().bind(name, connectionFactory);
                     } else {
                         LOG.warn("Skipping binding for '{}' because ConnectionFactory creation returned null", name);
+                        continue;
                     }
                 }
+
+                // Register a per-broker JmsComponent so routes using "name:queue:..."
+                // get the correct ConnectionFactory and JTA scoping (#433)
+                ConnectionFactoryConfig cfConfig = new ConnectionFactoryConfig(name);
+                JtaTransactionManager perBrokerTm = cfConfig.transactionEnabled() ? jtaTransactionManager : null;
+                JmsComponent jmsComponent = JmsJtaTransactionSupport.createJmsComponent(connectionFactory, perBrokerTm);
+                camelContext.addComponent(name, jmsComponent);
             }
         } else {
             try {

--- a/library/jms/forage-jms/src/test/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactoryTransactionTest.java
+++ b/library/jms/forage-jms/src/test/java/io/kaoto/forage/jms/ConnectionFactoryBeanFactoryTransactionTest.java
@@ -28,8 +28,9 @@ class ConnectionFactoryBeanFactoryTransactionTest {
     @Test
     void prefixedTransactionEnabledBindsJtaPolicies() {
         CamelContext camelContext = new DefaultCamelContext();
-        // Pre-bind the prefixed ConnectionFactory so configure() does not need a broker provider
+        // Pre-bind the prefixed ConnectionFactories so configure() does not need a broker provider
         camelContext.getRegistry().bind("mq1", dummyConnectionFactory());
+        camelContext.getRegistry().bind("mq2", dummyConnectionFactory());
 
         ConnectionFactoryBeanFactory beanFactory = new ConnectionFactoryBeanFactory();
         beanFactory.setCamelContext(camelContext);
@@ -43,10 +44,11 @@ class ConnectionFactoryBeanFactoryTransactionTest {
     }
 
     @Test
-    void transactionEnabledWiresJtaTransactionManagerIntoJmsComponent() {
+    void transactionEnabledWiresJtaTransactionManagerIntoNamedComponent() {
         CamelContext camelContext = new DefaultCamelContext();
         ConnectionFactory connectionFactory = dummyConnectionFactory();
         camelContext.getRegistry().bind("mq1", connectionFactory);
+        camelContext.getRegistry().bind("mq2", dummyConnectionFactory());
 
         ConnectionFactoryBeanFactory beanFactory = new ConnectionFactoryBeanFactory();
         beanFactory.setCamelContext(camelContext);
@@ -58,19 +60,73 @@ class ConnectionFactoryBeanFactoryTransactionTest {
                 .as("A JtaTransactionManager should be bound when transactions are enabled")
                 .isNotNull();
 
-        // Resolving the component fires onComponentAdd, which applies the registered
-        // ComponentCustomizer — the mechanism used at runtime when routes create the component
+        // The named component (mq1) should have the JTA transaction manager set
+        // directly at creation time (#427, #433)
+        JmsComponent mq1Component = (JmsComponent) camelContext.getComponent("mq1");
+        assertThat(mq1Component.getConfiguration().getTransactionManager())
+                .as("Named JmsComponent 'mq1' should receive the Forage JTA transaction manager (#427)")
+                .isSameAs(jtaTransactionManager);
+        assertThat(mq1Component.getConfiguration().getConnectionFactory())
+                .as("Named JmsComponent 'mq1' should use its own ConnectionFactory")
+                .isSameAs(connectionFactory);
+    }
+
+    @Test
+    void perBrokerJmsComponentHasScopedTransactionManager() {
+        CamelContext camelContext = new DefaultCamelContext();
+        ConnectionFactory mq1Cf = dummyConnectionFactory();
+        ConnectionFactory mq2Cf = dummyConnectionFactory();
+        camelContext.getRegistry().bind("mq1", mq1Cf);
+        camelContext.getRegistry().bind("mq2", mq2Cf);
+
+        ConnectionFactoryBeanFactory beanFactory = new ConnectionFactoryBeanFactory();
+        beanFactory.setCamelContext(camelContext);
+        beanFactory.configure();
+
+        JtaTransactionManager jtaTransactionManager =
+                camelContext.getRegistry().lookupByNameAndType("jtaTransactionManager", JtaTransactionManager.class);
+
+        // mq1 has transactions enabled — its JmsComponent should have a TM
+        JmsComponent mq1Component = (JmsComponent) camelContext.getComponent("mq1");
+        assertThat(mq1Component)
+                .as("A JmsComponent should be registered for prefix 'mq1'")
+                .isNotNull();
+        assertThat(mq1Component.getConfiguration().getTransactionManager())
+                .as("mq1 JmsComponent should have the JTA transaction manager (transactions enabled)")
+                .isSameAs(jtaTransactionManager);
+        assertThat(mq1Component.getConfiguration().getConnectionFactory())
+                .as("mq1 JmsComponent should use the mq1 ConnectionFactory")
+                .isSameAs(mq1Cf);
+
+        // mq2 has transactions disabled — its JmsComponent should NOT have a TM
+        JmsComponent mq2Component = (JmsComponent) camelContext.getComponent("mq2");
+        assertThat(mq2Component)
+                .as("A JmsComponent should be registered for prefix 'mq2'")
+                .isNotNull();
+        assertThat(mq2Component.getConfiguration().getTransactionManager())
+                .as("mq2 JmsComponent should NOT have a transaction manager (transactions disabled, #433)")
+                .isNull();
+        assertThat(mq2Component.getConfiguration().getConnectionFactory())
+                .as("mq2 JmsComponent should use the mq2 ConnectionFactory")
+                .isSameAs(mq2Cf);
+    }
+
+    @Test
+    void defaultJmsComponentNotAffectedByNamedPrefixTransactions() {
+        CamelContext camelContext = new DefaultCamelContext();
+        camelContext.getRegistry().bind("mq1", dummyConnectionFactory());
+        camelContext.getRegistry().bind("mq2", dummyConnectionFactory());
+
+        ConnectionFactoryBeanFactory beanFactory = new ConnectionFactoryBeanFactory();
+        beanFactory.setCamelContext(camelContext);
+        beanFactory.configure();
+
+        // Default (unnamed) config does NOT have transactions enabled, so the default
+        // "jms" component should NOT receive the JtaTransactionManager
         JmsComponent jmsComponent = camelContext.getComponent("jms", JmsComponent.class);
         assertThat(jmsComponent.getConfiguration().getTransactionManager())
-                .as("The Camel JMS component should receive the Forage JTA transaction manager (#427)")
-                .isSameAs(jtaTransactionManager);
-
-        // Setting a transaction manager disables JmsComponent's own ConnectionFactory
-        // auto-discovery, so the customizer must replicate it
-        assertThat(jmsComponent.getConfiguration().getConnectionFactory())
-                .as("The single registry ConnectionFactory should still be auto-discovered when a "
-                        + "transaction manager is set (#427)")
-                .isSameAs(connectionFactory);
+                .as("Default 'jms' component should NOT have TM when only a named prefix enables transactions (#433)")
+                .isNull();
     }
 
     private static ConnectionFactory dummyConnectionFactory() {

--- a/library/jms/forage-jms/src/test/resources/forage-connectionfactory.properties
+++ b/library/jms/forage-jms/src/test/resources/forage-connectionfactory.properties
@@ -1,5 +1,6 @@
-# Test configuration: a prefixed (named) JMS configuration with transactions enabled
-# and NO default (unprefixed) transaction property. Used by
-# ConnectionFactoryBeanFactoryTransactionTest to verify that JTA transaction policies
-# are bound when only a prefixed configuration enables transactions (issue #230).
+# Test configuration: two prefixed (named) JMS configurations. mq1 has transactions
+# enabled, mq2 does not. Used by ConnectionFactoryBeanFactoryTransactionTest to verify:
+# - JTA transaction policies are bound when a prefixed config enables transactions (#230)
+# - Per-broker JmsComponent instances have correct JTA scoping (#433)
 forage.mq1.jms.transaction.enabled=true
+forage.mq2.jms.transaction.enabled=false

--- a/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/ForageConnectionFactoryAutoConfiguration.java
+++ b/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/ForageConnectionFactoryAutoConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.artemis.autoconfigure.ArtemisAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -114,6 +115,7 @@ public class ForageConnectionFactoryAutoConfiguration implements DisposableBean 
      * Runs after all singletons are created but before the CamelContext starts.
      */
     @Bean
+    @ConditionalOnBean(CamelContext.class)
     SmartInitializingSingleton forageJmsComponentRegistrar(
             CamelContext camelContext, ConfigurableListableBeanFactory beanFactory, Environment environment) {
         return () -> {

--- a/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/ForageConnectionFactoryAutoConfiguration.java
+++ b/library/jms/spring-boot/forage-jms-starter/src/main/java/io/kaoto/forage/springboot/jms/ForageConnectionFactoryAutoConfiguration.java
@@ -4,10 +4,15 @@ import jakarta.jms.ConnectionFactory;
 
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.jms.JmsComponent;
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.artemis.autoconfigure.ArtemisAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -15,13 +20,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.transaction.jta.JtaTransactionManager;
 import io.kaoto.forage.core.annotations.FactoryType;
 import io.kaoto.forage.core.annotations.FactoryVariant;
 import io.kaoto.forage.core.annotations.ForageFactory;
 import io.kaoto.forage.core.jms.ConnectionFactoryProvider;
+import io.kaoto.forage.core.util.config.ConfigHelper;
 import io.kaoto.forage.jms.common.ConnectionFactoryConfig;
 import io.kaoto.forage.jms.common.JmsModuleDescriptor;
+import io.kaoto.forage.jms.common.transactions.JmsJtaTransactionSupport;
 import io.kaoto.forage.springboot.common.ForageSpringBootModuleAdapter;
+import io.kaoto.forage.springboot.common.SpringPropertyHelper;
 
 /**
  * Auto-configuration for Forage JMS ConnectionFactory creation using ServiceLoader discovery.
@@ -97,6 +106,42 @@ public class ForageConnectionFactoryAutoConfiguration implements DisposableBean 
                 .orElse("none");
         throw new IllegalStateException("No ConnectionFactoryProvider found for kind '" + kind + "' (expected "
                 + providerClassName + "). Available providers: " + available);
+    }
+
+    /**
+     * Registers per-broker {@link JmsComponent} instances so routes using
+     * {@code mq1:queue:...} get the correct ConnectionFactory and JTA scoping (#433).
+     * Runs after all singletons are created but before the CamelContext starts.
+     */
+    @Bean
+    SmartInitializingSingleton forageJmsComponentRegistrar(
+            CamelContext camelContext, ConfigurableListableBeanFactory beanFactory, Environment environment) {
+        return () -> {
+            Set<String> prefixes =
+                    SpringPropertyHelper.discoverPrefixes(environment, ConfigHelper.getNamedPropertyRegexp("jms"));
+            if (prefixes.isEmpty()) {
+                return;
+            }
+
+            JtaTransactionManager jtaTransactionManager = null;
+            try {
+                jtaTransactionManager = beanFactory.getBean(JtaTransactionManager.class);
+            } catch (Exception e) {
+                // no JtaTransactionManager — transactions are not enabled globally
+            }
+
+            for (String name : prefixes) {
+                ConnectionFactoryConfig cfConfig = new ConnectionFactoryConfig(name);
+                ConnectionFactory cf = beanFactory.getBean(name, ConnectionFactory.class);
+                JtaTransactionManager perBrokerTm = cfConfig.transactionEnabled() ? jtaTransactionManager : null;
+                JmsComponent component = JmsJtaTransactionSupport.createJmsComponent(cf, perBrokerTm);
+                camelContext.addComponent(name, component);
+                log.info(
+                        "Registered per-broker JmsComponent '{}' (transactions={})",
+                        name,
+                        cfConfig.transactionEnabled());
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
## Backport of #478

Cherry-pick of #478 onto `camel-latest`.

**Original PR:** #478 - Fix #433: scope JTA transaction wiring per named JMS broker
**Original author:** @Croway
**Target branch:** `camel-latest`

### Original description

- Register a per-broker `JmsComponent` for each named prefix (e.g., `mq1`, `plainBroker`) with its own `ConnectionFactory` and optional `JtaTransactionManager`
- Routes now use `mq1:queue:orders` / `plainBroker:queue:audit` with self-contained transaction semantics per broker
- The `ComponentCustomizer` only applies to the default `jms` component when the unprefixed config enables transactions
- Works consistently across plain Camel, Spring Boot, and Quarkus runtimes

### Conflict resolution

- `ForageConnectionFactoryAutoConfiguration.java`: kept `camel-latest` Artemis import (`org.springframework.boot.artemis.autoconfigure.ArtemisAutoConfiguration`) while adding the new `SmartInitializingSingleton` and `ConfigurableListableBeanFactory` imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-broker JMS component support for named configurations such as `mq1` and `mq2`.
  * JMS connection factories and transaction settings are now applied independently for each broker.
  * Added support across Quarkus and Spring Boot integrations.

* **Bug Fixes**
  * Prevented transaction settings from being incorrectly applied to brokers that have transactions disabled.
  * Preserved the default JMS component behavior when only named brokers enable transactions.

* **Tests**
  * Expanded coverage for multiple brokers and per-broker transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->