### PR TITLE
chore: migrate docs from langchain4j-tools to ai-tool

### DIFF
--- a/docs/multi-agent-guide.md
+++ b/docs/multi-agent-guide.md
@@ -273,7 +273,7 @@ Uses `forage-agent-factory.properties` for configuration (see section 1 above).
 
 ### Prerequisites
 
-1. **Camel JBang 4.14+**
+1. **Camel JBang 4.22+**
 2. **JBang 0.129.0+**
 3. **API Keys**: Configure Google API key in `forage-agent-factory.properties`
 4. **Ollama**: For local model integration, ensure Ollama is running on localhost:11434

--- a/docs/multi-agent-guide.md
+++ b/docs/multi-agent-guide.md
@@ -178,7 +178,7 @@ forage.ollama.agent.memory.max.messages=20
                 expression: "1"
             name: CamelLangChain4jAgentMemoryId
         - setBody:
-            simple: give the details of user 123
+            simple: look up user 123 in the user database and return their details
         - to:
             uri: langchain4j-agent:test
             parameters:
@@ -189,10 +189,12 @@ forage.ollama.agent.memory.max.messages=20
 - route:
     id: tool-route
     from:
-      uri: langchain4j-tools:userDb
+      uri: ai-tool:userDb
       parameters:
-        description: Query user database
+        description: Query user database by user ID
         parameter.userId: string
+        parameter.userId.description: The user ID to look up
+        parameter.userId.required: true
         tags: users
       steps:
         - setBody:
@@ -220,7 +222,7 @@ Uses `forage-agent-factory.properties` for configuration (see section 1 above).
                 expression: "1"
             name: CamelLangChain4jAgentMemoryId
         - setBody:
-            simple: give the details of user 123
+            simple: look up user 123 in the user database and return their details
         - to:
             uri: langchain4j-agent:foo-test
             parameters:
@@ -253,10 +255,12 @@ Uses `forage-agent-factory.properties` for configuration (see section 1 above).
 - route:
     id: user-database-tool
     from:
-      uri: langchain4j-tools:userDb
+      uri: ai-tool:userDb
       parameters:
-        description: Query user database
+        description: Query user database by user ID
         parameter.userId: string
+        parameter.userId.description: The user ID to look up
+        parameter.userId.required: true
         tags: users
       steps:
         - setBody:

--- a/website/docs/examples/ai/multi-agent.md
+++ b/website/docs/examples/ai/multi-agent.md
@@ -70,7 +70,7 @@ Two routes send different questions to different agents. A shared tool is scoped
                 expression: "1"
             name: CamelLangChain4jAgentMemoryId
         - setBody:
-            simple: give the details of user 123
+            simple: look up user 123 in the user database and return their details
         - to:
             uri: langchain4j-agent:google
             parameters:
@@ -101,10 +101,12 @@ Two routes send different questions to different agents. A shared tool is scoped
 - route:
     id: user-db-tool
     from:
-      uri: langchain4j-tools:userDb
+      uri: ai-tool:userDb
       parameters:
-        description: Query user database
+        description: Query user database by user ID
         parameter.userId: string
+        parameter.userId.description: The user ID to look up
+        parameter.userId.required: true
         tags: users                                        # (4)
       steps:
         - setBody:
@@ -125,7 +127,7 @@ Two routes send different questions to different agents. A shared tool is scoped
 camel run *
 ```
 
-Both routes fire once. The Gemini agent receives "give the details of user 123", calls the `userDb` tool, and returns user details. The Ollama agent receives "What is the timezone in Brasilia?" and answers from its training data -- it has no tools available.
+Both routes fire once. The Gemini agent receives the user lookup prompt, calls the `userDb` tool, and returns user details. The Ollama agent receives "What is the timezone in Brasilia?" and answers from its training data -- it has no tools available.
 
 ## Key Takeaways
 

--- a/website/docs/examples/ai/single-agent.md
+++ b/website/docs/examples/ai/single-agent.md
@@ -7,7 +7,7 @@ An AI agent with tool use capabilities and conversation memory, powered by a loc
 ## What You'll Learn
 
 - How to configure an AI agent with Forage using named bean prefixes
-- How to give the agent access to tools via Camel's `langchain4j-tools` component
+- How to give the agent access to tools via Camel's `ai-tool` component
 - How to enable conversation memory with a message-window strategy
 - How the agent autonomously decides when to call a tool and how to interpret results
 
@@ -66,7 +66,7 @@ The route sends a natural-language question to the agent, which decides whether 
                 expression: "1"
             name: CamelLangChain4jAgentMemoryId          # (1)
         - setBody:
-            simple: give the details of user 123          # (2)
+            simple: look up user 123 in the user database and return their details  # (2)
         - to:
             uri: langchain4j-agent:agent
             parameters:
@@ -76,10 +76,12 @@ The route sends a natural-language question to the agent, which decides whether 
 - route:
     id: user-db-tool
     from:
-      uri: langchain4j-tools:userDb                       # (5)
+      uri: ai-tool:userDb                                  # (5)
       parameters:
-        description: Query user database                  # (6)
+        description: Query user database by user ID       # (6)
         parameter.userId: string                          # (7)
+        parameter.userId.description: The user ID to look up
+        parameter.userId.required: true
         tags: users                                       # (8)
       steps:
         - setBody:
@@ -104,11 +106,11 @@ The route sends a natural-language question to the agent, which decides whether 
 camel run *
 ```
 
-The route fires once, sends the prompt "give the details of user 123" to the agent. The agent recognizes it needs user data, calls the `userDb` tool, receives the JSON response, and formulates a natural-language answer containing the user's name and ID.
+The route fires once, sends the prompt to the agent. The agent recognizes it needs user data, calls the `userDb` tool, receives the JSON response, and formulates a natural-language answer containing the user's name and ID.
 
 ## Key Takeaways
 
 - **Named bean prefixes** (`forage.myAgent.agent.*`) define the bean name used in routes via `#myAgent`.
-- **Tool routing** is declarative: define a `langchain4j-tools` route, tag it, and the agent discovers it automatically.
+- **Tool routing** is declarative: define an `ai-tool` route, tag it, and the agent discovers it automatically.
 - **Memory** is a single property toggle (`features=memory`) with pluggable strategies.
 - **Zero boilerplate**: Forage handles all LangChain4j wiring -- model creation, memory setup, and tool binding.


### PR DESCRIPTION
## Summary
- Update all documentation references from `langchain4j-tools` to `ai-tool` component (new in Camel 4.22)
- Improve tool parameter descriptions for reliable tool invocation across LLM models
- Update prompt wording in code examples

## Details
Camel 4.22 introduced the `ai-tool` component as a framework-agnostic replacement for `langchain4j-tools`. The old component does not register into the new `AiToolRegistry`, causing agents to send an empty tools array to the model.

### Files changed
- `website/docs/examples/ai/single-agent.md`
- `website/docs/examples/ai/multi-agent.md`
- `docs/multi-agent-guide.md`

## Test plan
- [x] Verified no `langchain4j-tools` references remain in docs
- [x] Changes match the corresponding forage-examples PR (KaotoIO/forage-examples#32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI agent examples to demonstrate retrieving user details from the database.
  * Migrated example tool references to the current `ai-tool:userDb` format.
  * Clarified that `userId` is required and added descriptive parameter guidance.
  * Updated prompts, running instructions, and takeaways across single-agent and multi-agent examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->