### PR TITLE
chore: fix Sonar vulnerability and reliability findings

### DIFF
--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -150,6 +150,14 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
                             try {
                                 handle.onExit().get(10, TimeUnit.SECONDS);
                                 LOG.info("Camel integration '{}' (pid: {}) stopped", integrationName, pid);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                LOG.warn(
+                                        "Interrupted while waiting for Camel integration '{}' (pid: {}) to stop, forcing kill",
+                                        integrationName,
+                                        pid);
+                                handle.descendants().forEach(ProcessHandle::destroyForcibly);
+                                handle.destroyForcibly();
                             } catch (Exception e) {
                                 LOG.warn(
                                         "Camel integration '{}' (pid: {}) did not stop gracefully, forcing kill",
@@ -255,6 +263,10 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
             }
             LOG.warn("Could not parse Camel CLI version from output: {}", output);
             return "BROKEN";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while checking Camel CLI version");
+            return null;
         } catch (Exception e) {
             LOG.warn("Failed to check Camel CLI version: {}", e.getMessage());
             return null;
@@ -285,6 +297,12 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
             }
         } catch (IllegalStateException e) {
             throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrupted while installing Camel CLI. Run manually: jbang app install --force -Dcamel.jbang.version="
+                            + version + " camel@apache/camel",
+                    e);
         } catch (Exception e) {
             throw new IllegalStateException(
                     "Failed to install Camel CLI. Run manually: jbang app install --force -Dcamel.jbang.version="
@@ -328,6 +346,9 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
             } else {
                 LOG.debug("No existing forage plugin to delete (exit code {})", exitCode);
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debug("Interrupted while deleting forage plugin");
         } catch (Exception e) {
             LOG.debug("Could not delete forage plugin (may not exist): {}", e.getMessage());
         }

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/PropertiesTemplateHelper.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/PropertiesTemplateHelper.java
@@ -3,8 +3,11 @@ package io.kaoto.forage.integration.tests;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -22,6 +25,15 @@ public final class PropertiesTemplateHelper {
 
     private PropertiesTemplateHelper() {
         // Utility class
+    }
+
+    private static FileAttribute<?>[] ownerOnlyPermissions() {
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            return new FileAttribute<?>[] {
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"))
+            };
+        }
+        return new FileAttribute<?>[0];
     }
 
     /**
@@ -51,8 +63,10 @@ public final class PropertiesTemplateHelper {
             String templateFileName = templateResource.getFile().getName();
             String propertiesFileName = templateFileName.replace(".template", "");
 
-            // Write to temp directory with proper name
-            Path tempDir = Files.createTempDirectory("forage-test-");
+            // Write to temp directory with proper name. Restrict permissions to the owner
+            // only, since the generated properties files can carry testcontainer credentials
+            // and the default temp directory is otherwise world-readable.
+            Path tempDir = Files.createTempDirectory("forage-test-", ownerOnlyPermissions());
             Path tempPropertiesFile = tempDir.resolve(propertiesFileName);
             Files.writeString(tempPropertiesFile, propertiesContent, StandardCharsets.UTF_8);
 

--- a/library/policy/forage-policy-flip/src/main/java/io/kaoto/forage/policy/flip/ForageFlipRoutePolicy.java
+++ b/library/policy/forage-policy-flip/src/main/java/io/kaoto/forage/policy/flip/ForageFlipRoutePolicy.java
@@ -102,6 +102,9 @@ public class ForageFlipRoutePolicy extends RoutePolicySupport {
                         Thread.sleep(1000); // Wait for startup to complete
                         controller.stopRoute(route.getId());
                         LOG.info("Route '{}' stopped (initially inactive)", route.getId());
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        LOG.warn("Interrupted while stopping initially inactive route '{}'", route.getId());
                     } catch (Exception e) {
                         LOG.warn("Failed to stop initially inactive route '{}': {}", route.getId(), e.getMessage());
                     }

--- a/library/vertx/forage-vertx/src/main/java/io/kaoto/forage/vertx/DefaultVertxProvider.java
+++ b/library/vertx/forage-vertx/src/main/java/io/kaoto/forage/vertx/DefaultVertxProvider.java
@@ -85,8 +85,11 @@ public class DefaultVertxProvider implements VertxProvider {
                         .toCompletionStage()
                         .toCompletableFuture()
                         .get(30, TimeUnit.SECONDS);
-            } catch (TimeoutException | InterruptedException | ExecutionException ie) {
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(ie);
+            } catch (TimeoutException | ExecutionException e) {
+                throw new RuntimeException(e);
             }
         }
         return Vertx.vertx(options);


### PR DESCRIPTION
## Summary

Addresses the SonarCloud findings you flagged, scoped to Vulnerabilities + the InterruptedException swallows (not the broader ~312-item code-smell backlog).

- **S5443** (High, `PropertiesTemplateHelper.java:55`) — the temp directory used to write generated test properties files (which can carry testcontainer DB credentials) is now created with owner-only permissions (`rwx------`) on POSIX systems, instead of inheriting the default world-readable OS temp dir.
- **S2142 x6** (InterruptedException swallowed as a plain `Exception`) — split into a dedicated `catch (InterruptedException e)` that calls `Thread.currentThread().interrupt()` before continuing, in:
  - `IntegrationTestSetupExtension.java` (4x: `destroyProcess`, `getInstalledCamelVersion`, `installCamelCli`, `deleteForagePlugin`)
  - `ForageFlipRoutePolicy.java:105` (the delayed-stop `Thread.sleep`)
  - `DefaultVertxProvider.java:88` (clustered Vert.x startup wait)

## Not included

- **S4036 x3** (Low, `IntegrationTestSetupExtension.java:233,268,313`) — "PATH variable only contains fixed, unwriteable directories," a former Security Hotspot now auto-converted to a Vulnerability. These are `ProcessBuilder("camel", ...)` / `ProcessBuilder("jbang", ...)` calls in test-only infrastructure that intentionally resolve dev CLI tools via `PATH`. Hardcoding absolute paths isn't practical (install location varies across the macOS/Linux/Windows CI matrix and local dev machines) and wouldn't meaningfully improve security for code that never processes untrusted input. Recommend marking these "Safe" in SonarCloud with that justification rather than a code change — let me know if you'd rather I do something else here.
- **`ServiceLoaderHelper.java:83`** (CRITICAL Bug, S6416, "Fix this IllegalArgumentException when executed") — investigated separately (not part of this PR's diff): every real call site passes a valid class name, none pass null/empty, and the guard-clause-then-throw is the same defensive pattern used elsewhere in the codebase. Looks like a Sonar dataflow-engine false positive on the guard-then-stream-filter shape rather than a real bug — flagging for you to mark as such, or tell me if you'd like it restructured anyway.

## Test plan
- [x] `mvn -pl integration-tests/common,library/policy/forage-policy-flip,library/vertx/forage-vertx -am -DskipTests clean install` then `mvn test` on those modules — all green