### PR TITLE
Fix #483: add configClass and STS session token support to Bedrock bean

### DIFF
--- a/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockConfig.java
+++ b/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockConfig.java
@@ -7,6 +7,7 @@ import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.MAX_TOKEN
 import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.MODEL_ID;
 import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.REGION;
 import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.SECRET_ACCESS_KEY;
+import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.SESSION_TOKEN;
 import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.TEMPERATURE;
 import static io.kaoto.forage.models.chat.bedrock.BedrockConfigEntries.TOP_P;
 
@@ -149,6 +150,18 @@ public class BedrockConfig extends AbstractConfig {
      */
     public String secretAccessKey() {
         return get(SECRET_ACCESS_KEY).orElse(null);
+    }
+
+    /**
+     * Returns the AWS session token for temporary STS credentials.
+     *
+     * <p>Used together with {@link #accessKeyId()} and {@link #secretAccessKey()} when
+     * authenticating with temporary credentials from an assumed IAM role.
+     *
+     * @return the AWS session token, or null if not configured
+     */
+    public String sessionToken() {
+        return get(SESSION_TOKEN).orElse(null);
     }
 
     /**

--- a/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockConfigEntries.java
+++ b/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockConfigEntries.java
@@ -41,6 +41,15 @@ public final class BedrockConfigEntries extends ConfigEntries {
             "password",
             true,
             ConfigTag.SECURITY);
+    public static final ConfigModule SESSION_TOKEN = ConfigModule.of(
+            BedrockConfig.class,
+            "forage.bedrock.session.token",
+            "AWS session token for temporary STS credentials (optional, used together with access key ID and secret access key)",
+            "Session Token",
+            null,
+            "password",
+            true,
+            ConfigTag.SECURITY);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(
             BedrockConfig.class,
             "forage.bedrock.temperature",
@@ -76,6 +85,7 @@ public final class BedrockConfigEntries extends ConfigEntries {
                 MODEL_ID,
                 ACCESS_KEY_ID,
                 SECRET_ACCESS_KEY,
+                SESSION_TOKEN,
                 TEMPERATURE,
                 MAX_TOKENS,
                 TOP_P);

--- a/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockConfigEntries.java
+++ b/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockConfigEntries.java
@@ -5,6 +5,8 @@ import io.kaoto.forage.core.util.config.ConfigModule;
 import io.kaoto.forage.core.util.config.ConfigTag;
 
 public final class BedrockConfigEntries extends ConfigEntries {
+    private static final String TYPE_PASSWORD = "password";
+
     public static final ConfigModule REGION = ConfigModule.of(
             BedrockConfig.class,
             "forage.bedrock.region",
@@ -29,7 +31,7 @@ public final class BedrockConfigEntries extends ConfigEntries {
             "AWS access key ID (optional, uses default credential chain if not provided)",
             "Access Key ID",
             null,
-            "password",
+            TYPE_PASSWORD,
             true,
             ConfigTag.SECURITY);
     public static final ConfigModule SECRET_ACCESS_KEY = ConfigModule.of(
@@ -38,7 +40,7 @@ public final class BedrockConfigEntries extends ConfigEntries {
             "AWS secret access key (optional, uses default credential chain if not provided)",
             "Secret Access Key",
             null,
-            "password",
+            TYPE_PASSWORD,
             true,
             ConfigTag.SECURITY);
     public static final ConfigModule SESSION_TOKEN = ConfigModule.of(
@@ -47,7 +49,7 @@ public final class BedrockConfigEntries extends ConfigEntries {
             "AWS session token for temporary STS credentials (optional, used together with access key ID and secret access key)",
             "Session Token",
             null,
-            "password",
+            TYPE_PASSWORD,
             true,
             ConfigTag.SECURITY);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(

--- a/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockProvider.java
+++ b/library/ai/models/chat/forage-model-bedrock/src/main/java/io/kaoto/forage/models/chat/bedrock/BedrockProvider.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.chat.ChatModel;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -55,6 +56,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
         value = "bedrock",
         components = {"camel-langchain4j-agent"},
         feature = "Chat Model",
+        configClass = BedrockConfig.class,
         description = "Amazon Bedrock multi-model provider supporting Claude, Llama, Titan, Cohere, and Mistral")
 public class BedrockProvider implements ModelProvider {
     private static final Logger LOG = LoggerFactory.getLogger(BedrockProvider.class);
@@ -109,7 +111,10 @@ public class BedrockProvider implements ModelProvider {
     private BedrockRuntimeClient buildBedrockClient(BedrockConfig config) {
         AwsCredentialsProvider credentialsProvider;
 
-        if (config.accessKeyId() != null && config.secretAccessKey() != null) {
+        if (config.accessKeyId() != null && config.secretAccessKey() != null && config.sessionToken() != null) {
+            credentialsProvider = StaticCredentialsProvider.create(AwsSessionCredentials.create(
+                    config.accessKeyId(), config.secretAccessKey(), config.sessionToken()));
+        } else if (config.accessKeyId() != null && config.secretAccessKey() != null) {
             credentialsProvider = StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(config.accessKeyId(), config.secretAccessKey()));
         } else {

--- a/library/ai/models/chat/forage-model-bedrock/src/main/resources/forage-model-bedrock.properties
+++ b/library/ai/models/chat/forage-model-bedrock/src/main/resources/forage-model-bedrock.properties
@@ -11,6 +11,7 @@ forage.bedrock.region=us-east-1
 # AWS Credentials (optional - if not provided, uses default AWS credential chain)
 # forage.bedrock.access.key.id=
 # forage.bedrock.secret.access.key=
+# forage.bedrock.session.token=
 
 # Model parameters
 # forage.bedrock.temperature=0.7

--- a/library/ai/models/chat/forage-model-bedrock/src/test/java/io/kaoto/forage/models/chat/bedrock/BedrockProviderTest.java
+++ b/library/ai/models/chat/forage-model-bedrock/src/test/java/io/kaoto/forage/models/chat/bedrock/BedrockProviderTest.java
@@ -18,6 +18,9 @@ class BedrockProviderTest {
     void cleanup() {
         System.clearProperty("forage.bedrock.model.id");
         System.clearProperty("forage.bedrock.region");
+        System.clearProperty("forage.bedrock.access.key.id");
+        System.clearProperty("forage.bedrock.secret.access.key");
+        System.clearProperty("forage.bedrock.session.token");
         System.clearProperty("forage.bedrock.temperature");
         System.clearProperty("forage.bedrock.max.tokens");
         System.clearProperty("forage.bedrock.top.p");
@@ -155,6 +158,20 @@ class BedrockProviderTest {
         void shouldApplyTopPConfiguration() {
             System.setProperty("forage.bedrock.model.id", "anthropic.claude-3-haiku-20240307-v1:0");
             System.setProperty("forage.bedrock.top.p", "0.9");
+
+            BedrockProvider provider = new BedrockProvider();
+            ChatModel model = provider.create();
+
+            assertThat(model).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should apply STS session token credentials")
+        void shouldApplySessionTokenCredentials() {
+            System.setProperty("forage.bedrock.model.id", "anthropic.claude-3-haiku-20240307-v1:0");
+            System.setProperty("forage.bedrock.access.key.id", "test-access-key");
+            System.setProperty("forage.bedrock.secret.access.key", "test-secret-key");
+            System.setProperty("forage.bedrock.session.token", "test-session-token");
 
             BedrockProvider provider = new BedrockProvider();
             ChatModel model = provider.create();


### PR DESCRIPTION
Fixes #483

## Summary
- Adds `configClass = BedrockConfig.class` to `BedrockProvider`'s `@ForageBean` annotation so the catalog plugin can resolve its properties file (it was missing while every other model provider with a dedicated config sets it, e.g. `MessageWindowChatMemoryBeanProvider`).
- Adds a `forage.bedrock.session.token` config entry (`SECURITY` tag, `password` type). When set alongside the access key ID and secret access key, it's passed to the AWS credential builder via `AwsSessionCredentials` instead of `AwsBasicCredentials`, supporting temporary STS credentials from an assumed IAM role — the standard pattern for production AWS environments.
- Falls back to static credentials (no session token) or the default AWS credential chain exactly as before when the new field isn't set — no behavior change for existing users.

## Test plan
- [x] `mvn -pl library/ai/models/chat/forage-model-bedrock -am clean test` passes, including a new `shouldApplySessionTokenCredentials` test
- [x] `mvn -pl tooling/forage-maven-catalog-plugin -am clean test` passes — catalog generation resolves the bean correctly with `configClass` now set