### PR TITLE
fix(sonar): resolve java:S1186 empty method bodies

### DIFF
--- a/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ConfigurationModule.java
+++ b/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ConfigurationModule.java
@@ -22,7 +22,9 @@ public class ConfigurationModule {
     @JsonProperty("configEntries")
     private List<ConfigEntry> configEntries;
 
-    public ConfigurationModule() {}
+    public ConfigurationModule() {
+        // Required by Jackson for deserialization
+    }
 
     public String getArtifactId() {
         return artifactId;

--- a/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/FactoryVariants.java
+++ b/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/FactoryVariants.java
@@ -19,7 +19,9 @@ public class FactoryVariants {
     @JsonProperty("quarkus")
     private FactoryVariant quarkus;
 
-    public FactoryVariants() {}
+    public FactoryVariants() {
+        // Required by Jackson for deserialization
+    }
 
     public FactoryVariant getBase() {
         return base;

--- a/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageCatalog.java
+++ b/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageCatalog.java
@@ -27,7 +27,9 @@ public class ForageCatalog {
     @JsonProperty("factories")
     private List<ForageFactory> factories;
 
-    public ForageCatalog() {}
+    public ForageCatalog() {
+        // Required by Jackson for deserialization
+    }
 
     public String getVersion() {
         return version;

--- a/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageConfigurationCatalog.java
+++ b/core/forage-catalog-model/src/main/java/io/kaoto/forage/catalog/model/ForageConfigurationCatalog.java
@@ -24,7 +24,9 @@ public class ForageConfigurationCatalog {
     @JsonProperty("modules")
     private List<ConfigurationModule> modules;
 
-    public ForageConfigurationCatalog() {}
+    public ForageConfigurationCatalog() {
+        // Required by Jackson for deserialization
+    }
 
     public String getVersion() {
         return version;

--- a/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisRecoveryTest/CrashRecoveryRoute.java
+++ b/integration-tests/jms/src/test/resources/io/kaoto/forage/jms/JmsArtemisRecoveryTest/CrashRecoveryRoute.java
@@ -88,16 +88,25 @@ public class CrashRecoveryRoute extends RouteBuilder {
         }
 
         @Override
-        public void rollback(Xid xid) {}
+        public void rollback(Xid xid) {
+            // XA rollback is a no-op for this crash-test resource: the JVM halts on commit,
+            // so rollback is never called in the normal test flow.
+        }
 
         @Override
-        public void start(Xid xid, int flags) {}
+        public void start(Xid xid, int flags) {
+            // XA start requires no state tracking for this crash-test-only resource.
+        }
 
         @Override
-        public void end(Xid xid, int flags) {}
+        public void end(Xid xid, int flags) {
+            // XA end requires no state tracking for this crash-test-only resource.
+        }
 
         @Override
-        public void forget(Xid xid) {}
+        public void forget(Xid xid) {
+            // Heuristic forget is not applicable for this crash-test-only resource.
+        }
 
         @Override
         public Xid[] recover(int flag) {

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/simple/SimpleAgent.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/simple/SimpleAgent.java
@@ -42,7 +42,9 @@ public class SimpleAgent implements Agent, ConfigurationAware {
     private volatile ForageAgentWithMemory cachedMemoryService;
     private volatile ForageAgentWithoutMemory cachedNoMemoryService;
 
-    public SimpleAgent() {}
+    public SimpleAgent() {
+        // Required for ServiceLoader-based instantiation
+    }
 
     @Override
     public void configure(AgentConfiguration configuration) {

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanMemoryBeanProvider.java
@@ -58,7 +58,9 @@ public class InfinispanMemoryBeanProvider implements ChatMemoryBeanProvider, Max
     private volatile RemoteCacheManager defaultCacheManager;
     private volatile PersistentInfinispanStore defaultStore;
 
-    public InfinispanMemoryBeanProvider() {}
+    public InfinispanMemoryBeanProvider() {
+        // Required for ServiceLoader-based instantiation
+    }
 
     @Override
     public void withMaxMessages(int maxMessages) {

--- a/library/ai/chat-memory/forage-memory-message-window/src/main/java/io/kaoto/forage/memory/chat/messagewindow/MessageWindowChatMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-message-window/src/main/java/io/kaoto/forage/memory/chat/messagewindow/MessageWindowChatMemoryBeanProvider.java
@@ -19,7 +19,9 @@ public class MessageWindowChatMemoryBeanProvider implements ChatMemoryBeanProvid
 
     private volatile Integer maxMessagesOverride;
 
-    public MessageWindowChatMemoryBeanProvider() {}
+    public MessageWindowChatMemoryBeanProvider() {
+        // Required for ServiceLoader-based instantiation
+    }
 
     @Override
     public void withMaxMessages(int maxMessages) {

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisMemoryBeanProvider.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisMemoryBeanProvider.java
@@ -59,7 +59,9 @@ public class RedisMemoryBeanProvider implements ChatMemoryBeanProvider, MaxMessa
     private volatile JedisPool defaultPool;
     private volatile PersistentRedisStore defaultStore;
 
-    public RedisMemoryBeanProvider() {}
+    public RedisMemoryBeanProvider() {
+        // Required for ServiceLoader-based instantiation
+    }
 
     @Override
     public void withMaxMessages(int maxMessages) {

--- a/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepositoryTest.java
+++ b/library/jdbc/forage-jdbc-common/src/test/java/io/kaoto/forage/jdbc/common/idempotent/ForageJdbcMessageIdRepositoryTest.java
@@ -51,10 +51,14 @@ class ForageJdbcMessageIdRepositoryTest {
         }
 
         @Override
-        public void setLogWriter(PrintWriter out) throws SQLException {}
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            // No-op stub — not needed for this unit test
+        }
 
         @Override
-        public void setLoginTimeout(int seconds) throws SQLException {}
+        public void setLoginTimeout(int seconds) throws SQLException {
+            // No-op stub — not needed for this unit test
+        }
 
         @Override
         public int getLoginTimeout() throws SQLException {

--- a/library/jdbc/forage-jdbc/src/test/java/io/kaoto/forage/jdbc/DataSourceBeanFactoryTransactionTest.java
+++ b/library/jdbc/forage-jdbc/src/test/java/io/kaoto/forage/jdbc/DataSourceBeanFactoryTransactionTest.java
@@ -61,10 +61,14 @@ class DataSourceBeanFactoryTransactionTest {
             }
 
             @Override
-            public void setLogWriter(PrintWriter out) {}
+            public void setLogWriter(PrintWriter out) {
+                // No-op stub — not needed for this unit test
+            }
 
             @Override
-            public void setLoginTimeout(int seconds) {}
+            public void setLoginTimeout(int seconds) {
+                // No-op stub — not needed for this unit test
+            }
 
             @Override
             public int getLoginTimeout() {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePlugin.java
@@ -70,7 +70,9 @@ public class ForagePlugin implements Plugin {
             }
 
             @Override
-            public void addSourceFiles(Path buildDir, String packageName, Printer printer) {}
+            public void addSourceFiles(Path buildDir, String packageName, Printer printer) {
+                // This exporter contributes only runtime dependencies, not source files.
+            }
         });
     }
 

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/ForageComponent.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/ForageComponent.java
@@ -31,7 +31,9 @@ public class ForageComponent {
 
     private Map<String, String> configClasses; // Not serialized to JSON, just for internal use
 
-    public ForageComponent() {}
+    public ForageComponent() {
+        // Required by Jackson for deserialization
+    }
 
     public String getArtifactId() {
         return artifactId;


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/forage/issues/501

## What

Add explanatory comments to 18 empty method bodies (java:S1186, CRITICAL) across 13 files. No behavioral change — all methods were already correct, just missing the comment that Sonar requires to confirm intent.

## Breakdown

| Pattern | Count | Files |
|---|---|---|
| Jackson no-arg constructors | 5 | `ConfigurationModule`, `FactoryVariants`, `ForageCatalog`, `ForageConfigurationCatalog`, `ForageComponent` |
| ServiceLoader no-arg constructors | 4 | `SimpleAgent`, `InfinispanMemoryBeanProvider`, `MessageWindowChatMemoryBeanProvider`, `RedisMemoryBeanProvider` |
| XAResource override stubs (crash-test) | 4 | `CrashRecoveryRoute` — `rollback`, `start`, `end`, `forget` |
| DataSource stubs in unit tests | 4 | `ForageJdbcMessageIdRepositoryTest`, `DataSourceBeanFactoryTransactionTest` |
| Intentional no-op exporter method | 1 | `ForagePlugin#addSourceFiles` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory comments to default constructors and intentionally empty methods.
  * Clarified requirements for deserialization, service loading, and test-only no-op behavior.
* **Refactor**
  * No functional behavior, public interfaces, or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->