### PR TITLE
chore(release): push docs bump through SSH deploy key; website version 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
           VERSION: ${{ github.event.inputs.releaseVersion }}
+          # main only accepts changes through PRs, which blocks GITHUB_TOKEN pushes.
+          # The SSH deploy key set up in "Create release" bypasses that rule (it is
+          # how release:prepare pushes its commits and tag), so push through it.
+          SSH_REMOTE: git@github.com:${{ github.repository }}.git
         run: |
           case "$BRANCH" in
             main)
@@ -94,7 +98,7 @@ jobs:
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
               git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
-              git push
+              git push "${SSH_REMOTE}" HEAD:main
             fi
           else
             # Commit on top of origin/main in a separate worktree: committing on the
@@ -106,7 +110,7 @@ jobs:
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
               git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
-              git push origin HEAD:main
+              git push "${SSH_REMOTE}" HEAD:main
             fi
             popd
             git worktree remove --force "${RUNNER_TEMP}/docs-main"

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -44,7 +44,7 @@ theme:
     - toc.follow
 
 extra:
-  forage_version: "1.4.0"
+  forage_version: "1.6.0"
   forage_previous_lts_version: "1.4.0"
   forage_latest_version: "1.5.0"
   camel_lts_version: "4.22.0"


### PR DESCRIPTION
## Summary
Follow-up to the 1.6.0 release run ([32859576533](https://github.com/KaotoIO/forage/actions/runs/32859576533)): `release:prepare`/`perform` succeeded (tag `v1.6.0`, `main` at `1.6.1-SNAPSHOT`), but **Update docs version** was rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

That step pushed over HTTPS with `GITHUB_TOKEN`. The release plugin's pushes go through the SSH deploy key set up in the same job (`developerConnection: git@github.com:…`), which bypasses the rule — so this PR makes the docs step push through the same SSH remote (both the `main` and maintenance-branch paths).

Also applies the `forage_version: "1.6.0"` bump the step failed to commit.

The `camel-4.18.x` workflow needs the same change before the 1.4.1 release (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the website documentation version to 1.6.0.
  * Improved the release process for publishing documentation version updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->