### PR TITLE
chore: realign camel-4.18.x as the previous-LTS maintenance branch (Camel 4.18.4)

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -10,7 +10,7 @@ name: Build Main
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "camel-4.18.x" ]
 
 env:
   PROJECTS: ${{ github.workspace }}

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -11,7 +11,7 @@ name: Multiplatform PR Builds
 on:
   pull_request:
     branches:
-      - "main"
+      - "camel-4.18.x"
     paths-ignore:
       - .github/**
       - docs/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,20 +65,39 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           VERSION: ${{ github.event.inputs.releaseVersion }}
         run: |
+          case "$BRANCH" in
+            main)
+              DOC_KEY=forage_version
+              DOC_LABEL="LTS"
+              ;;
+            camel-4.18.x)
+              DOC_KEY=forage_previous_lts_version
+              DOC_LABEL="previous LTS"
+              ;;
+            camel-latest)
+              DOC_KEY=forage_latest_version
+              DOC_LABEL="latest"
+              ;;
+            *)
+              echo "Unknown release branch '$BRANCH' — skipping website version bump"
+              exit 0
+              ;;
+          esac
+
           if [ "$BRANCH" = "main" ]; then
-            sed -i "s/forage_version: \".*\"/forage_version: \"${VERSION}\"/" website/mkdocs.yml
+            sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
-              git commit -m "docs: update LTS version to ${VERSION}"
+              git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
               git push
             fi
           else
             git fetch origin main
             git checkout main -- website/mkdocs.yml
-            sed -i "s/forage_latest_version: \".*\"/forage_latest_version: \"${VERSION}\"/" website/mkdocs.yml
+            sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
-              git commit -m "docs: update latest version to ${VERSION}"
+              git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
               git push origin HEAD:main
             fi
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,18 +14,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Branching and Versioning Strategy
 
-Forage uses **major.minor.micro** versioning (`1.4.0`, `1.4.1`, `1.5.0`, etc.).
+Forage uses **major.minor.micro** versioning (`1.4.0`, `1.4.1`, `1.6.0`, etc.), tracked
+micro-to-micro against Apache Camel on the current-LTS line (`1.6.0` ↔ Camel `4.22.0`,
+`1.6.1` ↔ Camel `4.22.1`, etc.).
 
-| Branch | Tracks | Version | Description |
-|--------|--------|---------|-------------|
-| `main` | Apache Camel LTS | `1.4.x` | Follows the latest Camel LTS release (currently 4.18.x). Micro bumps (`1.4.0` → `1.4.1` → ...) for each release. |
-| `camel-latest` | Latest Apache Camel | `1.5.x` | Follows the latest Camel release (currently 4.20.x) with corresponding Spring Boot and Quarkus versions. |
+| Branch | Tracks | Version | Status |
+|--------|--------|---------|--------|
+| `main` | Current Camel LTS | `1.6.x` | Follows the current Camel LTS release (currently 4.22.x). Active, primary branch — micro bumps (`1.6.0` → `1.6.1` → ...) for each release. |
+| `camel-4.18.x` | Previous Camel LTS | `1.4.x` | Maintenance branch for the previous LTS line (Camel 4.18.x), branched from `main` when Camel 4.22 became LTS. Micro bumps (`1.4.1` → `1.4.2` → ...) as needed. |
+| `camel-latest` | Latest (non-LTS) Camel | `1.5.x` | **Dormant.** Frozen at Camel 4.20.x / Forage 1.5.x until Apache Camel ships its next post-LTS "latest" release (expected around 4.23), at which point it's rebased from `main` and resumes releases. |
+
+When a new Camel LTS lands, the current `main` line becomes the new `camel-N.M.x`
+maintenance branch (via a fresh branch off `main`, not a rename), `main` is upgraded
+in place to track the new LTS, and `camel-latest` is re-evaluated against whatever
+Camel considers "latest" at that point.
 
 ### Backporting
 
-When making changes (features, bug fixes, etc.), **always investigate whether the change needs backporting** to the other branch:
-- A fix on `main` may also apply to `camel-latest` and vice versa.
-- After completing work on one branch, check if the same change is relevant to the other branch and create a backport PR if needed.
+When making changes (features, bug fixes, etc.), **always investigate whether the change needs backporting** to the other active branch(es):
+- A fix on `main` may also apply to `camel-4.18.x` (and to `camel-latest` once it's active again), and vice versa.
+- After completing work on one branch, check if the same change is relevant to the other branch(es) and create a backport PR if needed.
 - Use `/oss-backport-pr` to automate backporting when applicable.
 
 ## Build Commands

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <description>A plugin extension for Apache Camel that provides opinionated bean factories</description>
 
     <properties>
-        <camel.version>4.18.3</camel.version>
+        <camel.version>4.18.4</camel.version>
         <langchain4j.version>1.11.0</langchain4j.version>
         <langchain4j-beta.version>1.11.0-beta19</langchain4j-beta.version>
         <langchain4j-community.version>1.11.0-beta19</langchain4j-community.version>


### PR DESCRIPTION
## Summary
- Bumps `camel.version` 4.18.3 → 4.18.4 (latest Camel 4.18.x LTS micro).
- Retargets this branch's own CI triggers (`main-build.yml`, `pr-builds.yml`) from `main` to `camel-4.18.x`, since this branch was just cut from `main` and its copies of those workflows still reference `main`.
- Updates `release.yml`'s doc-version step to be branch-aware for the new 3-line model (`main` → `forage_version`, `camel-4.18.x` → new `forage_previous_lts_version`, `camel-latest` → `forage_latest_version`) instead of the old binary `main`/else split, which would otherwise clobber the wrong website version key when releasing from this branch.
- Updates the branching table in `CLAUDE.md`.

Context: Camel 4.22.0 is a new LTS. `camel-4.18.x` is a new branch (cut from `main`) that keeps maintaining the previous LTS line while `main` moves on to track 4.22.x. Next release from this branch: **1.4.2**.

Note: `website/mkdocs.yml` gets a new `forage_previous_lts_version` / `camel_previous_lts_version` key pair as part of the companion `main` PR, since the live website is only ever built/deployed from `main`.

## Test plan
- [x] `mvn clean compile` passes with Camel 4.18.4
- [ ] CI runs green on this PR (validates the retargeted `pr-builds.yml` trigger actually fires)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Apache Camel runtime to version 4.18.4, incorporating the latest maintenance improvements.
  - Refined release version handling across supported maintenance and long-term support branches.
  - Improved branch-specific documentation version updates for more accurate published information.

- **Documentation**
  - Updated branching, versioning, release transition, and backporting guidance to reflect the current support strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->