### PR TITLE
chore: prepare release workflow and docs for 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,20 +65,44 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           VERSION: ${{ github.event.inputs.releaseVersion }}
         run: |
+          case "$BRANCH" in
+            main)
+              DOC_KEY=forage_version
+              DOC_LABEL="LTS"
+              ;;
+            camel-4.18.x)
+              DOC_KEY=forage_previous_lts_version
+              DOC_LABEL="previous LTS"
+              ;;
+            camel-latest)
+              DOC_KEY=forage_latest_version
+              DOC_LABEL="latest"
+              ;;
+            *)
+              echo "Unknown release branch '$BRANCH' — skipping website version bump"
+              exit 0
+              ;;
+          esac
+
+          # release:prepare may leave Spotless-formatted files behind; discard them so the
+          # commit below only contains the mkdocs bump (see failed run 29409942135).
+          git checkout -- .
+          git status --short
+
           if [ "$BRANCH" = "main" ]; then
-            sed -i "s/forage_version: \".*\"/forage_version: \"${VERSION}\"/" website/mkdocs.yml
+            sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
-              git commit -m "docs: update LTS version to ${VERSION}"
+              git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
               git push
             fi
           else
             git fetch origin main
             git checkout main -- website/mkdocs.yml
-            sed -i "s/forage_latest_version: \".*\"/forage_latest_version: \"${VERSION}\"/" website/mkdocs.yml
+            sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
-              git commit -m "docs: update latest version to ${VERSION}"
+              git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
               git push origin HEAD:main
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,14 +97,19 @@ jobs:
               git push
             fi
           else
+            # Commit on top of origin/main in a separate worktree: committing on the
+            # maintenance branch and pushing HEAD:main would be rejected as non-fast-forward.
             git fetch origin main
-            git checkout main -- website/mkdocs.yml
+            git worktree add --detach "${RUNNER_TEMP}/docs-main" origin/main
+            pushd "${RUNNER_TEMP}/docs-main"
             sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
               git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
               git push origin HEAD:main
             fi
+            popd
+            git worktree remove --force "${RUNNER_TEMP}/docs-main"
           fi
 
       # Create a release

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ Add the desired modules to your project. For example, to use the default agent f
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-model-open-ai</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
 </dependency>
 <!--This component provides support for the message window chat memory -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-memory-message-window</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
 </dependency>
 <!--This component adds the composable agent implementation (pulls in agent factories transitively) -->
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-agent</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
 </dependency>
 ```
 
@@ -145,12 +145,12 @@ camel infra run postgres
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-jdbc</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
 </dependency>
 <dependency>
     <groupId>io.kaoto.forage</groupId>
     <artifactId>forage-jdbc-postgresql</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
 </dependency>
 ```
 
@@ -283,8 +283,8 @@ public class MyRoutes extends RouteBuilder {
 ## Requirements
 
 - Java 17+
-- Apache Camel 4.18.3+
-- LangChain4j 1.11.0+
+- Apache Camel 4.22.0+
+- LangChain4j 1.13.0+
 
 ## Contributing
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,20 +1,42 @@
 # Release Forage
 
-To release Forage, first export the variables referencing the current and the next version: 
+Releases are fully automated by the `release` GitHub workflow. It runs
+`maven-release-plugin` (`release:prepare` + `release:perform`), publishes to Maven Central,
+updates the website version in `website/mkdocs.yml` on `main`, and creates the GitHub
+release with JReleaser.
 
+The workflow takes two inputs:
+
+- `releaseVersion` – the version to release (e.g. `1.6.0`)
+- `nextDevelopmentVersion` – the next development version, **without** the `-SNAPSHOT`
+  suffix (e.g. `1.6.1`)
+
+Run it against the branch you want to release (see the branching strategy in `CLAUDE.md`):
 
 ```shell
-export CURRENT_DEVELOPMENT_VERSION=1.1
-export NEXT_DEVELOPMENT_VERSION=1.2
+# Current LTS line (main)
+gh workflow run release --ref main -f releaseVersion=1.6.0 -f nextDevelopmentVersion=1.6.1
+
+# Previous LTS maintenance line
+gh workflow run release --ref camel-4.18.x -f releaseVersion=1.4.1 -f nextDevelopmentVersion=1.4.2
+
+# Latest (non-LTS) line, when active
+gh workflow run release --ref camel-latest -f releaseVersion=1.5.1 -f nextDevelopmentVersion=1.5.2
 ```
 
-Then, trigger the Github workflow action that will perform the release:
+Release `main` before the maintenance branches: every branch pushes its
+`website/mkdocs.yml` version bump to `main`.
 
-```shell
-gh workflow run release -f currentDevelopmentVersion=1.0 -f nextDevelopmentVersion=1.1
-```
+It may take from a few minutes to as much as 1 hour for the Maven Central publication to
+happen. You can verify the publication status on the
+[Publishing Page](https://central.sonatype.com/publishing).
 
-The process is completely automated. It may take from a few minutes to as much as 1 hour for the Maven Central publication to happen. 
+After the workflow completes, check that:
 
-You can verify the publication status on the [Publishing Page](https://central.sonatype.com/publishing).
+- the `v<releaseVersion>` tag and the GitHub release exist,
+- `website/mkdocs.yml` on `main` shows the new version,
+- the artifacts are visible on Maven Central.
 
+The Camel version keys in `website/mkdocs.yml` (`camel_lts_version`,
+`camel_previous_lts_version`, `camel_latest_version`) and the versions in `README.md` are
+**not** updated by the workflow and must be bumped manually when the Camel line changes.

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -47,8 +47,8 @@ extra:
   forage_version: "1.4.0"
   forage_previous_lts_version: "1.4.0"
   forage_latest_version: "1.5.0"
-  camel_lts_version: "4.18.3"
-  camel_previous_lts_version: "4.18.3"
+  camel_lts_version: "4.22.0"
+  camel_previous_lts_version: "4.18.4"
   camel_latest_version: "4.20.0"
 
 extra_css:


### PR DESCRIPTION
## Summary
- Port the branch-aware **Update docs version** step of `release.yml` from `camel-4.18.x` (commit 4b6730a5) so all release branches share the same workflow
- Harden that step: `git checkout -- .` before committing, so Spotless-formatted leftovers from `release:prepare` can't break the commit — this is what failed the 1.4.0 release run (29409942135) and skipped JReleaser
- Rewrite `docs/release.md`: the documented inputs (`currentDevelopmentVersion`) don't exist; the workflow takes `releaseVersion` / `nextDevelopmentVersion`. Adds per-branch commands and post-release checks
- `README.md`: 1.4.0 → 1.6.0, Camel 4.18.3+ → 4.22.0+, LangChain4j 1.11.0+ → 1.13.0+
- `website/mkdocs.yml`: `camel_lts_version` → 4.22.0, `camel_previous_lts_version` → 4.18.4 (the workflow only bumps `forage_*` keys)

Prep for releasing Forage 1.6.0 (Camel 4.22.0) from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README dependency examples and minimum supported versions.
  * Updated documented Camel LTS and previous LTS versions.
  * Reworked release instructions to reflect the automated release workflow, branch-specific usage, verification steps, and manual version updates.
* **Chores**
  * Improved release automation to update documentation versions appropriately for each release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->