### PR TITLE
chore(release): push docs bump through SSH deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
           VERSION: ${{ github.event.inputs.releaseVersion }}
+          # main only accepts changes through PRs, which blocks GITHUB_TOKEN pushes.
+          # The SSH deploy key set up in "Create release" bypasses that rule (it is
+          # how release:prepare pushes its commits and tag), so push through it.
+          SSH_REMOTE: git@github.com:${{ github.repository }}.git
         run: |
           case "$BRANCH" in
             main)
@@ -94,7 +98,7 @@ jobs:
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
               git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
-              git push
+              git push "${SSH_REMOTE}" HEAD:main
             fi
           else
             # Commit on top of origin/main in a separate worktree: committing on the
@@ -106,7 +110,7 @@ jobs:
             git add website/mkdocs.yml
             if ! git diff --cached --quiet; then
               git commit -m "docs: update ${DOC_LABEL} version to ${VERSION}"
-              git push origin HEAD:main
+              git push "${SSH_REMOTE}" HEAD:main
             fi
             popd
             git worktree remove --force "${RUNNER_TEMP}/docs-main"


### PR DESCRIPTION
## Summary
Backport of #494. The 1.6.0 release run showed that the **Update docs version** push to `main` is rejected when done with `GITHUB_TOKEN` (`main` only accepts changes via PR). Push through the SSH deploy key that `release:prepare` already uses instead.

Required before releasing 1.4.1 from this branch — its docs bump also goes to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)