### PR TITLE
chore(release): fix maintenance-branch docs bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,11 @@ jobs:
               ;;
           esac
 
+          # release:prepare may leave Spotless-formatted files behind; discard them so the
+          # commit below only contains the mkdocs bump (see failed run 29409942135).
+          git checkout -- .
+          git status --short
+
           if [ "$BRANCH" = "main" ]; then
             sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
@@ -92,14 +97,19 @@ jobs:
               git push
             fi
           else
+            # Commit on top of origin/main in a separate worktree: committing on the
+            # maintenance branch and pushing HEAD:main would be rejected as non-fast-forward.
             git fetch origin main
-            git checkout main -- website/mkdocs.yml
+            git worktree add --detach "${RUNNER_TEMP}/docs-main" origin/main
+            pushd "${RUNNER_TEMP}/docs-main"
             sed -i "s/${DOC_KEY}: \".*\"/${DOC_KEY}: \"${VERSION}\"/" website/mkdocs.yml
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
               git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
               git push origin HEAD:main
             fi
+            popd
+            git worktree remove --force "${RUNNER_TEMP}/docs-main"
           fi
 
       # Create a release


### PR DESCRIPTION
## Summary
Backport of the `release.yml` fixes from #491, needed before releasing 1.4.1 from this branch:

- The "Update docs version" step committed on the maintenance branch and then ran `git push origin HEAD:main`, which is rejected as non-fast-forward once `main` has diverged. It now commits in a detached worktree on `origin/main` and pushes from there.
- `git checkout -- .` before committing, so Spotless-formatted leftovers from `release:prepare` can't break the commit (what failed the 1.4.0 release run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)