### PR TITLE
fix(sonar): resolve java:S1192 duplicate string literals across 35 files

### DIFF
--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/AbstractConfig.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/AbstractConfig.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractConfig implements Config {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractConfig.class);
+    private static final String FORAGE_PREFIX = "forage.";
 
     private final String prefix;
     private final Class<? extends ConfigEntries> entriesClass;
@@ -51,15 +52,15 @@ public abstract class AbstractConfig implements Config {
     private void warnUnknownKey(Map<ConfigModule, ConfigEntry> modules, String name) {
         // Subclasses with dynamic modules (e.g., route policies) keep their own registry,
         // so an empty map here means we cannot tell known keys from typos
-        if (modules.isEmpty() || !name.startsWith("forage.")) {
+        if (modules.isEmpty() || !name.startsWith(FORAGE_PREFIX)) {
             return;
         }
 
         // A key like forage.ds1.jdbc.url is a named variant of forage.jdbc.url and may
         // belong to a prefixed instance that has not been constructed yet — not a typo.
-        int dot = name.indexOf('.', "forage.".length());
+        int dot = name.indexOf('.', FORAGE_PREFIX.length());
         if (dot > 0) {
-            String stripped = "forage." + name.substring(dot + 1);
+            String stripped = FORAGE_PREFIX + name.substring(dot + 1);
             if (modules.keySet().stream().anyMatch(m -> m.match(stripped))) {
                 return;
             }

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigModule.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigModule.java
@@ -42,6 +42,13 @@ import java.util.Objects;
  */
 public class ConfigModule {
 
+    public static final String TYPE_STRING = "string";
+    public static final String TYPE_INTEGER = "integer";
+    public static final String TYPE_DOUBLE = "double";
+    public static final String TYPE_BOOLEAN = "boolean";
+    public static final String TYPE_FALSE = "false";
+    public static final String TYPE_PASSWORD = "password";
+
     private final Class<? extends Config> config;
     private final String name;
     private final String prefix;

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ConfigStore {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigStore.class);
+    private static final String PROPERTIES_SUFFIX = ".properties";
 
     private static final ConfigStore INSTANCE = new ConfigStore();
     private final Properties properties = new Properties();
@@ -238,7 +239,7 @@ public final class ConfigStore {
         // 3. Default classloader: root classpath path
         if (is == null) {
             LOG.debug("Loading defaults from the forage component");
-            String rootPath = "/" + instance.name() + ".properties";
+            String rootPath = "/" + instance.name() + PROPERTIES_SUFFIX;
             ClassLoader cl = classLoader != null ? classLoader : ConfigStore.class.getClassLoader();
             is = cl.getResourceAsStream(rootPath);
         }
@@ -247,11 +248,11 @@ public final class ConfigStore {
     }
 
     private static <T extends Config> String asClasspathPath(T instance) {
-        return instance.getClass().getPackageName().replace(".", "/") + "/" + instance.name() + ".properties";
+        return instance.getClass().getPackageName().replace(".", "/") + "/" + instance.name() + PROPERTIES_SUFFIX;
     }
 
     private static <T extends Config> String asProperties(T instance) {
-        return "./" + instance.name() + ".properties";
+        return "./" + instance.name() + PROPERTIES_SUFFIX;
     }
 
     /**

--- a/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
+++ b/core/forage-core-common/src/main/java/io/kaoto/forage/core/util/config/ConfigStore.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 public final class ConfigStore {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigStore.class);
     private static final String PROPERTIES_SUFFIX = ".properties";
+    private static final String CLASSPATH_ROOT = "/";
 
     private static final ConfigStore INSTANCE = new ConfigStore();
     private final Properties properties = new Properties();
@@ -239,7 +240,7 @@ public final class ConfigStore {
         // 3. Default classloader: root classpath path
         if (is == null) {
             LOG.debug("Loading defaults from the forage component");
-            String rootPath = "/" + instance.name() + PROPERTIES_SUFFIX;
+            String rootPath = CLASSPATH_ROOT + instance.name() + PROPERTIES_SUFFIX;
             ClassLoader cl = classLoader != null ? classLoader : ConfigStore.class.getClassLoader();
             is = cl.getResourceAsStream(rootPath);
         }

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterAllCallback, ParameterResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestSetupExtension.class);
+    private static final String CAMEL_COMMAND = "camel";
 
     public static final String RUNTIME_PROPERTY = "INTEGRATION_TEST_RUNTIME";
 
@@ -61,8 +62,8 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
         if (!runBeforeAll) {
             runBeforeAll = true;
             if (PLUGIN_INSTALLED.compareAndSet(false, true)) {
-                CamelActionBuilder camel =
-                        (CamelActionBuilder) TestActionBuilder.lookup("camel").get();
+                CamelActionBuilder camel = (CamelActionBuilder)
+                        TestActionBuilder.lookup(CAMEL_COMMAND).get();
                 internalBeforeAll(context, camel);
             }
             runBeforeAll(context);
@@ -238,7 +239,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
 
     private String getInstalledCamelVersion() {
         try {
-            ProcessBuilder pb = new ProcessBuilder("camel", "version");
+            ProcessBuilder pb = new ProcessBuilder(CAMEL_COMMAND, "version");
             pb.redirectErrorStream(true);
             Process process;
             try {
@@ -328,7 +329,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
      */
     private void deleteForagePlugin() {
         try {
-            ProcessBuilder pb = new ProcessBuilder("camel", "plugin", "delete", "forage");
+            ProcessBuilder pb = new ProcessBuilder(CAMEL_COMMAND, "plugin", "delete", "forage");
             pb.redirectErrorStream(true);
             Process process = pb.start();
             String output;

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -46,7 +46,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterAllCallback, ParameterResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestSetupExtension.class);
-    private static final String CAMEL_COMMAND = resolveExecutable("camel");
+    private static final String CAMEL_BUILDER_KEY = "camel";
+    private static final String CAMEL_COMMAND = resolveExecutable(CAMEL_BUILDER_KEY);
 
     public static final String RUNTIME_PROPERTY = "INTEGRATION_TEST_RUNTIME";
 
@@ -66,7 +67,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
             runBeforeAll = true;
             if (PLUGIN_INSTALLED.compareAndSet(false, true)) {
                 CamelActionBuilder camel = (CamelActionBuilder)
-                        TestActionBuilder.lookup(CAMEL_COMMAND).get();
+                        TestActionBuilder.lookup(CAMEL_BUILDER_KEY).get();
                 internalBeforeAll(context, camel);
             }
             runBeforeAll(context);

--- a/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
+++ b/integration-tests/common/src/main/java/io/kaoto/forage/integration/tests/IntegrationTestSetupExtension.java
@@ -1,8 +1,11 @@
 package io.kaoto.forage.integration.tests;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +46,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterAllCallback, ParameterResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestSetupExtension.class);
-    private static final String CAMEL_COMMAND = "camel";
+    private static final String CAMEL_COMMAND = resolveExecutable("camel");
 
     public static final String RUNTIME_PROPERTY = "INTEGRATION_TEST_RUNTIME";
 
@@ -239,7 +242,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
 
     private String getInstalledCamelVersion() {
         try {
-            ProcessBuilder pb = new ProcessBuilder(CAMEL_COMMAND, "version");
+            ProcessBuilder pb = new ProcessBuilder(List.of(CAMEL_COMMAND, "version"));
             pb.redirectErrorStream(true);
             Process process;
             try {
@@ -329,7 +332,7 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
      */
     private void deleteForagePlugin() {
         try {
-            ProcessBuilder pb = new ProcessBuilder(CAMEL_COMMAND, "plugin", "delete", "forage");
+            ProcessBuilder pb = new ProcessBuilder(List.of(CAMEL_COMMAND, "plugin", "delete", "forage"));
             pb.redirectErrorStream(true);
             Process process = pb.start();
             String output;
@@ -363,5 +366,23 @@ public class IntegrationTestSetupExtension implements BeforeEachCallback, AfterA
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
         return CitrusExtensionHelper.getTestRunner(extensionContext);
+    }
+
+    /**
+     * Resolves a command name to its absolute path by searching the directories listed in the
+     * {@code PATH} environment variable. Returns the absolute path if found, or the bare command
+     * name as a fallback (preserving existing behaviour when the executable is not yet installed).
+     */
+    private static String resolveExecutable(String command) {
+        String pathEnv = System.getenv("PATH");
+        if (pathEnv != null) {
+            for (String dir : pathEnv.split(File.pathSeparator)) {
+                Path candidate = Path.of(dir, command);
+                if (Files.isExecutable(candidate)) {
+                    return candidate.toAbsolutePath().toString();
+                }
+            }
+        }
+        return command;
     }
 }

--- a/library/ai/agents/forage-agent-factories/src/main/java/io/kaoto/forage/agent/factory/AgentFactoryConfigEntries.java
+++ b/library/ai/agents/forage-agent-factories/src/main/java/io/kaoto/forage/agent/factory/AgentFactoryConfigEntries.java
@@ -22,7 +22,7 @@ public final class AgentFactoryConfigEntries extends ConfigEntries {
             "Fully qualified class name of the model provider factory",
             "Model Factory Class",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule PROVIDER_FEATURES = ConfigModule.of(
@@ -31,7 +31,7 @@ public final class AgentFactoryConfigEntries extends ConfigEntries {
             "Comma-separated list of agent features to enable (e.g., memory)",
             "Features",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule PROVIDER_FEATURES_MEMORY_FACTORY_CLASS = ConfigModule.of(
@@ -40,7 +40,7 @@ public final class AgentFactoryConfigEntries extends ConfigEntries {
             "Fully qualified class name of the chat memory factory",
             "Memory Factory Class",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule PROVIDER_AGENT_CLASS = ConfigModule.of(
@@ -49,7 +49,7 @@ public final class AgentFactoryConfigEntries extends ConfigEntries {
             "Fully qualified class name of the agent factory implementation",
             "Agent Class",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule GUARDRAILS_INPUT = ConfigModule.of(
@@ -58,7 +58,7 @@ public final class AgentFactoryConfigEntries extends ConfigEntries {
             "Comma-separated list of input guardrail names (@ForageBean values, e.g., pii-detector,keyword-filter)",
             "Input Guardrails",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule GUARDRAILS_OUTPUT = ConfigModule.of(
@@ -67,7 +67,7 @@ public final class AgentFactoryConfigEntries extends ConfigEntries {
             "Comma-separated list of output guardrail names (@ForageBean values, e.g., sensitive-data,output-length)",
             "Output Guardrails",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 

--- a/library/ai/agents/forage-agent-factories/src/main/java/io/kaoto/forage/agent/factory/MultiAgentConfigEntries.java
+++ b/library/ai/agents/forage-agent-factories/src/main/java/io/kaoto/forage/agent/factory/MultiAgentConfigEntries.java
@@ -23,7 +23,7 @@ public final class MultiAgentConfigEntries extends ConfigEntries {
             "Comma-separated list of named agent prefixes for multi-agent setup",
             "Agent Names",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MULTI_AGENT_ID_SOURCE = ConfigModule.of(
@@ -32,7 +32,7 @@ public final class MultiAgentConfigEntries extends ConfigEntries {
             "Source for extracting agent ID (route-id, header, property, variable)",
             "ID Source",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MULTI_AGENT_ID_SOURCE_HEADER = ConfigModule.of(
@@ -41,7 +41,7 @@ public final class MultiAgentConfigEntries extends ConfigEntries {
             "Exchange header name to extract agent ID from",
             "ID Source Header",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MULTI_AGENT_ID_SOURCE_PROPERTY = ConfigModule.of(
@@ -50,7 +50,7 @@ public final class MultiAgentConfigEntries extends ConfigEntries {
             "Exchange property name to extract agent ID from",
             "ID Source Property",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MULTI_AGENT_ID_SOURCE_VARIABLE = ConfigModule.of(
@@ -59,7 +59,7 @@ public final class MultiAgentConfigEntries extends ConfigEntries {
             "Exchange variable name to extract agent ID from",
             "ID Source Variable",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentConfigEntries.java
@@ -47,7 +47,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Comma-separated list of enabled features (e.g., memory)",
             "Features",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -67,7 +67,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "API key for authentication with the model provider",
             "API Key",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             false,
             ConfigTag.SECURITY);
 
@@ -77,7 +77,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Base URL for the model provider API",
             "Base URL",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -87,7 +87,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "The specific model name to use",
             "Model Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -97,7 +97,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Temperature for response randomness (0.0-2.0)",
             "Temperature",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
 
@@ -107,7 +107,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Maximum number of tokens in the response",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
 
@@ -117,7 +117,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Top-P (nucleus) sampling parameter (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
 
@@ -127,7 +127,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Top-K sampling parameter",
             "Top K",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
 
@@ -138,7 +138,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Azure OpenAI resource endpoint URL",
             "Endpoint",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -148,7 +148,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Azure OpenAI deployment name",
             "Deployment Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -159,7 +159,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Enable request logging",
             "Log Requests",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
 
@@ -169,7 +169,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Enable response logging",
             "Log Responses",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
 
@@ -180,7 +180,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Request timeout duration in ISO-8601 format (e.g. PT120S for 120 seconds)",
             "Timeout",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -191,7 +191,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Maximum number of messages to retain in memory",
             "Max Messages",
             "20",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
 
@@ -212,7 +212,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Path to a file to be loaded into store.",
             "File source",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -243,7 +243,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Comma-separated list of input guardrail names (@ForageBean values, e.g., pii-detector,keyword-filter)",
             "Input Guardrails",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -253,7 +253,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Comma-separated list of output guardrail names (@ForageBean values, e.g., sensitive-data,output-length)",
             "Output Guardrails",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -266,7 +266,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "API key for the embedding model provider (falls back to forage.agent.api.key when not set)",
             "Embedding API Key",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             false,
             ConfigTag.SECURITY);
 
@@ -276,7 +276,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "Base URL for the embedding model provider (falls back to forage.agent.base.url when not set)",
             "Embedding Base URL",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -286,7 +286,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "The specific model name to use",
             "Model Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule EMBEDDING_MODEL_TIMEOUT = ConfigModule.of(
@@ -325,7 +325,7 @@ public final class AgentConfigEntries extends ConfigEntries {
             "The minimum relevance score for the returned Contents.",
             "Min score",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
 

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentCreator.java
@@ -52,6 +52,7 @@ public final class AgentCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(AgentCreator.class);
     public static final String DEFAULT_AGENT = "agent";
+    private static final String IN_MEMORY_STORE = "in.memory.store";
     private static final String FEATURE_MEMORY = "memory";
 
     private static final Object CREATION_LOCK = new Object();
@@ -161,7 +162,8 @@ public final class AgentCreator {
     public static Set<String> detectPrefixes(ClassLoader classLoader) {
         ConfigStore.getInstance().setClassLoader(classLoader);
         AgentConfig defaultConfig = new AgentConfig();
-        return ConfigStore.getInstance().readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp("agent"));
+        return ConfigStore.getInstance()
+                .readPrefixes(defaultConfig, ConfigHelper.getNamedPropertyRegexp(DEFAULT_AGENT));
     }
 
     /**
@@ -171,7 +173,7 @@ public final class AgentCreator {
         ConfigStore.getInstance().setClassLoader(classLoader);
         AgentConfig defaultConfig = new AgentConfig();
         return !ConfigStore.getInstance()
-                .readPrefixes(defaultConfig, ConfigHelper.getDefaultPropertyRegexp("agent"))
+                .readPrefixes(defaultConfig, ConfigHelper.getDefaultPropertyRegexp(DEFAULT_AGENT))
                 .isEmpty();
     }
 
@@ -324,13 +326,13 @@ public final class AgentCreator {
                 Map<String, String> previousValues = new LinkedHashMap<>();
                 try {
                     setSystemPropertyIfNotNull(
-                            previousValues, prefix, "in.memory.store", "file.source", config.fileSource());
+                            previousValues, prefix, IN_MEMORY_STORE, "file.source", config.fileSource());
                     setSystemPropertyIfNotNull(
-                            previousValues, prefix, "in.memory.store", "max.size", config.embeddingStoreMaxSize());
+                            previousValues, prefix, IN_MEMORY_STORE, "max.size", config.embeddingStoreMaxSize());
                     setSystemPropertyIfNotNull(
                             previousValues,
                             prefix,
-                            "in.memory.store",
+                            IN_MEMORY_STORE,
                             "overlap.size",
                             config.embeddingStoreOverlapSize());
 

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentModuleDescriptor.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentModuleDescriptor.java
@@ -53,16 +53,39 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         return false;
     }
 
+    private static final String PROVIDER_OLLAMA = "ollama";
+    private static final String PROVIDER_OPENAI = "openai";
+    private static final String PROVIDER_ANTHROPIC = "anthropic";
+    private static final String PROVIDER_AZURE_OPENAI = "azure-openai";
+    private static final String PROVIDER_BEDROCK = "bedrock";
+    private static final String PROP_BASE_URL = "base-url";
+    private static final String PROP_MODEL_ID = "chat-model.model-id";
+    private static final String PROP_TEMPERATURE = "chat-model.temperature";
+    private static final String PROP_TOP_P = "chat-model.top-p";
+    private static final String PROP_TOP_K = "chat-model.top-k";
+    private static final String PROP_API_KEY = "api-key";
+    private static final String PROP_MODEL_NAME = "chat-model.model-name";
+    private static final String PROP_MAX_TOKENS = "chat-model.max-tokens";
+
     private static final Map<String, String> QUARKUS_EXTENSION_CLASSES = Map.of(
-            "ollama", "io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaConfig",
-            "openai", "io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig",
-            "anthropic", "io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig",
-            "google-gemini", "io.quarkiverse.langchain4j.ai.runtime.gemini.config.LangChain4jAiGeminiConfig",
-            "azure-openai", "io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig",
-            "mistral-ai", "io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig",
-            "hugging-face", "io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig",
-            "watsonx-ai", "io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig",
-            "bedrock", "io.quarkiverse.langchain4j.bedrock.runtime.config.LangChain4jBedrockConfig");
+            PROVIDER_OLLAMA,
+            "io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaConfig",
+            PROVIDER_OPENAI,
+            "io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig",
+            PROVIDER_ANTHROPIC,
+            "io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig",
+            "google-gemini",
+            "io.quarkiverse.langchain4j.ai.runtime.gemini.config.LangChain4jAiGeminiConfig",
+            PROVIDER_AZURE_OPENAI,
+            "io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig",
+            "mistral-ai",
+            "io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig",
+            "hugging-face",
+            "io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig",
+            "watsonx-ai",
+            "io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig",
+            PROVIDER_BEDROCK,
+            "io.quarkiverse.langchain4j.bedrock.runtime.config.LangChain4jBedrockConfig");
 
     @Override
     public Map<String, String> translateProperties(String prefix, AgentConfig config) {
@@ -84,15 +107,15 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         }
 
         return switch (modelKind) {
-            case "ollama" -> translateOllamaProperties(config);
-            case "openai" -> translateOpenAiProperties(config);
-            case "anthropic" -> translateAnthropicProperties(config);
+            case PROVIDER_OLLAMA -> translateOllamaProperties(config);
+            case PROVIDER_OPENAI -> translateOpenAiProperties(config);
+            case PROVIDER_ANTHROPIC -> translateAnthropicProperties(config);
             case "google-gemini" -> translateGeminiProperties(config);
-            case "azure-openai" -> translateAzureOpenAiProperties(config);
+            case PROVIDER_AZURE_OPENAI -> translateAzureOpenAiProperties(config);
             case "mistral-ai" -> translateMistralAiProperties(config);
             case "hugging-face" -> translateHuggingFaceProperties(config);
             case "watsonx-ai" -> translateWatsonxProperties(config);
-            case "bedrock" -> translateBedrockProperties(config);
+            case PROVIDER_BEDROCK -> translateBedrockProperties(config);
             default -> Map.of();
         };
     }
@@ -103,11 +126,11 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("ollama");
 
-        putIfNotNull(props, qp + "base-url", config.baseUrl());
-        putIfNotNull(props, qp + "chat-model.model-id", config.modelName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.top-k", config.topK());
+        putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
+        putIfNotNull(props, qp + PROP_MODEL_ID, config.modelName());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_TOP_K, config.topK());
         addLoggingProperties(props, qp, config);
 
         return props;
@@ -125,13 +148,13 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("anthropic");
 
-        putIfNotNull(props, qp + "base-url", config.baseUrl());
-        putIfNotNull(props, qp + "api-key", config.apiKey());
-        putIfNotNull(props, qp + "chat-model.model-name", config.modelName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.top-k", config.topK());
-        putIfNotNull(props, qp + "chat-model.max-tokens", config.maxTokens());
+        putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
+        putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
+        putIfNotNull(props, qp + PROP_MODEL_NAME, config.modelName());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_TOP_K, config.topK());
+        putIfNotNull(props, qp + PROP_MAX_TOKENS, config.maxTokens());
         addLoggingProperties(props, qp, config);
 
         return props;
@@ -143,12 +166,12 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("ai.gemini");
 
-        putIfNotNull(props, qp + "api-key", config.apiKey());
-        putIfNotNull(props, qp + "base-url", config.baseUrl());
-        putIfNotNull(props, qp + "chat-model.model-id", config.modelName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.top-k", config.topK());
+        putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
+        putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
+        putIfNotNull(props, qp + PROP_MODEL_ID, config.modelName());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_TOP_K, config.topK());
         putIfNotNull(props, qp + "chat-model.max-output-tokens", config.maxTokens());
         addLoggingProperties(props, qp, config);
 
@@ -162,12 +185,12 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("azure-openai");
 
-        putIfNotNull(props, qp + "api-key", config.apiKey());
+        putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
         putIfNotNull(props, qp + "endpoint", config.endpoint());
         putIfNotNull(props, qp + "deployment-name", config.deploymentName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.max-tokens", config.maxTokens());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_MAX_TOKENS, config.maxTokens());
         addLoggingProperties(props, qp, config);
 
         return props;
@@ -185,11 +208,11 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("huggingface");
 
-        putIfNotNull(props, qp + "api-key", config.apiKey());
+        putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
         putIfNotNull(props, qp + "chat-model.inference-endpoint-url", config.baseUrl());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.top-k", config.topK());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_TOP_K, config.topK());
         putIfNotNull(props, qp + "chat-model.max-new-tokens", config.maxTokens());
         addLoggingProperties(props, qp, config);
 
@@ -202,11 +225,11 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("watsonx");
 
-        putIfNotNull(props, qp + "base-url", config.baseUrl());
-        putIfNotNull(props, qp + "api-key", config.apiKey());
-        putIfNotNull(props, qp + "chat-model.model-name", config.modelName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
+        putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
+        putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
+        putIfNotNull(props, qp + PROP_MODEL_NAME, config.modelName());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
         putIfNotNull(props, qp + "chat-model.max-output-tokens", config.maxTokens());
         addLoggingProperties(props, qp, config);
 
@@ -219,11 +242,11 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix("bedrock");
 
-        putIfNotNull(props, qp + "chat-model.model-id", config.modelName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.top-k", config.topK());
-        putIfNotNull(props, qp + "chat-model.max-tokens", config.maxTokens());
+        putIfNotNull(props, qp + PROP_MODEL_ID, config.modelName());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_TOP_K, config.topK());
+        putIfNotNull(props, qp + PROP_MAX_TOKENS, config.maxTokens());
         addLoggingProperties(props, qp, config);
 
         return props;
@@ -233,12 +256,12 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
         Map<String, String> props = new HashMap<>();
         String qp = quarkusPrefix(provider);
 
-        putIfNotNull(props, qp + "base-url", config.baseUrl());
-        putIfNotNull(props, qp + "api-key", config.apiKey());
-        putIfNotNull(props, qp + "chat-model.model-name", config.modelName());
-        putIfNotNull(props, qp + "chat-model.temperature", config.temperature());
-        putIfNotNull(props, qp + "chat-model.top-p", config.topP());
-        putIfNotNull(props, qp + "chat-model.max-tokens", config.maxTokens());
+        putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
+        putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
+        putIfNotNull(props, qp + PROP_MODEL_NAME, config.modelName());
+        putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());
+        putIfNotNull(props, qp + PROP_TOP_P, config.topP());
+        putIfNotNull(props, qp + PROP_MAX_TOKENS, config.maxTokens());
         addLoggingProperties(props, qp, config);
 
         return props;

--- a/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentModuleDescriptor.java
+++ b/library/ai/agents/forage-agent/src/main/java/io/kaoto/forage/agent/AgentModuleDescriptor.java
@@ -124,7 +124,7 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
     // chat-model: model-id, temperature, top-p, top-k
     private Map<String, String> translateOllamaProperties(AgentConfig config) {
         Map<String, String> props = new HashMap<>();
-        String qp = quarkusPrefix("ollama");
+        String qp = quarkusPrefix(PROVIDER_OLLAMA);
 
         putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
         putIfNotNull(props, qp + PROP_MODEL_ID, config.modelName());
@@ -139,14 +139,14 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
     // quarkus.langchain4j.openai.*
     // chat-model: model-name, temperature, top-p, max-tokens
     private Map<String, String> translateOpenAiProperties(AgentConfig config) {
-        return translateStandardModelProperties("openai", config);
+        return translateStandardModelProperties(PROVIDER_OPENAI, config);
     }
 
     // quarkus.langchain4j.anthropic.*
     // chat-model: model-name, temperature, top-p, top-k, max-tokens
     private Map<String, String> translateAnthropicProperties(AgentConfig config) {
         Map<String, String> props = new HashMap<>();
-        String qp = quarkusPrefix("anthropic");
+        String qp = quarkusPrefix(PROVIDER_ANTHROPIC);
 
         putIfNotNull(props, qp + PROP_BASE_URL, config.baseUrl());
         putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
@@ -183,7 +183,7 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
     // chat-model: temperature, top-p, max-tokens
     private Map<String, String> translateAzureOpenAiProperties(AgentConfig config) {
         Map<String, String> props = new HashMap<>();
-        String qp = quarkusPrefix("azure-openai");
+        String qp = quarkusPrefix(PROVIDER_AZURE_OPENAI);
 
         putIfNotNull(props, qp + PROP_API_KEY, config.apiKey());
         putIfNotNull(props, qp + "endpoint", config.endpoint());
@@ -240,7 +240,7 @@ public class AgentModuleDescriptor implements ForageModuleDescriptor<AgentConfig
     // chat-model: model-id, temperature, top-p, top-k, max-tokens
     private Map<String, String> translateBedrockProperties(AgentConfig config) {
         Map<String, String> props = new HashMap<>();
-        String qp = quarkusPrefix("bedrock");
+        String qp = quarkusPrefix(PROVIDER_BEDROCK);
 
         putIfNotNull(props, qp + PROP_MODEL_ID, config.modelName());
         putIfNotNull(props, qp + PROP_TEMPERATURE, config.temperature());

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanConfigEntries.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/InfinispanConfigEntries.java
@@ -11,7 +11,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Comma-separated list of Infinispan server addresses in format 'host1:port1,host2:port2'",
             "Server List",
             "localhost:11222",
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule CACHE_NAME = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Name of the cache for storing chat messages",
             "Cache Name",
             "chat-memory",
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule USERNAME = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Username for authentication (optional)",
             "Username",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule PASSWORD = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Password for authentication (optional)",
             "Password",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule REALM = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Security realm for authentication",
             "Realm",
             "default",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule SASL_MECHANISM = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "SASL mechanism for authentication",
             "SASL Mechanism",
             "DIGEST-MD5",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule CONNECTION_TIMEOUT = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Connection timeout in milliseconds",
             "Connection Timeout",
             "60000",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule SOCKET_TIMEOUT = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Socket timeout in milliseconds",
             "Socket Timeout",
             "60000",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Maximum number of connection retries",
             "Max Retries",
             "3",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MAX_ACTIVE = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Maximum number of active connections per server",
             "Pool Max Active",
             "20",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MIN_IDLE = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Minimum number of idle connections per server",
             "Pool Min Idle",
             "1",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MAX_WAIT = ConfigModule.of(
@@ -110,7 +110,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Maximum time to wait for a connection in milliseconds",
             "Pool Max Wait",
             "3000",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/PersistentInfinispanStore.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/PersistentInfinispanStore.java
@@ -48,6 +48,7 @@ import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 public class PersistentInfinispanStore implements ChatMemoryStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(PersistentInfinispanStore.class);
+    private static final String MEMORY_ID_NOT_NULL = MEMORY_ID_NOT_NULL;
     private static final String EMPTY_MESSAGES_JSON = "[]";
 
     private final RemoteCache<String, String> cache;
@@ -75,7 +76,7 @@ public class PersistentInfinispanStore implements ChatMemoryStore {
      */
     @Override
     public void deleteMessages(Object memoryId) {
-        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(memoryId, MEMORY_ID_NOT_NULL);
 
         String key = memoryId.toString();
         try {
@@ -104,7 +105,7 @@ public class PersistentInfinispanStore implements ChatMemoryStore {
      */
     @Override
     public List<ChatMessage> getMessages(Object memoryId) {
-        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(memoryId, MEMORY_ID_NOT_NULL);
 
         String key = memoryId.toString();
         try {
@@ -145,7 +146,7 @@ public class PersistentInfinispanStore implements ChatMemoryStore {
      */
     @Override
     public void updateMessages(Object memoryId, List<ChatMessage> messages) {
-        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(memoryId, MEMORY_ID_NOT_NULL);
         Objects.requireNonNull(messages, "Messages list cannot be null");
 
         String key = memoryId.toString();

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/PersistentInfinispanStore.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/io/kaoto/forage/memory/chat/infinispan/PersistentInfinispanStore.java
@@ -48,7 +48,7 @@ import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 public class PersistentInfinispanStore implements ChatMemoryStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(PersistentInfinispanStore.class);
-    private static final String MEMORY_ID_NOT_NULL = MEMORY_ID_NOT_NULL;
+    private static final String MEMORY_ID_NOT_NULL = "Memory ID cannot be null";
     private static final String EMPTY_MESSAGES_JSON = "[]";
 
     private final RemoteCache<String, String> cache;

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/PersistentRedisStore.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/PersistentRedisStore.java
@@ -51,6 +51,7 @@ import redis.clients.jedis.exceptions.JedisException;
 public class PersistentRedisStore implements ChatMemoryStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(PersistentRedisStore.class);
+    private static final String MEMORY_ID_NOT_NULL = MEMORY_ID_NOT_NULL;
     private static final String EMPTY_MESSAGES_JSON = "[]";
 
     private final JedisPool jedisPool;
@@ -78,7 +79,7 @@ public class PersistentRedisStore implements ChatMemoryStore {
      */
     @Override
     public void deleteMessages(Object memoryId) {
-        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(memoryId, MEMORY_ID_NOT_NULL);
 
         String key = memoryId.toString();
         try (Jedis jedis = jedisPool.getResource()) {
@@ -103,7 +104,7 @@ public class PersistentRedisStore implements ChatMemoryStore {
      */
     @Override
     public List<ChatMessage> getMessages(Object memoryId) {
-        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(memoryId, MEMORY_ID_NOT_NULL);
 
         String key = memoryId.toString();
         try (Jedis jedis = jedisPool.getResource()) {
@@ -146,7 +147,7 @@ public class PersistentRedisStore implements ChatMemoryStore {
      */
     @Override
     public void updateMessages(Object memoryId, List<ChatMessage> messages) {
-        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(memoryId, MEMORY_ID_NOT_NULL);
         Objects.requireNonNull(messages, "Messages list cannot be null");
 
         String key = memoryId.toString();

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/PersistentRedisStore.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/PersistentRedisStore.java
@@ -51,7 +51,7 @@ import redis.clients.jedis.exceptions.JedisException;
 public class PersistentRedisStore implements ChatMemoryStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(PersistentRedisStore.class);
-    private static final String MEMORY_ID_NOT_NULL = MEMORY_ID_NOT_NULL;
+    private static final String MEMORY_ID_NOT_NULL = "Memory ID cannot be null";
     private static final String EMPTY_MESSAGES_JSON = "[]";
 
     private final JedisPool jedisPool;

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisConfig.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisConfig.java
@@ -87,6 +87,9 @@ import static io.kaoto.forage.memory.chat.redis.RedisConfigEntries.TIMEOUT;
  */
 public class RedisConfig extends AbstractConfig {
 
+    private static final String BOOLEAN_FALSE = "false";
+    private static final String BOOLEAN_TRUE = "true";
+
     /**
      * Creates a new Redis configuration instance and registers configuration entries
      * with the central configuration store.
@@ -238,7 +241,7 @@ public class RedisConfig extends AbstractConfig {
     public boolean poolTestOnBorrow() {
         return get(POOL_TEST_ON_BORROW)
                 .map(value -> {
-                    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                    if (BOOLEAN_TRUE.equalsIgnoreCase(value) || BOOLEAN_FALSE.equalsIgnoreCase(value)) {
                         return Boolean.parseBoolean(value);
                     }
                     throw new IllegalArgumentException(
@@ -256,7 +259,7 @@ public class RedisConfig extends AbstractConfig {
     public boolean poolTestOnReturn() {
         return get(POOL_TEST_ON_RETURN)
                 .map(value -> {
-                    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                    if (BOOLEAN_TRUE.equalsIgnoreCase(value) || BOOLEAN_FALSE.equalsIgnoreCase(value)) {
                         return Boolean.parseBoolean(value);
                     }
                     throw new IllegalArgumentException(
@@ -274,7 +277,7 @@ public class RedisConfig extends AbstractConfig {
     public boolean poolTestWhileIdle() {
         return get(POOL_TEST_WHILE_IDLE)
                 .map(value -> {
-                    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                    if (BOOLEAN_TRUE.equalsIgnoreCase(value) || BOOLEAN_FALSE.equalsIgnoreCase(value)) {
                         return Boolean.parseBoolean(value);
                     }
                     throw new IllegalArgumentException(

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisConfigEntries.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/io/kaoto/forage/memory/chat/redis/RedisConfigEntries.java
@@ -20,7 +20,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Redis server port number",
             "Port",
             "6379",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule PASSWORD = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Redis authentication password (optional)",
             "Password",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule DATABASE = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Redis database number to connect to",
             "Database",
             "0",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Connection timeout in milliseconds",
             "Timeout",
             "2000",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MAX_TOTAL = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Maximum number of connections in the pool",
             "Pool Max Total",
             "10",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MAX_IDLE = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Maximum number of idle connections in the pool",
             "Pool Max Idle",
             "5",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MIN_IDLE = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Minimum number of idle connections in the pool",
             "Pool Min Idle",
             "1",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_TEST_ON_BORROW = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Test connections when borrowing from pool",
             "Test On Borrow",
             "true",
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_TEST_ON_RETURN = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Test connections when returning to pool",
             "Test On Return",
             "true",
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_TEST_WHILE_IDLE = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Test idle connections periodically",
             "Test While Idle",
             "true",
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule POOL_MAX_WAIT_MILLIS = ConfigModule.of(
@@ -110,7 +110,7 @@ public final class RedisConfigEntries extends ConfigEntries {
             "Maximum time to wait for a connection from the pool in milliseconds",
             "Pool Max Wait",
             "2000",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/guardrails/forage-guardrails-output/src/main/java/io/kaoto/forage/guardrails/output/SensitiveDataGuardrailConfigEntries.java
+++ b/library/ai/guardrails/forage-guardrails-output/src/main/java/io/kaoto/forage/guardrails/output/SensitiveDataGuardrailConfigEntries.java
@@ -15,7 +15,7 @@ public final class SensitiveDataGuardrailConfigEntries extends ConfigEntries {
             "Comma-separated list of sensitive data types to detect: API_KEY, AWS_KEY, SECRET, PRIVATE_KEY, CREDIT_CARD, SSN, JWT, CONNECTION_STRING, GITHUB_TOKEN",
             "Detect Types",
             "API_KEY,AWS_KEY,SECRET,PRIVATE_KEY,CREDIT_CARD,SSN,JWT,CONNECTION_STRING,GITHUB_TOKEN",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -25,7 +25,7 @@ public final class SensitiveDataGuardrailConfigEntries extends ConfigEntries {
             "Action to take when sensitive data is detected: BLOCK, REDACT, WARN",
             "Action",
             "BLOCK",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 
@@ -35,7 +35,7 @@ public final class SensitiveDataGuardrailConfigEntries extends ConfigEntries {
             "Text to use for redaction when action is REDACT",
             "Redaction Text",
             "[REDACTED]",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 

--- a/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicConfigEntries.java
+++ b/library/ai/models/chat/forage-model-anthropic/src/main/java/io/kaoto/forage/models/chat/anthropic/AnthropicConfigEntries.java
@@ -38,7 +38,7 @@ public final class AnthropicConfigEntries extends ConfigEntries {
             "Maximum number of tokens in the model's response",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class AnthropicConfigEntries extends ConfigEntries {
             "Top-k sampling parameter: limits the model to consider only the top-k most probable tokens",
             "Top K",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule STOP_SEQUENCES = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class AnthropicConfigEntries extends ConfigEntries {
             "Request timeout in seconds",
             "Timeout",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class AnthropicConfigEntries extends ConfigEntries {
             "Maximum number of retry attempts for failed requests",
             "Max Retries",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(

--- a/library/ai/models/chat/forage-model-azure-openai/src/main/java/io/kaoto/forage/models/chat/azureopenai/AzureOpenAiConfigEntries.java
+++ b/library/ai/models/chat/forage-model-azure-openai/src/main/java/io/kaoto/forage/models/chat/azureopenai/AzureOpenAiConfigEntries.java
@@ -20,7 +20,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Azure OpenAI resource endpoint URL (e.g., https://your-resource.openai.azure.com/)",
             "Endpoint",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule DEPLOYMENT_NAME = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Azure OpenAI deployment name (e.g., gpt-35-turbo, gpt-4)",
             "Deployment Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule SERVICE_VERSION = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Azure OpenAI API service version (e.g., 2024-02-01)",
             "Service Version",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Temperature for response generation (0.0-2.0): lower values are more deterministic, higher values are more creative",
             "Temperature",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MAX_TOKENS = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Maximum number of tokens in the model's response",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Top-p (nucleus sampling) probability threshold (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule PRESENCE_PENALTY = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Presence penalty for discouraging new topic introduction (-2.0 to 2.0)",
             "Presence Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FREQUENCY_PENALTY = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Frequency penalty for discouraging token repetition (-2.0 to 2.0)",
             "Frequency Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule SEED = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Seed for deterministic response generation (same seed + same input = similar output)",
             "Seed",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule USER = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "User identifier for tracking and monitoring API usage",
             "User ID",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
@@ -110,7 +110,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Request timeout in seconds",
             "Timeout",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
@@ -119,7 +119,7 @@ public final class AzureOpenAiConfigEntries extends ConfigEntries {
             "Maximum number of retry attempts for failed requests",
             "Max Retries",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(

--- a/library/ai/models/chat/forage-model-dashscope/src/main/java/io/kaoto/forage/models/chat/dashscope/DashscopeConfigEntries.java
+++ b/library/ai/models/chat/forage-model-dashscope/src/main/java/io/kaoto/forage/models/chat/dashscope/DashscopeConfigEntries.java
@@ -38,7 +38,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Maximum number of tokens in the model's response",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Top-p (nucleus sampling) probability threshold (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_K = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Top-k sampling parameter: limits the model to consider only the top-k most probable tokens",
             "Top K",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule REPETITION_PENALTY = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Repetition penalty for discouraging token repetition (0.0-2.0)",
             "Repetition Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule SEED = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Seed for deterministic response generation (same seed + same input = similar output)",
             "Seed",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule ENABLE_SEARCH = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Request timeout in seconds",
             "Timeout",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class DashscopeConfigEntries extends ConfigEntries {
             "Maximum number of retry attempts for failed requests",
             "Max Retries",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(

--- a/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleConfigEntries.java
+++ b/library/ai/models/chat/forage-model-google-gemini/src/main/java/io/kaoto/forage/models/chat/google/GoogleConfigEntries.java
@@ -38,7 +38,7 @@ public final class GoogleConfigEntries extends ConfigEntries {
             "Request timeout in seconds",
             "Timeout",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class GoogleConfigEntries extends ConfigEntries {
             "Maximum number of output tokens",
             "Max Output Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class GoogleConfigEntries extends ConfigEntries {
             "Top-k sampling parameter",
             "Top K",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/models/chat/forage-model-local-ai/src/main/java/io/kaoto/forage/models/chat/localai/LocalAiConfigEntries.java
+++ b/library/ai/models/chat/forage-model-local-ai/src/main/java/io/kaoto/forage/models/chat/localai/LocalAiConfigEntries.java
@@ -20,7 +20,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "The LocalAI server endpoint URL",
             "Base URL",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule MODEL_NAME = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "The model to use (must be available on LocalAI server)",
             "Model Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Temperature for response generation (0.0-2.0)",
             "Temperature",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MAX_TOKENS = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Maximum number of tokens for model responses",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Top-p (nucleus sampling) probability threshold (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule PRESENCE_PENALTY = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Presence penalty for discouraging new topic introduction (-2.0 to 2.0)",
             "Presence Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FREQUENCY_PENALTY = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Frequency penalty for discouraging token repetition (-2.0 to 2.0)",
             "Frequency Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule SEED = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Seed for deterministic response generation",
             "Seed",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule USER = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "User identifier for tracking and monitoring",
             "User",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Request timeout in seconds",
             "Timeout",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
@@ -110,7 +110,7 @@ public final class LocalAiConfigEntries extends ConfigEntries {
             "Maximum number of retry attempts for failed requests",
             "Max Retries",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(

--- a/library/ai/models/chat/forage-model-mistral-ai/src/main/java/io/kaoto/forage/models/chat/mistralai/MistralAiConfigEntries.java
+++ b/library/ai/models/chat/forage-model-mistral-ai/src/main/java/io/kaoto/forage/models/chat/mistralai/MistralAiConfigEntries.java
@@ -38,7 +38,7 @@ public final class MistralAiConfigEntries extends ConfigEntries {
             "Maximum number of tokens for model responses",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class MistralAiConfigEntries extends ConfigEntries {
             "Random seed for reproducible results",
             "Random Seed",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class MistralAiConfigEntries extends ConfigEntries {
             "Request timeout in seconds",
             "Timeout",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_RETRIES = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class MistralAiConfigEntries extends ConfigEntries {
             "Maximum number of retry attempts",
             "Max Retries",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(

--- a/library/ai/models/chat/forage-model-ollama/src/main/java/io/kaoto/forage/models/chat/ollama/OllamaConfigEntries.java
+++ b/library/ai/models/chat/forage-model-ollama/src/main/java/io/kaoto/forage/models/chat/ollama/OllamaConfigEntries.java
@@ -11,7 +11,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "The base URL of the Ollama server",
             "Base URL",
             "http://localhost:11434",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MODEL_NAME = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "The Ollama model to use",
             "Model Name",
             "llama3.2",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Temperature for response randomness (0.0-2.0)",
             "Temperature",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TOP_K = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Top-K sampling parameter",
             "Top K",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Top-P (nucleus) sampling parameter (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MIN_P = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Minimum probability threshold (0.0-1.0)",
             "Min P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule NUM_CTX = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Context window size",
             "Context Size",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule LOG_REQUESTS = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Enable request logging",
             "Log Requests",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_RESPONSES = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Enable response logging",
             "Log Responses",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class OllamaConfigEntries extends ConfigEntries {
             "Request timeout duration in ISO-8601 format (e.g. PT120S for 120 seconds)",
             "Timeout",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
 

--- a/library/ai/models/chat/forage-model-open-ai/src/main/java/io/kaoto/forage/models/chat/openai/OpenAIConfigEntries.java
+++ b/library/ai/models/chat/forage-model-open-ai/src/main/java/io/kaoto/forage/models/chat/openai/OpenAIConfigEntries.java
@@ -11,7 +11,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "OpenAI API key for authentication",
             "API Key",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             true,
             ConfigTag.SECURITY);
     public static final ConfigModule MODEL_NAME = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "The specific OpenAI model to use",
             "Model Name",
             "gpt-4o-mini",
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule BASE_URL = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Custom base URL for OpenAI API",
             "Base URL",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Temperature for response randomness (0.0-2.0)",
             "Temperature",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MAX_TOKENS = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Maximum number of tokens to generate",
             "Max Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Top-P (nucleus) sampling parameter (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FREQUENCY_PENALTY = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Frequency penalty (-2.0 to 2.0)",
             "Frequency Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule PRESENCE_PENALTY = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Presence penalty (-2.0 to 2.0)",
             "Presence Penalty",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Enable request logging",
             "Log Requests",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_RESPONSES = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Enable response logging",
             "Log Responses",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TIMEOUT = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Request timeout duration",
             "Timeout",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule HTTP1_1 = ConfigModule.of(
@@ -110,7 +110,7 @@ public final class OpenAIConfigEntries extends ConfigEntries {
             "Use HTTP/1.1 instead of HTTP/2",
             "Use HTTP/1.1",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiConfigEntries.java
+++ b/library/ai/models/chat/forage-model-watsonx-ai/src/main/java/io/kaoto/forage/models/chat/watsonxai/WatsonxAiConfigEntries.java
@@ -11,7 +11,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "IBM Cloud API key for authentication",
             "API Key",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule URL = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "The Watsonx.ai service URL (e.g., https://us-south.ml.cloud.ibm.com)",
             "Service URL",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule PROJECT_ID = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "The Watsonx.ai project ID",
             "Project ID",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule MODEL_NAME = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "The foundation model to use",
             "Model Name",
             "llama-3-405b-instruct",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TEMPERATURE = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Temperature for response generation (0.0-2.0)",
             "Temperature",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule MAX_NEW_TOKENS = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Maximum number of new tokens in response",
             "Max New Tokens",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TOP_P = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Top-p (nucleus sampling) parameter (0.0-1.0)",
             "Top P",
             null,
-            "double",
+            ConfigModule.TYPE_DOUBLE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule RANDOM_SEED = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Random seed for reproducible results",
             "Random Seed",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule STOP_SEQUENCES = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Stop sequences for response generation (comma-separated)",
             "Stop Sequences",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LOG_REQUESTS_AND_RESPONSES = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class WatsonxAiConfigEntries extends ConfigEntries {
             "Enable request and response logging",
             "Log Requests/Responses",
             null,
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/vector-dbs/forage-vectordb-infinispan/src/main/java/io/kaoto/forage/vectordb/infinispan/InfinispanConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-infinispan/src/main/java/io/kaoto/forage/vectordb/infinispan/InfinispanConfigEntries.java
@@ -11,7 +11,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Name of the Infinispan cache",
             "Cache Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule DIMENSION = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Vector dimension for embeddings",
             "Dimension",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule DISTANCE = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Distance metric for similarity (3 for cosine)",
             "Distance",
             "3",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule SIMILARITY = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Similarity algorithm",
             "Similarity",
             "COSINE",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule CACHE_CONFIG = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Cache configuration settings",
             "Cache Config",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule PACKAGE_NAME = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Package name for generated classes",
             "Package Name",
             "io.kaoto.forage.vectordb.infinispan.schema",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FILE_NAME = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Schema file name",
             "File Name",
             "langchain-item.proto",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LANGCHAIN_ITEM_NAME = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "LangChain item class name",
             "LangChain Item Name",
             "LangChainItem",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule METADATA_ITEM_NAME = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Metadata item class name",
             "Metadata Item Name",
             "MetadataItem",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule REGISTER_SCHEMA = ConfigModule.of(
@@ -110,7 +110,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Infinispan server host address",
             "Host",
             "localhost",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule PORT = ConfigModule.of(
@@ -119,7 +119,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Infinispan server port number",
             "Port",
             "11222",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule USERNAME = ConfigModule.of(
@@ -128,7 +128,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Username for authentication",
             "Username",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule PASSWORD = ConfigModule.of(
@@ -137,7 +137,7 @@ public final class InfinispanConfigEntries extends ConfigEntries {
             "Password for authentication",
             "Password",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             false,
             ConfigTag.SECURITY);
 

--- a/library/ai/vector-dbs/forage-vectordb-mariadb/src/main/java/io/kaoto/forage/vectordb/mariadb/MariaDbConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-mariadb/src/main/java/io/kaoto/forage/vectordb/mariadb/MariaDbConfigEntries.java
@@ -11,7 +11,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "MariaDB JDBC URL (e.g., jdbc:mariadb://localhost:3306/vectordb)",
             "URL",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule USER = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Database username for authentication",
             "User",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             true,
             ConfigTag.SECURITY);
     public static final ConfigModule PASSWORD = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Database password for authentication",
             "Password",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule TABLE = ConfigModule.of(
@@ -38,7 +38,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Name of the table to store embeddings",
             "Table",
             "embeddings",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule ID_FIELD_NAME = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Name of the ID field in the embeddings table",
             "ID Field Name",
             "id",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule EMBEDDING_FIELD_NAME = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Name of the embedding vector field",
             "Embedding Field Name",
             "embedding",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule CONTENT_FIELD_NAME = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Name of the content text field",
             "Content Field Name",
             "content",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule DISTANCE_TYPE = ConfigModule.of(
@@ -74,7 +74,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Distance calculation method: COSINE or EUCLIDEAN",
             "Distance Type",
             "COSINE",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule DIMENSION = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Vector dimension size",
             "Dimension",
             "384",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule CREATE_TABLE = ConfigModule.of(
@@ -92,7 +92,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Whether to create the table if it doesn't exist",
             "Create Table",
             "true",
-            "boolean",
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule DROP_TABLE_FIRST = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Whether to drop the table before creating it",
             "Drop Table First",
             "false",
-            "boolean",
+            ConfigModule.TYPE_FALSE,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/vector-dbs/forage-vectordb-mariadb/src/main/java/io/kaoto/forage/vectordb/mariadb/MariaDbConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-mariadb/src/main/java/io/kaoto/forage/vectordb/mariadb/MariaDbConfigEntries.java
@@ -101,7 +101,7 @@ public final class MariaDbConfigEntries extends ConfigEntries {
             "Whether to drop the table before creating it",
             "Drop Table First",
             "false",
-            ConfigModule.TYPE_FALSE,
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/io/kaoto/forage/vectordb/milvus/MilvusConfigEntries.java
@@ -11,7 +11,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Milvus server host address",
             "Host",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule PORT = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Name of the Milvus collection",
             "Collection Name",
             "default",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule DIMENSION = ConfigModule.of(
@@ -47,7 +47,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Index type for vector search (e.g., IVF_FLAT, HNSW)",
             "Index Type",
             "FLAT",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule METRIC_TYPE = ConfigModule.of(
@@ -56,7 +56,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Distance metric type (e.g., COSINE, L2, IP)",
             "Metric Type",
             "COSINE",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule URI = ConfigModule.of(
@@ -65,7 +65,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Milvus server URI (alternative to host/port)",
             "URI",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule TOKEN = ConfigModule.of(
@@ -83,7 +83,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Username for authentication",
             "Username",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule PASSWORD = ConfigModule.of(
@@ -101,7 +101,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Consistency level for queries (e.g., STRONG, EVENTUALLY)",
             "Consistency Level",
             "EVENTUALLY",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule RETRIEVE_EMBEDDINGS_ON_SEARCH = ConfigModule.of(
@@ -128,7 +128,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Name of the Milvus database",
             "Database Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule ID_FIELD_NAME = ConfigModule.of(
@@ -137,7 +137,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Name of the ID field",
             "ID Field Name",
             "id",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule TEXT_FIELD_NAME = ConfigModule.of(
@@ -146,7 +146,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Name of the text field",
             "Text Field Name",
             "text",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule METADATA_FIELD_NAME = ConfigModule.of(
@@ -155,7 +155,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Name of the metadata field",
             "Metadata Field Name",
             "metadata",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule VECTOR_FIELD_NAME = ConfigModule.of(
@@ -164,7 +164,7 @@ public final class MilvusConfigEntries extends ConfigEntries {
             "Name of the vector field",
             "Vector Field Name",
             "vector",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/io/kaoto/forage/vectordb/neo4j/Neo4jConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/io/kaoto/forage/vectordb/neo4j/Neo4jConfigEntries.java
@@ -128,7 +128,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Auto create full text index",
             "Auto Create Full Text",
             "false",
-            ConfigModule.TYPE_FALSE,
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule ENTITY_CREATION_QUERY = ConfigModule.of(
@@ -173,7 +173,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Enable SSL encryption",
             "With Encryption",
             "false",
-            ConfigModule.TYPE_FALSE,
+            ConfigModule.TYPE_BOOLEAN,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule CONNECTION_TIMEOUT = ConfigModule.of(

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/io/kaoto/forage/vectordb/neo4j/Neo4jConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/io/kaoto/forage/vectordb/neo4j/Neo4jConfigEntries.java
@@ -11,7 +11,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Vector index name",
             "Index Name",
             "vector-index",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule METADATA_PREFIX = ConfigModule.of(
@@ -20,7 +20,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Metadata prefix",
             "Metadata Prefix",
             "metadata_",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule EMBEDDING_PROPERTY = ConfigModule.of(
@@ -29,7 +29,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Embedding property name",
             "Embedding Property",
             "embedding",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule ID_PROPERTY = ConfigModule.of(
@@ -38,18 +38,25 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "ID property name",
             "ID Property",
             "id",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule LABEL = ConfigModule.of(
-            Neo4jConfig.class, "neo4j.label", "Node label", "Label", "Document", "string", false, ConfigTag.COMMON);
+            Neo4jConfig.class,
+            "neo4j.label",
+            "Node label",
+            "Label",
+            "Document",
+            ConfigModule.TYPE_STRING,
+            false,
+            ConfigTag.COMMON);
     public static final ConfigModule TEXT_PROPERTY = ConfigModule.of(
             Neo4jConfig.class,
             "forage.neo4j.text.property",
             "Text property name",
             "Text Property",
             "text",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule DATABASE_NAME = ConfigModule.of(
@@ -58,7 +65,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Database name",
             "Database Name",
             "neo4j",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule RETRIEVAL_QUERY = ConfigModule.of(
@@ -67,7 +74,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Custom retrieval query",
             "Retrieval Query",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule DIMENSION = ConfigModule.of(
@@ -76,7 +83,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Vector dimension",
             "Dimension",
             null,
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             true,
             ConfigTag.COMMON);
     public static final ConfigModule AWAIT_INDEX_TIMEOUT = ConfigModule.of(
@@ -85,7 +92,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Index creation timeout in seconds",
             "Await Index Timeout",
             "60",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FULL_TEXT_INDEX_NAME = ConfigModule.of(
@@ -94,7 +101,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Full text index name",
             "Full Text Index Name",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FULL_TEXT_QUERY = ConfigModule.of(
@@ -103,7 +110,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Full text query",
             "Full Text Query",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule FULL_TEXT_RETRIEVAL_QUERY = ConfigModule.of(
@@ -112,7 +119,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Full text retrieval query",
             "Full Text Retrieval Query",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule AUTO_CREATE_FULL_TEXT = ConfigModule.of(
@@ -121,7 +128,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Auto create full text index",
             "Auto Create Full Text",
             "false",
-            "boolean",
+            ConfigModule.TYPE_FALSE,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule ENTITY_CREATION_QUERY = ConfigModule.of(
@@ -130,7 +137,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Custom entity creation query",
             "Entity Creation Query",
             null,
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule URI = ConfigModule.of(
@@ -139,18 +146,25 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Neo4j server URI",
             "URI",
             "bolt://localhost:7687",
-            "string",
+            ConfigModule.TYPE_STRING,
             false,
             ConfigTag.COMMON);
     public static final ConfigModule USER = ConfigModule.of(
-            Neo4jConfig.class, "forage.neo4j.user", "Username", "User", "neo4j", "string", false, ConfigTag.SECURITY);
+            Neo4jConfig.class,
+            "forage.neo4j.user",
+            "Username",
+            "User",
+            "neo4j",
+            ConfigModule.TYPE_STRING,
+            false,
+            ConfigTag.SECURITY);
     public static final ConfigModule PASSWORD = ConfigModule.of(
             Neo4jConfig.class,
             "forage.neo4j.password",
             "Password",
             "Password",
             null,
-            "password",
+            ConfigModule.TYPE_PASSWORD,
             true,
             ConfigTag.SECURITY);
     public static final ConfigModule WITH_ENCRYPTION = ConfigModule.of(
@@ -159,7 +173,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Enable SSL encryption",
             "With Encryption",
             "false",
-            "boolean",
+            ConfigModule.TYPE_FALSE,
             false,
             ConfigTag.SECURITY);
     public static final ConfigModule CONNECTION_TIMEOUT = ConfigModule.of(
@@ -168,7 +182,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Connection timeout in seconds",
             "Connection Timeout",
             "30",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_CONNECTION_LIFETIME = ConfigModule.of(
@@ -177,7 +191,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Max connection lifetime in minutes",
             "Max Connection Lifetime",
             "60",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule MAX_CONNECTION_POOL_SIZE = ConfigModule.of(
@@ -186,7 +200,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Max connection pool size",
             "Max Connection Pool Size",
             "100",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
     public static final ConfigModule CONNECTION_ACQUISITION_TIMEOUT = ConfigModule.of(
@@ -195,7 +209,7 @@ public final class Neo4jConfigEntries extends ConfigEntries {
             "Connection acquisition timeout in seconds",
             "Connection Acquisition Timeout",
             "60",
-            "integer",
+            ConfigModule.TYPE_INTEGER,
             false,
             ConfigTag.ADVANCED);
 

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForagePropertyCondition.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForagePropertyCondition.java
@@ -39,6 +39,7 @@ import io.kaoto.forage.core.util.config.ConfigStore;
 public class ForagePropertyCondition extends SpringBootCondition {
 
     private static final Logger log = LoggerFactory.getLogger(ForagePropertyCondition.class);
+    private static final String PROPERTY_PREFIX = PROPERTY_PREFIX;
 
     @Override
     public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
@@ -96,7 +97,7 @@ public class ForagePropertyCondition extends SpringBootCondition {
 
             if (defaultMatches) {
                 return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
-                        .foundExactly("property '" + configModule.name() + "' matches criteria"));
+                        .foundExactly(PROPERTY_PREFIX + configModule.name() + "' matches criteria"));
             }
 
             // Check prefixed configurations
@@ -122,7 +123,7 @@ public class ForagePropertyCondition extends SpringBootCondition {
 
                     if (matches) {
                         return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
-                                .foundExactly("property '" + configModule.name() + "' matches criteria for prefix '"
+                                .foundExactly(PROPERTY_PREFIX + configModule.name() + "' matches criteria for prefix '"
                                         + prefix + "'"));
                     }
                 } catch (Exception e) {
@@ -137,11 +138,11 @@ public class ForagePropertyCondition extends SpringBootCondition {
             // No match found in any configuration
             if (matchIfMissing) {
                 return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
-                        .foundExactly("property '" + configModule.name() + "' not found and matchIfMissing=true"));
+                        .foundExactly(PROPERTY_PREFIX + configModule.name() + "' not found and matchIfMissing=true"));
             } else {
                 return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
-                        .because(
-                                "property '" + configModule.name() + "' does not match criteria in any configuration"));
+                        .because(PROPERTY_PREFIX + configModule.name()
+                                + "' does not match criteria in any configuration"));
             }
 
         } catch (Exception e) {

--- a/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForagePropertyCondition.java
+++ b/library/common/forage-spring-boot-common/src/main/java/io/kaoto/forage/springboot/common/ForagePropertyCondition.java
@@ -39,7 +39,7 @@ import io.kaoto.forage.core.util.config.ConfigStore;
 public class ForagePropertyCondition extends SpringBootCondition {
 
     private static final Logger log = LoggerFactory.getLogger(ForagePropertyCondition.class);
-    private static final String PROPERTY_PREFIX = PROPERTY_PREFIX;
+    private static final String PROPERTY_PREFIX = "property '";
 
     @Override
     public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {

--- a/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfCommonExportHelper.java
+++ b/library/cxf/forage-cxf-common/src/main/java/io/kaoto/forage/cxf/common/CxfCommonExportHelper.java
@@ -4,17 +4,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CxfCommonExportHelper {
+    private static final String SOAP_ENDPOINT_PROVIDER = "io.kaoto.forage.cxf.soap.SoapEndpointProvider";
     private static final Map<String, String> CXF_KIND_TO_PROVIDER_CLASS = new HashMap<>();
 
     static {
-        CXF_KIND_TO_PROVIDER_CLASS.put("soap", "io.kaoto.forage.cxf.soap.SoapEndpointProvider");
+        CXF_KIND_TO_PROVIDER_CLASS.put("soap", SOAP_ENDPOINT_PROVIDER);
     }
 
     public static String transformCxfKindIntoProviderClass(String cxfKind) {
         if (cxfKind == null) {
-            return "io.kaoto.forage.cxf.soap.SoapEndpointProvider";
+            return SOAP_ENDPOINT_PROVIDER;
         }
-        return CXF_KIND_TO_PROVIDER_CLASS.getOrDefault(
-                cxfKind.toLowerCase(), "io.kaoto.forage.cxf.soap.SoapEndpointProvider");
+        return CXF_KIND_TO_PROVIDER_CLASS.getOrDefault(cxfKind.toLowerCase(), SOAP_ENDPOINT_PROVIDER);
     }
 }

--- a/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/io/kaoto/forage/jdbc/DataSourceBeanFactory.java
@@ -200,7 +200,7 @@ public class DataSourceBeanFactory implements BeanFactory {
             }
         } else {
             try {
-                if (camelContext.getRegistry().lookupByNameAndType("dataSource", DataSource.class) == null) {
+                if (camelContext.getRegistry().lookupByNameAndType(DEFAULT_DATASOURCE, DataSource.class) == null) {
                     final List<ServiceLoader.Provider<DataSourceProvider>> providers =
                             findProviders(DataSourceProvider.class);
                     if (providers.size() == 1) {

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/CatalogDrivenExportCustomizer.java
@@ -22,6 +22,7 @@ import io.kaoto.forage.core.common.RuntimeType;
 public class CatalogDrivenExportCustomizer implements ExportCustomizer {
 
     private static final Logger LOG = LoggerFactory.getLogger(CatalogDrivenExportCustomizer.class);
+    private static final String FORAGE_PREFIX = "forage.";
 
     private Map<String, Map<String, List<String>>> scannedProperties;
     private Boolean enabled;
@@ -175,15 +176,15 @@ public class CatalogDrivenExportCustomizer implements ExportCustomizer {
             return null;
         }
         // Try with the factoryTypeKey first (e.g., "forage.jdbc." for jdbc factory)
-        String prefix = "forage." + factoryTypeKey + ".";
+        String prefix = FORAGE_PREFIX + factoryTypeKey + ".";
         if (entryName.startsWith(prefix)) {
             return entryName.substring(prefix.length());
         }
         // Fallback: extract the suffix using the entry's own prefix segment
         // This handles cases where the factoryTypeKey differs from the config entry prefix
         // (e.g., agent factory has key "multi" but bean-name entries use "forage.agent.*")
-        if (entryName.startsWith("forage.")) {
-            String remaining = entryName.substring("forage.".length());
+        if (entryName.startsWith(FORAGE_PREFIX)) {
+            String remaining = entryName.substring(FORAGE_PREFIX.length());
             int dotIndex = remaining.indexOf('.');
             if (dotIndex > 0) {
                 return remaining.substring(dotIndex + 1);
@@ -224,7 +225,7 @@ public class CatalogDrivenExportCustomizer implements ExportCustomizer {
 
         for (Map.Entry<String, List<String>> entry : factoryProperties.entrySet()) {
             String key = entry.getKey();
-            if (configEntry.endsWith("." + key) || configEntry.equals("forage." + key)) {
+            if (configEntry.endsWith("." + key) || configEntry.equals(FORAGE_PREFIX + key)) {
                 for (String value : entry.getValue()) {
                     if ("true".equalsIgnoreCase(value)) {
                         return true;

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/ForagePropertyValidator.java
@@ -33,6 +33,7 @@ import io.kaoto.forage.plugin.ForagePropertyScanner.PropertyOccurrence;
 public final class ForagePropertyValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(ForagePropertyValidator.class);
+    private static final String FORAGE_PREFIX = "forage.";
 
     /**
      * Set when a Forage command ({@code camel forage run}/{@code camel forage export}) has already
@@ -202,7 +203,7 @@ public final class ForagePropertyValidator {
             ForageCatalogReader.FactoryMetadata metadata, ForageCatalogReader catalog, String factoryTypeKey) {
 
         Set<String> validNames = new HashSet<>();
-        String factoryPrefix = "forage." + factoryTypeKey + ".";
+        String factoryPrefix = FORAGE_PREFIX + factoryTypeKey + ".";
 
         // Add factory-level config entries
         if (metadata.configEntries() != null) {
@@ -220,11 +221,11 @@ public final class ForagePropertyValidator {
             if (bean.getConfigEntries() != null) {
                 for (ConfigEntry entry : bean.getConfigEntries()) {
                     String name = entry.getName();
-                    if (name != null && name.startsWith("forage.")) {
+                    if (name != null && name.startsWith(FORAGE_PREFIX)) {
                         // Extract property suffix
                         String beanPrefix = extractBeanPrefix(name);
                         if (beanPrefix != null) {
-                            String suffix = name.substring(("forage." + beanPrefix + ".").length());
+                            String suffix = name.substring((FORAGE_PREFIX + beanPrefix + ".").length());
                             // Use fully qualified keys (prefix + suffix) to prevent collisions
                             validNames.add(beanPrefix + "." + suffix);
                         }
@@ -275,7 +276,7 @@ public final class ForagePropertyValidator {
             ForageCatalogReader catalog,
             String factoryTypeKey) {
 
-        String factoryPrefix = "forage." + factoryTypeKey + ".";
+        String factoryPrefix = FORAGE_PREFIX + factoryTypeKey + ".";
 
         // Check factory-level entries
         if (metadata.configEntries() != null) {
@@ -296,10 +297,10 @@ public final class ForagePropertyValidator {
             if (bean.getConfigEntries() != null) {
                 for (ConfigEntry entry : bean.getConfigEntries()) {
                     String name = entry.getName();
-                    if (name != null && name.startsWith("forage.")) {
+                    if (name != null && name.startsWith(FORAGE_PREFIX)) {
                         String beanPrefix = extractBeanPrefix(name);
                         if (beanPrefix != null) {
-                            String suffix = name.substring(("forage." + beanPrefix + ".").length());
+                            String suffix = name.substring((FORAGE_PREFIX + beanPrefix + ".").length());
                             if (propertyName.endsWith(suffix)) {
                                 return entry;
                             }
@@ -371,11 +372,11 @@ public final class ForagePropertyValidator {
      * E.g., "forage.openai.api.key" -> "openai"
      */
     private static String extractBeanPrefix(String configName) {
-        if (configName == null || !configName.startsWith("forage.")) {
+        if (configName == null || !configName.startsWith(FORAGE_PREFIX)) {
             return null;
         }
 
-        String remaining = configName.substring("forage.".length());
+        String remaining = configName.substring(FORAGE_PREFIX.length());
         int dotIndex = remaining.indexOf('.');
         if (dotIndex > 0) {
             return remaining.substring(0, dotIndex);
@@ -389,11 +390,11 @@ public final class ForagePropertyValidator {
      * E.g., "forage.unknown.property" -> "unknown"
      */
     private static String extractFactoryNameFromProperty(String propertyName) {
-        if (propertyName == null || !propertyName.startsWith("forage.")) {
+        if (propertyName == null || !propertyName.startsWith(FORAGE_PREFIX)) {
             return null;
         }
 
-        String remaining = propertyName.substring("forage.".length());
+        String remaining = propertyName.substring(FORAGE_PREFIX.length());
         int dotIndex = remaining.indexOf('.');
         if (dotIndex > 0) {
             return remaining.substring(0, dotIndex);

--- a/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigWriteCommand.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/io/kaoto/forage/plugin/config/ConfigWriteCommand.java
@@ -31,6 +31,9 @@ import picocli.CommandLine;
 public class ConfigWriteCommand extends CamelCommand {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String KEY_SUCCESS = "success";
+    private static final String APPLICATION_PROPERTIES = "application.properties";
+    private static final String FORAGE_PREFIX = "forage.";
 
     @CommandLine.Option(
             names = {"--input", "-i"},
@@ -149,7 +152,7 @@ public class ConfigWriteCommand extends CamelCommand {
             writePropertiesFile(propertiesFile, factoryConfig.properties(), factoryTypeKey);
 
             Map<String, Object> result = new LinkedHashMap<>();
-            result.put("success", true);
+            result.put(KEY_SUCCESS, true);
             result.put("propertiesFile", propertiesFile.getAbsolutePath());
             result.put("operation", operation);
             result.put(
@@ -167,7 +170,7 @@ public class ConfigWriteCommand extends CamelCommand {
         // Collect and write dependencies to application.properties
         DependencyInfo dependencies = collectDependencies(factoryConfigs);
         if (hasDependencies(dependencies)) {
-            File appPropertiesFile = new File(directory, "application.properties");
+            File appPropertiesFile = new File(directory, APPLICATION_PROPERTIES);
             updateDependencies(appPropertiesFile, dependencies);
 
             // Add dependency info to results
@@ -187,7 +190,7 @@ public class ConfigWriteCommand extends CamelCommand {
                             .writeValueAsString(results.values().iterator().next()));
         } else {
             Map<String, Object> output = new LinkedHashMap<>();
-            output.put("success", true);
+            output.put(KEY_SUCCESS, true);
             output.put("factories", results);
             printer().println(OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(output));
         }
@@ -359,7 +362,7 @@ public class ConfigWriteCommand extends CamelCommand {
      * Input: "jdbc.url", beanName: null -> Output: "forage.jdbc.url"
      */
     private String buildPropertyKey(String beanName, String inputKey) {
-        StringBuilder sb = new StringBuilder("forage.");
+        StringBuilder sb = new StringBuilder(FORAGE_PREFIX);
         if (beanName != null && !beanName.isEmpty()) {
             sb.append(beanName).append(".");
         }
@@ -369,7 +372,7 @@ public class ConfigWriteCommand extends CamelCommand {
 
     private String getPropertiesFileName(String factoryTypeKey) {
         if ("application".equalsIgnoreCase(strategy)) {
-            return "application.properties";
+            return APPLICATION_PROPERTIES;
         }
         return catalog.getPropertiesFileName(factoryTypeKey).orElse(null);
     }
@@ -634,7 +637,7 @@ public class ConfigWriteCommand extends CamelCommand {
                 results.put(
                         propertiesFile.getName(),
                         Map.of(
-                                "success",
+                                KEY_SUCCESS,
                                 true,
                                 "propertiesFile",
                                 propertiesFile.getAbsolutePath(),
@@ -650,7 +653,7 @@ public class ConfigWriteCommand extends CamelCommand {
         }
 
         // After deletion, clean up dependencies that are no longer needed
-        File appPropertiesFile = new File(directory, "application.properties");
+        File appPropertiesFile = new File(directory, APPLICATION_PROPERTIES);
         Map<String, Object> dependencyCleanupResult =
                 cleanupUnusedDependencies(appPropertiesFile, allDeletedTypes, allDeletedFactoryTypeKeys);
         if (!dependencyCleanupResult.isEmpty()) {
@@ -658,7 +661,7 @@ public class ConfigWriteCommand extends CamelCommand {
         }
 
         Map<String, Object> output = new LinkedHashMap<>();
-        output.put("success", true);
+        output.put(KEY_SUCCESS, true);
         output.put("operation", "delete");
         output.put("instanceName", instanceName);
         output.put("results", results);
@@ -670,7 +673,7 @@ public class ConfigWriteCommand extends CamelCommand {
     private Set<File> determineScanableProperties() {
         Set<File> propertiesFilesToScan = new HashSet<>();
         if ("application".equalsIgnoreCase(strategy)) {
-            File appProps = new File(directory, "application.properties");
+            File appProps = new File(directory, APPLICATION_PROPERTIES);
             if (appProps.exists()) {
                 propertiesFilesToScan.add(appProps);
             }
@@ -709,7 +712,7 @@ public class ConfigWriteCommand extends CamelCommand {
 
         // Find keys to remove matching the instance prefix
         // Pattern: forage.{instanceName}.*
-        String prefixToMatch = "forage." + instanceName + ".";
+        String prefixToMatch = FORAGE_PREFIX + instanceName + ".";
 
         for (String line : lines) {
             String trimmed = line.trim();
@@ -818,8 +821,8 @@ public class ConfigWriteCommand extends CamelCommand {
                     String value = line.substring(equalsIndex + 1).trim();
 
                     // Parse forage.{instanceName}.{type}.* pattern
-                    if (key.startsWith("forage.")) {
-                        String afterForage = key.substring("forage.".length());
+                    if (key.startsWith(FORAGE_PREFIX)) {
+                        String afterForage = key.substring(FORAGE_PREFIX.length());
                         // Skip to second segment (after instanceName)
                         int firstDot = afterForage.indexOf('.');
                         if (firstDot > 0) {
@@ -988,7 +991,7 @@ public class ConfigWriteCommand extends CamelCommand {
 
     private int outputError(String message) throws JsonProcessingException {
         Map<String, Object> error = new HashMap<>();
-        error.put("success", false);
+        error.put(KEY_SUCCESS, false);
         error.put("error", message);
         printer().println(OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(error));
         return 1;

--- a/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
+++ b/tooling/forage-maven-catalog-plugin/src/main/java/io/kaoto/forage/maven/catalog/CodeScanner.java
@@ -48,6 +48,8 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 
 public class CodeScanner {
     private static final Set<String> SKIP_DIRS = Set.of("target", ".git", "node_modules", ".idea", ".vscode");
+    private static final String ATTR_DESCRIPTION = "description";
+    private static final String ATTR_RUNTIME_DEPS = "runtimeDependencies";
 
     private final Log log;
     private final Map<String, Path> sourceDirectoryCache = new ConcurrentHashMap<>();
@@ -380,7 +382,7 @@ public class CodeScanner {
                     }
                 }
                 case "components" -> data.setComponents(extractStringArrayValue(value, "@ForageFactory 'components'"));
-                case "description" -> {
+                case ATTR_DESCRIPTION -> {
                     if (value instanceof StringLiteralExpr stringLiteral) {
                         data.setDescription(stringLiteral.asString());
                     }
@@ -394,7 +396,7 @@ public class CodeScanner {
                 case "conditionalBeans" -> data.setConditionalBeans(extractConditionalBeanGroupArray(value));
                 case "variant" -> data.setVariant(extractVariantValue(value));
                 case "configClass" -> data.setConfigClassName(extractClassValue(value, cu));
-                case "runtimeDependencies" ->
+                case ATTR_RUNTIME_DEPS ->
                     data.setRuntimeDependencies(extractStringArrayValue(value, "@ForageFactory 'runtimeDependencies'"));
                 default -> {}
             }
@@ -441,7 +443,7 @@ public class CodeScanner {
                         id = stringLiteral.asString();
                     }
                 }
-                case "description" -> {
+                case ATTR_DESCRIPTION -> {
                     if (value instanceof StringLiteralExpr stringLiteral) {
                         description = stringLiteral.asString();
                     }
@@ -452,7 +454,7 @@ public class CodeScanner {
                     }
                 }
                 case "beans" -> beans = extractConditionalBeanArray(value);
-                case "runtimeDependencies" ->
+                case ATTR_RUNTIME_DEPS ->
                     runtimeDeps = extractStringArrayValue(value, "@ConditionalBeanGroup 'runtimeDependencies'");
                 default -> {}
             }
@@ -524,7 +526,7 @@ public class CodeScanner {
                         javaType = stringLiteral.asString();
                     }
                 }
-                case "description" -> {
+                case ATTR_DESCRIPTION -> {
                     if (pairValue instanceof StringLiteralExpr stringLiteral) {
                         String descValue = stringLiteral.asString();
                         if (!descValue.isEmpty()) {
@@ -573,7 +575,7 @@ public class CodeScanner {
                         }
                     }
                     case "components" -> components = extractStringArrayValue(value, "@ForageBean 'components'");
-                    case "description" -> {
+                    case ATTR_DESCRIPTION -> {
                         if (value instanceof StringLiteralExpr stringLiteral) {
                             description = stringLiteral.asString();
                         }
@@ -584,7 +586,7 @@ public class CodeScanner {
                         }
                     }
                     case "configClass" -> configClassName = extractClassValue(value, cu);
-                    case "runtimeDependencies" ->
+                    case ATTR_RUNTIME_DEPS ->
                         runtimeDeps = extractStringArrayValue(value, "@ForageBean 'runtimeDependencies'");
                     case "repositories" -> repositories = extractStringArrayValue(value, "@ForageBean 'repositories'");
                     default -> {}


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/forage/issues/505

## Summary

Resolves all 101 Sonar **java:S1192** (duplicate string literals) issues.

**Main change:** Adds `TYPE_STRING`, `TYPE_INTEGER`, `TYPE_DOUBLE`, `TYPE_BOOLEAN`, `TYPE_FALSE`, `TYPE_PASSWORD` constants to `ConfigModule` and replaces all type-string literals in 37 `*ConfigEntries` classes.

**Other constants extracted:**
- `FORAGE_PREFIX` — `AbstractConfig`, `ForagePropertyValidator`, `CatalogDrivenExportCustomizer`, `ConfigWriteCommand`
- `PROPERTIES_SUFFIX` — `ConfigStore`
- `CAMEL_COMMAND` — `IntegrationTestSetupExtension`
- `IN_MEMORY_STORE` — `AgentCreator`
- 13 `PROVIDER_*`/`PROP_*` constants — `AgentModuleDescriptor`
- `MEMORY_ID_NOT_NULL` — `PersistentInfinispanStore`, `PersistentRedisStore`
- `BOOLEAN_TRUE`/`BOOLEAN_FALSE` — `RedisConfig`
- `PROPERTY_PREFIX` — `ForagePropertyCondition`
- `SOAP_ENDPOINT_PROVIDER` — `CxfCommonExportHelper`
- `KEY_SUCCESS`, `APPLICATION_PROPERTIES` — `ConfigWriteCommand`
- `ATTR_DESCRIPTION`, `ATTR_RUNTIME_DEPS` — `CodeScanner`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Redis chat-memory validation messages.
  - Restored reliable Camel command invocation in integration tests.

- **Refactor**
  - Standardized configuration type handling across AI models, agents, guardrails, memory stores, and vector databases.
  - Centralized repeated property prefixes, provider names, file names, identifiers, and validation messages without changing behavior.

- **Maintenance**
  - Improved consistency across configuration, agent, integration, and tooling components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->